### PR TITLE
ci: normalize merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Quality Checks
 
 on:
   push:
@@ -94,3 +94,14 @@ jobs:
           name: extension-dist
           path: apps/extension/.output/
           retention-days: 7
+
+  merge-gate:
+    runs-on: ubuntu-latest
+    needs: [build, extension-build]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]] || \
+             [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1


### PR DESCRIPTION
## Summary
- rename the legacy CI-required check to an explicit merge gate
- keep branch protection aligned with a single stable gate job

## Testing
- GitHub Actions
