### PR TITLE
chore(harness): move work tracking to backlog.d

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/code-review/.spellbook
+++ b/.agents/skills/code-review/.spellbook
@@ -1,5 +1,5 @@
 source: code-review
-installed: 2026-05-13T20:27:34Z
+installed: 2026-05-14T15:06:35Z
 installed-by: tailor
-tailor-version: 5df41e2d80c68c1b43469e8492e75d11bfca28f0
+tailor-version: e4b9d1a5b88e77035cdeaf389ccad518e80f31c5
 category: workflow

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -19,7 +19,7 @@ description: |
 
 Review for Sploot regressions first: auth bypass in API routes, upload validation drift between apps, Prisma raw SQL, pgvector query correctness, embedding job fanout/cost, serverless connection handling, extension env mistakes, and docs drift in `apps/web/docs/API.md`.
 
-Use Cerberus as an additional signal when present, not as the final verdict. Findings lead, ordered by severity, with file/line references and exact runtime impact.
+Use the local diff, GitHub PR context, CI results, and repo docs as evidence. Findings lead, ordered by severity, with file/line references and exact runtime impact.
 
 ## Output Contract
 

--- a/.agents/skills/deliver/SKILL.md
+++ b/.agents/skills/deliver/SKILL.md
@@ -9,17 +9,17 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
-Take one GitHub issue or shaped packet to merge-ready. Compose `/shape -> /implement -> /ci -> /code-review -> /refactor -> /qa`; stop before merge.
+Take one local backlog item or shaped packet to merge-ready. Compose `/shape -> /implement -> /ci -> /code-review -> /refactor -> /qa`; stop before merge.
 
-The delivery receipt must name issue refs, changed surfaces (`apps/web`, `apps/extension`, `packages/common`, CI/release), CI parity evidence, DB/pgvector verification status, and residual deploy/release risk. Delivered does not mean shipped.
+The delivery receipt must name backlog refs, changed surfaces (`apps/web`, `apps/extension`, `packages/common`, CI/release), CI parity evidence, DB/pgvector verification status, and residual deploy/release risk. Delivered does not mean shipped.
 
 ## Output Contract
 

--- a/.agents/skills/demo/SKILL.md
+++ b/.agents/skills/demo/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/flywheel/SKILL.md
+++ b/.agents/skills/flywheel/SKILL.md
@@ -9,17 +9,17 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
-Outer loop: pick GitHub issue -> `/shape` -> `/implement` -> `/yeet` -> `/settle` -> `/ship` -> `/monitor`. Leaf skills own their phase; flywheel only enforces ordering and state handoff.
+Outer loop: pick local backlog item -> `/shape` -> `/implement` -> `/yeet` -> `/settle` -> `/ship` -> `/monitor`. Leaf skills own their phase; flywheel only enforces ordering and state handoff.
 
-Closure lives in `/ship` through GitHub issue linkage and merge records. Flywheel never archives nonexistent `backlog.d` tickets and never invokes reflection directly. Parallel cycles require separate worktrees because git state is shared.
+Closure lives in `/ship` through local backlog item linkage and merge records. Flywheel never archives local backlog tickets and never invokes reflection directly. Parallel cycles require separate worktrees because git state is shared.
 
 ## Output Contract
 

--- a/.agents/skills/groom/SKILL.md
+++ b/.agents/skills/groom/SKILL.md
@@ -9,27 +9,27 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
-Groom GitHub Issues, not file backlog. A successful groom always ends with a refreshed backlog of work: opened GitHub issues, edited GitHub issues, explicit close/archive recommendations, or a ratification packet listing the exact issue mutations that need user approval. An inventory of issues and PRs is context, not a groom.
+Groom local `backlog.d`, not GitHub Issues. A successful groom always ends with a refreshed backlog of work: new top-level markdown tickets, edited markdown tickets, explicit `_done/` archive recommendations, or a ratification packet listing exact backlog file mutations that need user approval. An inventory of existing backlog items and PRs is context, not a groom.
 
 Run the full loop every time:
 
-1. **Tidy.** Reconcile open issues and PRs against merged commits, release notes, Sentry incidents, and docs. Use `gh issue list`, `gh pr list`, `git log --oneline --decorate -30`, `.github/workflows/`, `CHANGELOG.md`, `PROMPT.md`, and recent Sentry prompts when available.
-2. **Generate missing work.** If GitHub Issues is empty or thin, treat that as a backlog health failure, not a stopping condition. Mine product vision, TODO/debt comments, stale docs, open PR failures, production incidents, and hot files for candidate work.
+1. **Tidy.** Reconcile top-level `backlog.d/*.md` items and PRs against merged commits, release notes, Sentry incidents, and docs. Use `find backlog.d -maxdepth 2 -type f`, `gh pr list`, `git log --oneline --decorate -30`, `.github/workflows/`, `CHANGELOG.md`, `PROMPT.md`, and recent Sentry prompts when available.
+2. **Generate missing work.** If local `backlog.d` is empty or thin, treat that as a backlog health failure, not a stopping condition. Mine product vision, TODO/debt comments, stale docs, open PR failures, production incidents, and hot files for candidate work.
 3. **Interrogate.** For top candidates, state the user outcome, root cause, non-goals, oracle, and why this belongs on the backlog now. Challenge symptom tickets before writing them.
 4. **Rank.** Group candidates into 2-4 themes and rank by `(product impact * operational risk reduction) / effort`. Sploot's current product focus is save, search, shuffle; operational risk includes Prisma/pgvector, embeddings, Clerk auth, Vercel deploys, extension capture/upload, and release automation.
-5. **Emit backlog changes.** Create or update GitHub issues when the mutation is straightforward and non-destructive. For destructive or ambiguous actions, present a ratification packet with exact `gh issue` commands or issue bodies.
+5. **Emit backlog changes.** Create or update local backlog items when the mutation is straightforward and non-destructive. For destructive or ambiguous actions, present a ratification packet with exact `git mv`/file-edit commands or backlog file bodies.
 
-Always flag stale contradictions: an issue closed in GitHub but still referenced as active in docs, a shipped PR without issue linkage, an open PR that duplicates another PR, a Sentry incident fixed without a regression test or monitoring note, or a TODO/debt marker with no issue. If a file backlog is requested, create a GitHub issue first or ask for an explicit tracker migration.
+Always flag stale contradictions: a backlog item marked done but still referenced as active in docs, a shipped PR without backlog linkage, an open PR that duplicates another PR, a Sentry incident fixed without a regression test or monitoring note, or a TODO/debt marker with no backlog item. If someone asks to use GitHub Issues for work tracking, ask for explicit tracker migration approval first.
 
-Each new or refreshed issue must contain:
+Each new or refreshed backlog item must contain:
 
 - Goal: one sentence naming the outcome.
 - Oracle: mechanically checkable completion evidence, including the Sploot ship gate or a narrower command when justified.
@@ -39,4 +39,4 @@ Each new or refreshed issue must contain:
 
 ## Output Contract
 
-End with evidence, decisions, backlog mutations, and residual risk. The final answer must include a **Refreshed Backlog** section with created/updated issue URLs or a ratification packet. If no issue should be created, say which evidence made deletion/deferral better than backlog growth. If a changed executable path was not directly exercised, say so explicitly. Keep repo-specific names and commands in the body; do not append generic sidecar notes.
+End with evidence, decisions, backlog mutations, and residual risk. The final answer must include a **Refreshed Backlog** section with created/updated backlog file paths or a ratification packet. If no backlog item should be created, say which evidence made deletion/deferral better than backlog growth. If a changed executable path was not directly exercised, say so explicitly. Keep repo-specific names and commands in the body; do not append generic sidecar notes.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -9,15 +9,15 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
-Implement from a shaped packet or GitHub issue. Create branches as `<type>/<issue>-<slug>` when an issue exists; otherwise use `cx/<slug>` for Codex work. Write behavior tests before production code for business logic and API contracts.
+Implement from a shaped packet or local backlog item. Create branches as `<type>/<id>-<slug>` when a backlog item exists; otherwise use `cx/<slug>` for Codex work. Write behavior tests before production code for business logic and API contracts.
 
 Respect internal boundaries: do not mock Sploot-owned modules; use realistic fakes or the real implementation. Boundary mocks are allowed for Clerk, Sentry, Vercel Blob, Replicate, network, clock, and browser APIs. New code must keep `@sploot/common` as the source of upload limits and API types.
 

--- a/.agents/skills/monitor/.spellbook
+++ b/.agents/skills/monitor/.spellbook
@@ -1,5 +1,5 @@
 source: monitor
-installed: 2026-05-13T20:27:34Z
+installed: 2026-05-14T15:06:35Z
 installed-by: tailor
-tailor-version: 5df41e2d80c68c1b43469e8492e75d11bfca28f0
+tailor-version: e4b9d1a5b88e77035cdeaf389ccad518e80f31c5
 category: workflow

--- a/.agents/skills/monitor/SKILL.md
+++ b/.agents/skills/monitor/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/monitor/SKILL.md
+++ b/.agents/skills/monitor/SKILL.md
@@ -17,7 +17,7 @@ description: |
 
 ## How This Skill Works Here
 
-Watch signals after merge/deploy/release. For web: Vercel deploy status, `/api/health`, `/api/db-ping`, Sentry, structured logs, and release notes. For extension: build artifact presence, manual Chrome smoke, and store-submission status when available. For CI-only changes: subsequent GitHub Actions runs and Cerberus verdicts.
+Watch signals after merge/deploy/release. For web: Vercel deploy status, `/api/health`, `/api/db-ping`, Sentry, structured logs, and release notes. For extension: build artifact presence, manual Chrome smoke, and store-submission status when available. For CI-only changes: subsequent GitHub Actions runs.
 
 Monitor emits a clean result or escalates to `/diagnose`; it does not patch code.
 

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/reflect/.spellbook
+++ b/.agents/skills/reflect/.spellbook
@@ -1,5 +1,5 @@
 source: reflect
-installed: 2026-05-13T20:28:13Z
+installed: 2026-05-14T15:06:35Z
 installed-by: tailor
-tailor-version: 5df41e2d80c68c1b43469e8492e75d11bfca28f0
+tailor-version: e4b9d1a5b88e77035cdeaf389ccad518e80f31c5
 category: universal

--- a/.agents/skills/reflect/SKILL.md
+++ b/.agents/skills/reflect/SKILL.md
@@ -11,16 +11,16 @@ Reflect after meaningful Sploot work. The goal is not journaling; it is durable 
 
 ## Sploot Anchors
 
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or explicit unverified evidence.
 - Production signals: Vercel web deploys, Sentry, semantic-release, GitHub Actions CI, extension artifacts under `apps/extension/.output/`.
 
 ## Protocol
 
-1. Load the triggering evidence: issue/PR, merge SHA, CI run, Sentry ID, deploy receipt, or local failure transcript.
+1. Load the triggering evidence: backlog item/PR, merge SHA, CI run, Sentry ID, deploy receipt, or local failure transcript.
 2. Extract facts only: what failed, what fixed it, what was not verified, and which surface was involved (`apps/web`, `apps/extension`, `packages/common`, CI/release, harness).
-3. Decide the highest-leverage codification target: type, lint/hook, test, CI, skill, `AGENTS.md`, docs, or GitHub issue.
+3. Decide the highest-leverage codification target: type, lint/hook, test, CI, skill, `AGENTS.md`, docs, or local backlog item.
 4. Apply small repo/harness edits only when they directly prevent recurrence.
 5. Route harness-only follow-up branches as `harness/reflect-outputs`; do not mix them into protected branch shipping work.
 
@@ -28,8 +28,8 @@ Reflect after meaningful Sploot work. The goal is not journaling; it is durable 
 
 Return a short reflection with:
 
-- Trigger: issue/PR/Sentry/CI/deploy reference.
+- Trigger: backlog item/PR/Sentry/CI/deploy reference.
 - Learning: one or two concrete lessons.
-- Codification: exact file/issue/skill change made or proposed.
+- Codification: exact file/backlog item/skill change made or proposed.
 - Verification: command or evidence that proves the codification is valid.
-- Residual risk: what remains open, with GitHub issue reference when action is needed.
+- Residual risk: what remains open, with local backlog item reference when action is needed.

--- a/.agents/skills/reflect/SKILL.md
+++ b/.agents/skills/reflect/SKILL.md
@@ -14,7 +14,7 @@ Reflect after meaningful Sploot work. The goal is not journaling; it is durable 
 - Tracker: GitHub Issues. `backlog.d/` is not active here.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or explicit unverified evidence.
-- Production signals: Vercel web deploys, Sentry, semantic-release, Cerberus, extension artifacts under `apps/extension/.output/`.
+- Production signals: Vercel web deploys, Sentry, semantic-release, GitHub Actions CI, extension artifacts under `apps/extension/.output/`.
 
 ## Protocol
 

--- a/.agents/skills/research/SKILL.md
+++ b/.agents/skills/research/SKILL.md
@@ -9,15 +9,15 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
-Use research when Sploot work needs outside evidence, official docs, or multiple perspectives. Start from local truth: `ARCHITECTURE.md`, `vision.md`, `CLAUDE.md`, app-level `AGENTS.md`, `.spellbook/repo-brief.md`, and the current GitHub issue or PR. For framework/API facts that may have changed, cite primary docs: Next.js, WXT, Clerk, Prisma, Neon, Vercel Blob, Sentry, Replicate, Turborepo, Vitest.
+Use research when Sploot work needs outside evidence, official docs, or multiple perspectives. Start from local truth: `ARCHITECTURE.md`, `vision.md`, `CLAUDE.md`, app-level `AGENTS.md`, `.spellbook/repo-brief.md`, and the current local backlog item or PR. For framework/API facts that may have changed, cite primary docs: Next.js, WXT, Clerk, Prisma, Neon, Vercel Blob, Sentry, Replicate, Turborepo, Vitest.
 
 For repo investigations, fan out by surface: web/API, extension, common package, CI/release. Keep synthesis on the lead model and mark any unverified DB/pgvector path.
 

--- a/.agents/skills/settle/.spellbook
+++ b/.agents/skills/settle/.spellbook
@@ -1,5 +1,5 @@
 source: settle
-installed: 2026-05-13T20:27:34Z
+installed: 2026-05-14T15:06:35Z
 installed-by: tailor
-tailor-version: 5df41e2d80c68c1b43469e8492e75d11bfca28f0
+tailor-version: e4b9d1a5b88e77035cdeaf389ccad518e80f31c5
 category: workflow

--- a/.agents/skills/settle/SKILL.md
+++ b/.agents/skills/settle/SKILL.md
@@ -17,7 +17,7 @@ description: |
 
 ## How This Skill Works Here
 
-Polish a branch or PR until it is merge-ready. Preconditions: not on `master`, no unresolved merge/rebase, worktree state understood, branch has commits beyond `origin/master`. Loop through `/ci`, PR checks, Cerberus/review comments, `/code-review`, `/refactor`, and targeted `/qa`.
+Polish a branch or PR until it is merge-ready. Preconditions: not on `master`, no unresolved merge/rebase, worktree state understood, branch has commits beyond `origin/master`. Loop through `/ci`, GitHub PR checks and review comments, `/code-review`, `/refactor`, and targeted `/qa`.
 
 Stop at merge-ready. Do not merge, deploy, close issues, or reflect; hand off to `/ship`. The lifecycle gate blocks merge-ready claims unless issue linkage and CI parity evidence are present.
 

--- a/.agents/skills/settle/SKILL.md
+++ b/.agents/skills/settle/SKILL.md
@@ -9,17 +9,17 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
 Polish a branch or PR until it is merge-ready. Preconditions: not on `master`, no unresolved merge/rebase, worktree state understood, branch has commits beyond `origin/master`. Loop through `/ci`, GitHub PR checks and review comments, `/code-review`, `/refactor`, and targeted `/qa`.
 
-Stop at merge-ready. Do not merge, deploy, close issues, or reflect; hand off to `/ship`. The lifecycle gate blocks merge-ready claims unless issue linkage and CI parity evidence are present.
+Stop at merge-ready. Do not merge, deploy, archive backlog items, or reflect; hand off to `/ship`. The lifecycle gate blocks merge-ready claims unless backlog linkage and CI parity evidence are present.
 
 ## Output Contract
 

--- a/.agents/skills/shape/SKILL.md
+++ b/.agents/skills/shape/SKILL.md
@@ -9,11 +9,11 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -9,17 +9,17 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
-Final mile for a merge-ready PR. Verify issue refs, CI parity, and mergeability; preserve `Closes #<id>`/`Refs #<id>` or explicit trailers in the squash body so GitHub closure remains structured. Use `origin/master` as base.
+Final mile for a merge-ready PR. Verify backlog refs, CI parity, and mergeability; preserve an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer or equivalent PR body reference so local backlog closure remains structured. Use `origin/master` as base.
 
-Before merge, update docs touched by the change and ensure web versus extension release implications are stated. After merge, verify issue closure/reference state, semantic-release implications, run `/reflect` with the issue/PR/merge SHA, and then decide whether `/monitor` is needed. Reflect harness edits route to `harness/reflect-outputs`; do not invent `backlog.d` archive steps in this repo.
+Before merge, update docs touched by the change and ensure web versus extension release implications are stated. After merge, update the backlog item to `Status: done`, add `## What Was Built`, move it to `backlog.d/_done/`, verify semantic-release implications, run `/reflect` with the backlog item/PR/merge SHA, and then decide whether `/monitor` is needed.
 
 ## Output Contract
 

--- a/.agents/skills/yeet/SKILL.md
+++ b/.agents/skills/yeet/SKILL.md
@@ -9,17 +9,17 @@ description: |
 ## Sploot Anchors
 
 - Repo: pnpm Turborepo with `apps/web`, `apps/extension`, and `packages/common`.
-- Tracker: GitHub Issues. `backlog.d/` is not active here.
+- Tracker: local markdown files in `backlog.d/`; GitHub Issues are not active for Sploot work tracking.
 - Base branch: `origin/master`.
 - Ship gate: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with DB-backed paths requiring `DATABASE_URL` against pgvector or an explicit unverified note.
 - Remote CI: frozen install, web Prisma migrate against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, extension build.
-- Closure: issue reference plus Conventional Commit subject/body or explicit trailers (`Refs: #123`, `Closes: #123`, `Refs-issue: #123`).
+- Closure: backlog item status moves to `done` with a `What Was Built` note plus Conventional Commit subject/body or an explicit `Backlog: backlog.d/<id>-<slug>.md` trailer.
 
 ## How This Skill Works Here
 
 Turn local worktree changes into conventional commits and push. Read full `git status --short`, `git diff --stat`, and recent commits. Split by reviewer meaning: web/API, extension, common package, CI/release, docs/harness.
 
-Commit subjects follow Conventional Commits. Bodies should include issue refs when available and note DB/pgvector verification gaps. Do not push secrets, `.env`, extension private keys, or generated debris outside intended artifacts.
+Commit subjects follow Conventional Commits. Bodies should include backlog refs when available and note DB/pgvector verification gaps. Do not push secrets, `.env`, extension private keys, or generated debris outside intended artifacts.
 
 ## Output Contract
 

--- a/.spellbook/repo-brief.md
+++ b/.spellbook/repo-brief.md
@@ -31,7 +31,7 @@ Ship gate equals CI parity: `pnpm lint && pnpm type-check && pnpm --filter web t
 - Sentry #7117400497: stale Prisma serverless connection surfaced in `GET /api/health`; health and DB-ping paths need runtime proof, not adjacent test confidence.
 - Embedding spikes: recent guard/rate-limit work touched `apps/web/lib/embedding-guard.ts`, `apps/web/lib/embedding-rate-limit.ts`, `apps/web/lib/embeddings.ts`, and scheduler routes. Treat embedding cost and duplicate job pressure as production risks.
 - Release automation is sensitive to `GH_RELEASE_TOKEN`; semantic-release updates `CHANGELOG.md` and `package.json` on `master`.
-- Cerberus PR review runs through `.github/workflows/cerberus.yml`; review guidance should account for that external AI reviewer as a signal, not a substitute for local review.
+- Cerberus PR review was removed from `.github/workflows`; review and readiness guidance now depend on local code review plus GitHub Actions CI, not an AI-review workflow.
 - API docs under `apps/web/docs/API.md` are hand maintained and can drift from routes.
 
 ## Terminology

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Sploot is a pnpm Turborepo monorepo. `apps/web` owns the Next.js 15 app, API rou
 - Default base branch is `origin/master`.
 - Use `DATABASE_URL` for Prisma; do not invent env aliases.
 - `@sploot/common` is the source of truth for upload limits, MIME validation, and shared API types.
-- Source of truth for work tracking is GitHub Issues, not `backlog.d`.
-- Closure requires issue reference plus conventional commit or trailer linkage.
+- Source of truth for work tracking is local markdown files in `backlog.d/`, not GitHub Issues.
+- Closure requires the backlog item to move to `backlog.d/_done/` with a `What Was Built` note plus conventional commit or `Backlog: backlog.d/<id>-<slug>.md` trailer linkage.
 - Web deploy and extension release are separate surfaces.
 
 ## Gate Contract
@@ -34,16 +34,16 @@ Ship gate equals CI parity: `pnpm lint && pnpm type-check && pnpm --filter web t
 | Sentry #7117400497 / PR #151 | `apps/web/app/api/health/route.ts` | Stale Prisma serverless connections need runtime health evidence on future DB health changes. |
 | GitHub PR #142 | embedding scheduler/rate-limit modules | Embedding spikes and duplicate job pressure are production risks; test scheduling and cost controls directly. |
 | GitHub PR #153 | `.github/workflows/release.yml` | Semantic-release depends on `GH_RELEASE_TOKEN`; release fixes must prove token path without weakening permissions. |
-| GitHub issue refs required | `apps/web/docs/API.md` | API docs are hand maintained and can drift from route behavior. |
+| Backlog refs required | `apps/web/docs/API.md` | API docs are hand maintained and can drift from route behavior. |
 
 ## Harness Index
 
 | Skill | What it does here |
 |---|---|
 | `research` | Triangulates Sploot stack facts from local docs plus primary docs for Next/WXT/Clerk/Prisma/Neon/Vercel/Sentry/Replicate. |
-| `groom` | Refreshes the GitHub Issues backlog from PRs, commits, Sentry incidents, release notes, docs, and code debt. |
+| `groom` | Refreshes `backlog.d/` from PRs, commits, Sentry incidents, release notes, docs, and code debt. |
 | `shape` | Produces context packets with web/extension/common boundaries and CI parity oracle. |
-| `implement` | Builds from issues or packets with TDD and Sploot mocking boundaries. |
+| `implement` | Builds from backlog items or packets with TDD and Sploot mocking boundaries. |
 | `qa` | Runs browser/API/extension/DB smoke paths beyond unit tests. |
 | `demo` | Captures screenshots, request/response snippets, artifact notes, or release blurbs. |
 | `code-review` | Reviews for auth, upload validation, Prisma/pgvector, embeddings, extension env, and release risks. |
@@ -51,11 +51,11 @@ Ship gate equals CI parity: `pnpm lint && pnpm type-check && pnpm --filter web t
 | `ci` | Executes and diagnoses the CI parity gate. |
 | `diagnose` | Traces CI/Sentry/Vercel/release/extension failures source-to-sink. |
 | `monitor` | Watches health, Sentry, deploy, release, extension, and CI signals after changes. |
-| `deliver` | Composes one issue to merge-ready. |
+| `deliver` | Composes one backlog item to merge-ready. |
 | `settle` | Polishes branch/PR to merge-ready, then stops. |
-| `ship` | Lands merge-ready work with GitHub issue closure and post-merge checks. |
+| `ship` | Lands merge-ready work with local backlog closure and post-merge checks. |
 | `yeet` | Splits local changes into conventional commits and pushes. |
-| `flywheel` | Runs the issue-to-monitor outer loop. |
+| `flywheel` | Runs the backlog-to-monitor outer loop. |
 | `deploy` | Routes Vercel web deploy and extension production artifact release checks. |
 | `office-hours`, `ceo-review`, `reflect` | Universal judgment and learning protocols copied verbatim. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Sploot is a pnpm Turborepo monorepo. `apps/web` owns the Next.js 15 app, API rou
 - Web API docs: `apps/web/docs/API.md` must stay synced with route behavior
 - Shared upload/API contract: `packages/common/src/*`
 - Prisma schema/migrations: `apps/web/prisma`
-- CI: `.github/workflows/ci.yml`; release: `.github/workflows/release.yml`; AI review: `.github/workflows/cerberus.yml`
+- CI: `.github/workflows/ci.yml`; release: `.github/workflows/release.yml`
 
 ## Invariants
 

--- a/backlog.d/001-fix-extension-upload-response-contract.md
+++ b/backlog.d/001-fix-extension-upload-response-contract.md
@@ -1,0 +1,46 @@
+# Fix Extension Upload Response Contract
+
+Priority: high
+Status: ready
+Estimate: S
+
+## Goal
+
+Extension uploads return a populated asset id and blob URL after a successful
+`/api/upload` response.
+
+## Non-Goals
+
+- Redesigning the upload pipeline
+- Changing Vercel Blob storage behavior
+- Adding a second upload response shape for compatibility
+
+## Oracle
+
+- [ ] A contract test exercises the extension upload client against the actual
+      `SplootApiUploadResponse` shape.
+- [ ] A successful response shaped as `{ success: true, asset: { id, blobUrl,
+      pathname, ... } }` produces `UploadResult.assetId` and
+      `UploadResult.blobUrl`.
+- [ ] `apps/web/docs/API.md` examples match `packages/common/src/types.ts`.
+- [ ] `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`
+      passes, or any narrower verified command is justified in the delivery note.
+
+## Scope
+
+- `apps/extension/shared/api-client.ts`
+- `apps/web/app/api/upload/route.ts`
+- `packages/common/src/types.ts`
+- `apps/web/docs/API.md`
+
+## Why Now
+
+`/groom` found a user-facing contract mismatch: the extension currently reads
+`data.id || data.assetId`, while `/api/upload` returns the id under
+`data.asset.id`. That can make capture/upload appear successful at HTTP level
+while handing callers an undefined asset id.
+
+## Notes
+
+This item was first discovered during the 2026-05-14 `/groom` correction that
+moved Sploot back to `backlog.d` as the source of truth.

--- a/backlog.d/002-configure-extension-auth-authorized-parties.md
+++ b/backlog.d/002-configure-extension-auth-authorized-parties.md
@@ -1,0 +1,39 @@
+# Configure Extension Auth Authorized Parties
+
+Priority: high
+Status: ready
+Estimate: M
+
+## Goal
+
+Valid extension session tokens authenticate across development, staging, and
+production extension IDs without code changes.
+
+## Non-Goals
+
+- Replacing Clerk
+- Weakening authorized-party checks
+- Accepting arbitrary extension origins
+
+## Oracle
+
+- [ ] The hardcoded Chrome extension authorized party is replaced with an
+      environment-backed allowlist or equivalent runtime configuration.
+- [ ] At least one non-primary extension origin is covered by tests or documented
+      local verification.
+- [ ] Invalid origins still receive `401`.
+- [ ] `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`
+      passes, or any narrower verified command is justified in the delivery note.
+
+## Scope
+
+- `apps/web/lib/auth/verify-bearer.ts`
+- `apps/extension/shared/env.ts`
+- `apps/extension/shared/api-client.ts`
+- Extension auth/config docs if the operator contract changes
+
+## Why Now
+
+`/api/upload` supports Bearer tokens for the Chrome extension, but
+`verifyBearerOrThrow` currently hardcodes one extension ID. That is brittle for
+unpacked development, staging builds, and production extension ID changes.

--- a/backlog.d/003-ship-first-class-shuffle-api-contract.md
+++ b/backlog.d/003-ship-first-class-shuffle-api-contract.md
@@ -1,0 +1,43 @@
+# Ship First-Class Shuffle API Contract
+
+Priority: high
+Status: ready
+Estimate: M
+
+## Goal
+
+Shuffle is a documented, mechanically testable API behavior for returning
+randomized authenticated-user assets.
+
+## Non-Goals
+
+- Building AI meme generation
+- Reworking all search ranking
+- Adding anonymous/public shuffle
+
+## Oracle
+
+- [ ] A documented REST endpoint or documented query mode returns randomized
+      authenticated-user assets.
+- [ ] The contract includes `limit` and either seed semantics or an explicit
+      decision that shuffle is intentionally non-deterministic.
+- [ ] Focused route tests cover bounds and deterministic seed behavior when
+      applicable.
+- [ ] `apps/web/docs/API.md` describes the shipped contract.
+- [ ] `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`
+      passes, with DB-backed verification or an explicit DB-unverified note if
+      pgvector/database paths are touched.
+
+## Scope
+
+- `apps/web` API route or existing assets/search query behavior
+- `apps/web/docs/API.md`
+- `apps/web/lib/db.ts`
+- `apps/web/lib/filter-change.ts`
+- Extension call path only if quick shuffle UX consumes the API directly
+
+## Why Now
+
+`vision.md` names save/search/shuffle as the current core experience and calls
+shuffle a differentiator. Existing UI/database support should be grounded in a
+backend contract before more clients depend on it.

--- a/backlog.d/004-resync-api-docs-with-runtime-contracts.md
+++ b/backlog.d/004-resync-api-docs-with-runtime-contracts.md
@@ -1,0 +1,42 @@
+# Resync API Docs With Runtime Contracts
+
+Priority: medium
+Status: ready
+Estimate: M
+
+## Goal
+
+`apps/web/docs/API.md` matches the actual route responses and shared API types
+used by web and extension clients.
+
+## Non-Goals
+
+- Introducing generated OpenAPI unless that is the smallest durable fix
+- Rewriting all app documentation
+- Changing route behavior without a separate implementation ticket
+
+## Oracle
+
+- [ ] `/api/upload` is documented using `SplootApiUploadResponse`, including
+      `success`, `asset`, `isDuplicate`, `201`, and duplicate status behavior.
+- [ ] Upload, upload-url, embedding-status, batch embedding-status, and search
+      examples are checked against route code or request-level tests.
+- [ ] Stale base URLs and embedding dimension examples are fixed or explicitly
+      marked as placeholders.
+- [ ] Run the narrow docs/contract verification chosen for this change plus
+      `pnpm lint && pnpm type-check`.
+
+## Scope
+
+- `apps/web/docs/API.md`
+- `packages/common/src/types.ts`
+- `apps/web/app/api/upload/route.ts`
+- `apps/web/app/api/assets/[id]/embedding-status/route.ts`
+- `apps/web/app/api/assets/batch/embedding-status/route.ts`
+- `apps/web/app/api/search/route.ts`
+
+## Why Now
+
+`/groom` found API docs describing legacy response shapes while
+`@sploot/common` and route implementations expose different contracts. This
+directly compounds the extension upload bug and slows future client work.

--- a/backlog.d/005-triage-stale-prs-and-dependency-duplicates.md
+++ b/backlog.d/005-triage-stale-prs-and-dependency-duplicates.md
@@ -1,0 +1,39 @@
+# Triage Stale PRs And Dependency Duplicates
+
+Priority: medium
+Status: ready
+Estimate: S
+
+## Goal
+
+The open PR queue reflects current work instead of stale, conflicting, or
+duplicate tracks.
+
+## Non-Goals
+
+- Merging dependency updates without CI evidence
+- Reopening already closed dependency noise
+- Moving Sploot work tracking back to GitHub Issues
+
+## Oracle
+
+- [ ] Each stale human PR has one explicit action: rebase/resubmit or close with
+      a clear replacement note.
+- [ ] Duplicate Dependabot tracks for Next and `@clerk/clerk-react` are
+      consolidated so only the viable lockfile-correct PR remains.
+- [ ] Any retained PR has passing CI or a concrete follow-up backlog item.
+
+## Scope
+
+- PR #154 `feat(web): add PostHog product analytics`
+- PR #156 `ci: add trufflehog workflow`
+- PR #157 `ci: normalize merge gate`
+- PRs #169/#170 Next bump duplication
+- PRs #167/#168 `@clerk/clerk-react` duplication
+
+## Why Now
+
+The PR queue had ten open PRs while the local backlog was empty. Three March 6
+human PRs were stale/dirty, and two dependency families had duplicate tracks.
+That makes review state noisy unless PR hygiene is captured locally and
+resolved.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -1,0 +1,36 @@
+# Backlog
+
+Active work lives at the top level of `backlog.d/`. Completed work moves to
+`backlog.d/_done/` once its oracle is green and merged. Each ticket's
+`Status:` field is the source of truth; this index is only a readable map.
+
+Status conventions:
+- `ready` - shaped and unblocked; pick next.
+- `in-progress` - actively being built on a branch or worktree.
+- `done` - merged; lives under `backlog.d/_done/`.
+
+## Active
+
+| # | Title | Priority | Estimate |
+|---|-------|----------|----------|
+| [001](001-fix-extension-upload-response-contract.md) | Fix Extension Upload Response Contract | high | S |
+| [002](002-configure-extension-auth-authorized-parties.md) | Configure Extension Auth Authorized Parties | high | M |
+| [003](003-ship-first-class-shuffle-api-contract.md) | Ship First-Class Shuffle API Contract | high | M |
+| [004](004-resync-api-docs-with-runtime-contracts.md) | Resync API Docs With Runtime Contracts | medium | M |
+| [005](005-triage-stale-prs-and-dependency-duplicates.md) | Triage Stale PRs And Dependency Duplicates | medium | S |
+
+## Done
+
+See `_done/` for completed tickets with their `## What Was Built` notes.
+
+## Workflow
+
+- New tickets are created by `/groom` as markdown files at the top level.
+- `/shape` may add a sibling `.ctx.md` packet when implementation needs more
+  context than the ticket should carry.
+- When starting work, set `Status: in-progress` and keep the file at the top
+  level until merge.
+- When merged, set `Status: done`, add `## What Was Built`, move the file into
+  `_done/`, and update this index.
+- GitHub Issues are not the tracker for Sploot. PRs may reference backlog file
+  paths, but backlog state lives here.


### PR DESCRIPTION
## Summary
- remove stale Cerberus harness references from local skills
- make backlog.d the Sploot work-tracking source of truth
- add initial backlog.d tickets from the groom findings
- update workflow skills to close work through local backlog files instead of GitHub Issues

## Verification
- pnpm turbo run type-check
- lefthook pre-commit: gitleaks, typecheck, commitlint
- lefthook pre-push: typecheck

Backlog: backlog.d/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow and skill specifications to align with local backlog tracking system
  * Added comprehensive backlog index documentation and structure

* **New Features (In Progress)**
  * Shuffle API for authenticated user asset randomization with deterministic seeding options
  * Extension authentication configuration across development, staging, and production environments

* **Bug Fixes (Scheduled)**
  * Extension upload response contract alignment with API client expectations
  * API documentation synchronization with runtime contracts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/misty-step/sploot/pull/178)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->