### PR TITLE
[codex] shrink chunky meme uploads

### DIFF
--- a/apps/extension/entrypoints/background/image-fetcher.ts
+++ b/apps/extension/entrypoints/background/image-fetcher.ts
@@ -5,7 +5,12 @@
  * Background context has elevated permissions to bypass CORS.
  */
 
-import { UPLOAD, isValidMimeType } from '@sploot/common';
+import {
+  UPLOAD,
+  isValidMimeType,
+  prepareImageForUpload,
+  isCompressibleImageType,
+} from '@sploot/common';
 
 /**
  * Fetch image from URL
@@ -59,23 +64,20 @@ export async function fetchImage(url: string): Promise<Blob> {
     // Get blob
     const blob = await response.blob();
 
-    // Validate size
-    if (blob.size > UPLOAD.maxSize) {
-      const sizeMB = (blob.size / 1024 / 1024).toFixed(2);
-      console.warn('[ImageFetcher] Image too large', { url, sizeMB });
-      throw new Error(`Image too large: ${sizeMB}MB (max ${UPLOAD.maxSizeMB}MB)`);
-    }
-
     // Ensure blob has correct MIME type
     if (!isValidMimeType(blob.type)) {
       // Try to infer from content-type header
       const inferredType = contentType || 'image/jpeg';
-      return new Blob([blob], { type: inferredType });
+      return await prepareFetchedImage(new Blob([blob], { type: inferredType }));
     }
 
-    return blob;
+    return await prepareFetchedImage(blob);
   } catch (error) {
     // If fetch fails, try fallback method using image element
+    if (error instanceof Error && error.message.includes('too large')) {
+      throw error;
+    }
+
     console.warn('[ImageFetcher] Fetch failed, trying fallback:', error);
     return await fetchViaImageElement(url);
   }
@@ -106,16 +108,9 @@ async function fetchViaImageElement(url: string): Promise<Blob> {
 
         // Convert to blob
         canvas
-          .convertToBlob({ type: 'image/png', quality: 0.95 })
+          .convertToBlob({ type: 'image/webp', quality: UPLOAD.compressionQuality })
           .then(blob => {
-            // Validate size
-            if (blob.size > UPLOAD.maxSize) {
-              const sizeMB = (blob.size / 1024 / 1024).toFixed(2);
-              reject(new Error(`Image too large: ${sizeMB}MB (max ${UPLOAD.maxSizeMB}MB)`));
-              return;
-            }
-
-            resolve(blob);
+            prepareFetchedImage(blob).then(resolve).catch(reject);
           })
           .catch(reject);
       } catch (error) {
@@ -136,4 +131,24 @@ async function fetchViaImageElement(url: string): Promise<Blob> {
       reject(new Error('Image load timeout'));
     }, UPLOAD.timeout);
   });
+}
+
+async function prepareFetchedImage(blob: Blob): Promise<Blob> {
+  let uploadBlob = blob;
+
+  if (blob.size > UPLOAD.compressionTargetSize && isCompressibleImageType(blob.type)) {
+    const file = new File([blob], 'image-from-page', {
+      type: blob.type,
+      lastModified: Date.now(),
+    });
+    uploadBlob = (await prepareImageForUpload(file)).file;
+  }
+
+  if (uploadBlob.size > UPLOAD.multipartSafeSize) {
+    const sizeMB = (uploadBlob.size / 1024 / 1024).toFixed(2);
+    console.warn('[ImageFetcher] Image too large after preparation', { sizeMB });
+    throw new Error(`Image too large after compression: ${sizeMB}MB`);
+  }
+
+  return uploadBlob;
 }

--- a/apps/extension/entrypoints/background/notifications.ts
+++ b/apps/extension/entrypoints/background/notifications.ts
@@ -56,7 +56,7 @@ export function showErrorNotification(errorMessage: string): void {
   } else if (errorMessage.includes('Session expired')) {
     userMessage = 'Session expired. Please login again.';
   } else if (errorMessage.includes('too large')) {
-    userMessage = 'Image too large (max 10MB)';
+    userMessage = 'Image too large after compression.';
   } else if (errorMessage.includes('timeout')) {
     userMessage = 'Upload timeout. Please try again.';
   } else if (errorMessage.includes('Network error')) {

--- a/apps/extension/shared/api-client.ts
+++ b/apps/extension/shared/api-client.ts
@@ -84,7 +84,7 @@ export async function uploadImage(
       }
 
       if (response.status === 413) {
-        throw new Error(`Image too large (max ${UPLOAD.maxSizeMB}MB)`);
+        throw new Error('Image too large after compression.');
       }
 
       if (response.status === 429) {

--- a/apps/web/__tests__/lib/upload/image-preparation.test.ts
+++ b/apps/web/__tests__/lib/upload/image-preparation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UPLOAD,
+  isCompressibleImageType,
+  shouldPrepareImage,
+} from '@sploot/common';
+
+describe('image upload preparation policy', () => {
+  it('prepares static images above the safe transport target', () => {
+    const file = new File(
+      [new Uint8Array(UPLOAD.compressionTargetSize + 1)],
+      'big-meme.png',
+      { type: 'image/png' }
+    );
+
+    expect(shouldPrepareImage(file)).toBe(true);
+  });
+
+  it('does not prepare animated gif uploads because that would flatten animation', () => {
+    const file = new File(
+      [new Uint8Array(UPLOAD.compressionTargetSize + 1)],
+      'reaction.gif',
+      { type: 'image/gif' }
+    );
+
+    expect(shouldPrepareImage(file)).toBe(false);
+  });
+
+  it('keeps the current multipart target below the Vercel function body limit', () => {
+    expect(UPLOAD.compressionTargetSize).toBeLessThan(UPLOAD.multipartSafeSize);
+    expect(UPLOAD.multipartSafeSize).toBeLessThan(4.5 * 1024 * 1024);
+  });
+
+  it('only treats static browser image formats as compressible', () => {
+    expect(isCompressibleImageType('image/jpeg')).toBe(true);
+    expect(isCompressibleImageType('image/png')).toBe(true);
+    expect(isCompressibleImageType('image/webp')).toBe(true);
+    expect(isCompressibleImageType('image/gif')).toBe(false);
+  });
+});

--- a/apps/web/components/upload/upload-zone.tsx
+++ b/apps/web/components/upload/upload-zone.tsx
@@ -24,6 +24,7 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { UPLOAD, prepareImageForUpload } from '@sploot/common';
 
 // Lightweight metadata for display - only ~300 bytes per file vs 5MB for File object
 interface FileMetadata {
@@ -100,6 +101,41 @@ export function UploadZone({
   const router = useRouter();
   const uploadQueueManager = getUploadQueueManager();
   const { validateFile, ALLOWED_FILE_TYPES } = useFileValidation();
+
+  const getMultipartSizeError = useCallback((file: File) =>
+    `too chunky for upload: ${file.name}. tried shrinking it, still over ${(UPLOAD.multipartSafeSize / 1024 / 1024).toFixed(0)}mb.`,
+  []);
+
+  const prepareFile = useCallback(async (file: File): Promise<{ file: File; error: string | null }> => {
+    try {
+      const prepared = await prepareImageForUpload(file);
+      const validationError = validateFile(prepared.file);
+
+      if (validationError) {
+        return { file: prepared.file, error: validationError };
+      }
+
+      if (prepared.file.size > UPLOAD.multipartSafeSize) {
+        return {
+          file: prepared.file,
+          error: getMultipartSizeError(file),
+        };
+      }
+
+      return { file: prepared.file, error: null };
+    } catch (error) {
+      logger.warn('[UploadZone] Image preparation failed', {
+        filename: file.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      const validationError = validateFile(file);
+      return {
+        file,
+        error: validationError || (file.size > UPLOAD.multipartSafeSize ? getMultipartSizeError(file) : null),
+      };
+    }
+  }, [getMultipartSizeError, validateFile]);
 
   // Progress throttling to reduce re-renders
   const progressThrottleMap = useRef<Map<string, { lastUpdate: number; lastPercent: number }>>(new Map());
@@ -705,46 +741,48 @@ export function UploadZone({
     // Process each chunk with a small delay to allow UI to breathe
     for (const chunk of chunks) {
       for (const file of chunk) {
-        const error = validateFile(file);
+        const prepared = await prepareFile(file);
+        const uploadFile = prepared.file;
+        const error = prepared.error;
         const id = `${Date.now()}-${Math.random()}`;
 
         if (error) {
           const metadata: FileMetadata = {
             id,
-            name: file.name,
-            size: file.size,
+            name: uploadFile.name,
+            size: uploadFile.size,
             status: 'error',
             progress: 0,
             error,
             addedAt: Date.now()
           };
           metadataToAdd.set(id, metadata);
-          fileObjects.current.set(id, file);
+          fileObjects.current.set(id, uploadFile);
         } else if (isOffline && supportsBackgroundSync) {
           // Use background sync when offline
-          const syncId = await addToBackgroundSync(file);
+          const syncId = await addToBackgroundSync(uploadFile);
           const metadata: FileMetadata = {
             id: syncId,
-            name: file.name,
-            size: file.size,
+            name: uploadFile.name,
+            size: uploadFile.size,
             status: 'queued',
             progress: 0,
             addedAt: Date.now()
           };
           metadataToAdd.set(syncId, metadata);
-          fileObjects.current.set(syncId, file);
+          fileObjects.current.set(syncId, uploadFile);
         } else {
           // Upload immediately or use fallback
           const metadata: FileMetadata = {
             id,
-            name: file.name,
-            size: file.size,
+            name: uploadFile.name,
+            size: uploadFile.size,
             status: 'pending',
             progress: 0,
             addedAt: Date.now()
           };
           metadataToAdd.set(id, metadata);
-          fileObjects.current.set(id, file);
+          fileObjects.current.set(id, uploadFile);
           filesToUpload.push(id);
         }
       }
@@ -773,7 +811,7 @@ export function UploadZone({
     if (!isOffline && filesToUpload.length > 0) {
       uploadBatch(filesToUpload);
     }
-  }, [isOffline, supportsBackgroundSync, addToBackgroundSync, validateFile, uploadBatch]);
+  }, [isOffline, supportsBackgroundSync, addToBackgroundSync, prepareFile, uploadBatch]);
 
   // Process files for upload with streaming generator pattern
   const processFilesWithQueue = useCallback(async (fileList: FileList | File[]) => {
@@ -834,26 +872,28 @@ export function UploadZone({
 
         // Get the original file for metadata
         const originalFile = fileListToProcess[processedCount - 1];
-        const error = validateFile(originalFile);
+        const prepared = await prepareFile(originalFile);
+        const uploadFile = prepared.file;
+        const error = prepared.error;
 
       // If offline, queue the file instead of uploading
       if (isOffline && !error) {
-        const queueItem = addToQueue(originalFile);
+        const queueItem = addToQueue(uploadFile);
         const metadata: FileMetadata = {
           id: queueItem.id,
-          name: originalFile.name,
-          size: originalFile.size,
+          name: uploadFile.name,
+          size: uploadFile.size,
           status: 'queued',
           progress: 0,
           error: undefined,
           addedAt: Date.now()
         };
         newFiles.push(metadata);
-        fileObjects.current.set(queueItem.id, originalFile);
+        fileObjects.current.set(queueItem.id, uploadFile);
 
         // Also persist to IndexedDB for recovery
         try {
-          await uploadQueueManager.addUpload(originalFile);
+          await uploadQueueManager.addUpload(uploadFile);
         } catch (err) {
           console.error('[UploadZone] Failed to persist upload:', err);
         }
@@ -861,20 +901,20 @@ export function UploadZone({
         const id = `${Date.now()}-${Math.random()}`;
         const metadata: FileMetadata = {
           id,
-          name: originalFile.name,
-          size: originalFile.size,
+          name: uploadFile.name,
+          size: uploadFile.size,
           status: error ? 'error' : 'pending',
           progress: 0,
           error: error || undefined,
           addedAt: Date.now()
         };
         newFiles.push(metadata);
-        fileObjects.current.set(id, originalFile);
+        fileObjects.current.set(id, uploadFile);
 
         // Persist pending uploads to IndexedDB
         if (!error && metadata.status === 'pending') {
           try {
-            const persistedId = await uploadQueueManager.addUpload(originalFile);
+            const persistedId = await uploadQueueManager.addUpload(uploadFile);
             // Store the persisted ID for later removal
             (metadata as any).persistedId = persistedId;
           } catch (err) {
@@ -967,7 +1007,7 @@ export function UploadZone({
         uploadBatch(filesToUpload);
       }
     }
-  }, [isOffline, addToQueue, validateFile, uploadBatch]);
+  }, [isOffline, addToQueue, prepareFile, uploadBatch]);
 
   // Choose the appropriate file processor based on enableBackgroundSync
   const processFiles = enableBackgroundSync ? processFilesWithSync : processFilesWithQueue;

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -10,6 +10,16 @@ export const UPLOAD = {
   maxSize: 10 * 1024 * 1024,
   /** Maximum file size in MB for display */
   maxSizeMB: 10,
+  /** Safe multipart payload budget for Vercel Functions (4.5MB hard limit) */
+  multipartSafeSize: 4 * 1024 * 1024,
+  /** Compression target leaves room for multipart overhead */
+  compressionTargetSize: Math.floor(3.8 * 1024 * 1024),
+  /** Maximum static image edge before upload */
+  maxImageDimension: 2048,
+  /** Initial browser re-encode quality for static images */
+  compressionQuality: 0.86,
+  /** Lowest browser re-encode quality before giving up */
+  minimumCompressionQuality: 0.62,
   /** Upload timeout in milliseconds */
   timeout: 10_000,
   /** Allowed MIME types for image uploads */

--- a/packages/common/src/image-preparation.ts
+++ b/packages/common/src/image-preparation.ts
@@ -1,0 +1,139 @@
+import { UPLOAD, isValidMimeType } from './constants';
+
+export interface PreparedImage {
+  file: File;
+  originalSize: number;
+  compressed: boolean;
+}
+
+interface PrepareImageOptions {
+  targetSize?: number;
+  maxDimension?: number;
+  initialQuality?: number;
+  minimumQuality?: number;
+}
+
+const COMPRESSIBLE_TYPES = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/webp']);
+
+export function isCompressibleImageType(mimeType: string): boolean {
+  return COMPRESSIBLE_TYPES.has(mimeType.toLowerCase().split(';')[0].trim());
+}
+
+export function shouldPrepareImage(file: Blob): boolean {
+  return file.size > UPLOAD.compressionTargetSize && isCompressibleImageType(file.type);
+}
+
+export async function prepareImageForUpload(
+  file: File,
+  options: PrepareImageOptions = {}
+): Promise<PreparedImage> {
+  const targetSize = options.targetSize ?? UPLOAD.compressionTargetSize;
+
+  if (file.size <= targetSize || !isCompressibleImageType(file.type)) {
+    return {
+      file,
+      originalSize: file.size,
+      compressed: false,
+    };
+  }
+
+  const compressed = await compressStaticImage(file, {
+    targetSize,
+    maxDimension: options.maxDimension ?? UPLOAD.maxImageDimension,
+    initialQuality: options.initialQuality ?? UPLOAD.compressionQuality,
+    minimumQuality: options.minimumQuality ?? UPLOAD.minimumCompressionQuality,
+  });
+
+  if (!compressed || compressed.size >= file.size) {
+    return {
+      file,
+      originalSize: file.size,
+      compressed: false,
+    };
+  }
+
+  return {
+    file: compressed,
+    originalSize: file.size,
+    compressed: true,
+  };
+}
+
+async function compressStaticImage(
+  file: File,
+  options: Required<PrepareImageOptions>
+): Promise<File | null> {
+  if (!isValidMimeType(file.type) || typeof createImageBitmap === 'undefined') {
+    return null;
+  }
+
+  const bitmap = await createImageBitmap(file);
+
+  try {
+    const longestEdge = Math.max(bitmap.width, bitmap.height);
+    const scale = Math.min(1, options.maxDimension / longestEdge);
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = createCanvas(width, height);
+    const context = canvas.getContext('2d');
+
+    if (!context) {
+      return null;
+    }
+
+    context.drawImage(bitmap, 0, 0, width, height);
+
+    let quality = options.initialQuality;
+    let blob = await canvasToBlob(canvas, 'image/webp', quality);
+
+    while (blob.size > options.targetSize && quality > options.minimumQuality) {
+      quality = Math.max(options.minimumQuality, quality - 0.08);
+      blob = await canvasToBlob(canvas, 'image/webp', quality);
+    }
+
+    return new File([blob], replaceExtension(file.name, 'webp'), {
+      type: 'image/webp',
+      lastModified: file.lastModified,
+    });
+  } finally {
+    bitmap.close();
+  }
+}
+
+function createCanvas(width: number, height: number): OffscreenCanvas | HTMLCanvasElement {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    return new OffscreenCanvas(width, height);
+  }
+
+  if (typeof document === 'undefined') {
+    throw new Error('Image compression requires a browser canvas');
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+async function canvasToBlob(
+  canvas: OffscreenCanvas | HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob> {
+  if ('convertToBlob' in canvas) {
+    return canvas.convertToBlob({ type, quality });
+  }
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => blob ? resolve(blob) : reject(new Error('Image compression failed')),
+      type,
+      quality
+    );
+  });
+}
+
+function replaceExtension(filename: string, extension: string): string {
+  const base = filename.replace(/\.[^.]+$/, '');
+  return `${base || 'image'}.${extension}`;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,5 +13,12 @@ export {
   isValidFileSize,
 } from './constants';
 
+export {
+  prepareImageForUpload,
+  isCompressibleImageType,
+  shouldPrepareImage,
+  type PreparedImage,
+} from './image-preparation';
+
 // API Types
 export type { SplootApiUploadResponse, SplootApiError } from './types';


### PR DESCRIPTION
## what changed
- added a shared browser-side upload prep module that shrinks static jpeg/png/webp memes before they hit `/api/upload`
- set a real multipart-safe budget below Vercel Function body limits while keeping the existing 10mb app policy
- wired web uploads, offline queues, and extension right-click saves through the same prep logic
- kept gifs out of canvas compression so animated memes do not get flattened

## why
`/api/upload` can only help after the request body is accepted. chunky files were bonking into transport limits before Sploot could resize them with Sharp. this moves the first save attempt into a deeper intake boundary instead of making users resize things manually.

## verification
- `pnpm --filter web exec vitest run __tests__/lib/upload/image-preparation.test.ts __tests__/hooks/use-file-validation.test.ts __tests__/lib/upload/validation-service.test.ts`
- `pnpm --filter @sploot/common type-check`
- `pnpm --filter web type-check`
- `pnpm --filter extension type-check`
- `pnpm --filter web lint`
- `pnpm --filter extension lint`
- `pnpm --filter extension build`
- pre-commit: gitleaks, lint-extension, lint-web, typecheck
- pre-push: typecheck

## note
A full accidental web test run still needs local Postgres at `localhost:5432`; unrelated user-sync integration tests failed on missing DB. targeted upload tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic image optimization during upload to improve efficiency.
  * Enhanced image validation pipeline with centralized preparation logic.

* **Bug Fixes**
  * Improved error messages to distinguish between original file size and post-optimization size limits.
  * More precise handling of oversized files during upload fallback scenarios.

* **Tests**
  * Added comprehensive test coverage for image upload preparation and compression policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/misty-step/sploot/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->