### PR TITLE
ci(release): use package manager pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary\n- remove the duplicate pnpm/action-setup version override from the Release workflow\n- let pnpm/action-setup use packageManager pnpm@10.22.0 from package.json, matching CI\n\n## Verification\n- git diff --check\n- pre-commit gitleaks and typecheck via lefthook\n- pre-push typecheck via lefthook\n\nFixes the post-merge Release workflow setup failure from run 26455420839.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for the release process.

**Note:** This is an internal infrastructure update with no direct impact on end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/misty-step/sploot/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->