### PR TITLE
feat(web): integrate Canary observability

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -255,6 +255,11 @@ BLOB_READ_WRITE_TOKEN=
 # Embeddings API
 EMBEDDINGS_API_KEY=
 EMBEDDINGS_API_URL=
+
+# Agent observability (Canary)
+CANARY_ENDPOINT=https://canary-obs.fly.dev
+CANARY_API_KEY=
+CANARY_SERVICE_NAME=sploot-web
 ```
 
 ### Environment File Structure

--- a/apps/web/OBSERVABILITY.md
+++ b/apps/web/OBSERVABILITY.md
@@ -2,7 +2,26 @@
 
 ## Overview
 
-This guide is the go-to reference when you need to peek behind the curtain of Sploot's behaviour in production. Everything below is tuned for Vercel Logs + Sentry. Copy, paste, tweak filters, and keep the vibes tidy.
+This guide is the go-to reference when you need to inspect Sploot's behaviour in production. Vercel Logs and Sentry remain the human-debugging surfaces; Canary is the agent-facing substrate for grouped errors, health checks, replay, and annotations.
+
+## Canary Integration
+
+Server-side route failures and authenticated client error telemetry are forwarded to Canary when these production environment variables are present:
+
+```env
+CANARY_ENDPOINT=https://canary-obs.fly.dev
+CANARY_API_KEY=<ingest-scoped key>
+CANARY_SERVICE_NAME=sploot-web
+```
+
+Canary forwarding is best-effort: failures are swallowed so observability never blocks upload, search, auth, or telemetry responses. Payloads are sanitized before ingest; token, cookie, secret, session, and API-key shaped metadata keys are redacted.
+
+Runtime proof points:
+
+- `/api/health` includes `diagnostics.canary_configured`.
+- `/api/health/services` includes `services.canary` with `healthy`, `degraded`, or `not_configured`.
+- `EXPECT_CANARY_CONFIGURED=1 pnpm --filter web smoke:deployed` fails deployed smoke when Canary is not configured and reachable.
+- Canary query path: `GET /api/v1/query?service=sploot-web&window=1h`.
 
 ## SLO Monitoring Queries
 
@@ -87,6 +106,7 @@ Use these to calibrate alerts in Vercel or external tooling:
 | No logs appearing | Ensure `withObservability` wraps the route; confirm `TRACE_ID` header not stripped by clients. |
 | Missing analytics events | Verify client isn’t in Do Not Track mode; ensure `@vercel/analytics` is loaded. |
 | Sentry not capturing | Check `SENTRY_DSN` in env + preview env; run `npx @sentry/wizard` if reinitialising. |
+| Canary not receiving errors | Check `CANARY_ENDPOINT`, `CANARY_API_KEY`, and `/api/health/services` `services.canary`; run deployed smoke with `EXPECT_CANARY_CONFIGURED=1`. |
 | Telemetry endpoint returning 401 | Requires authenticated user; confirm session in app/api/telemetry hits `getAuth`. |
 | High cost alerts | Pull `/api/analytics/usage` to confirm counts per hour/day; cross-check with Vercel log queries above. |
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -32,6 +32,11 @@ BLOB_READ_WRITE_TOKEN=vercel_blob_...
 
 # AI (Replicate)
 REPLICATE_API_TOKEN=r8_...
+
+# Agent observability (Canary, optional but expected in production)
+CANARY_ENDPOINT=https://canary-obs.fly.dev
+CANARY_API_KEY=<ingest-scoped key>
+CANARY_SERVICE_NAME=sploot-web
 ```
 
 ### 2. Development

--- a/apps/web/__tests__/api/health.test.ts
+++ b/apps/web/__tests__/api/health.test.ts
@@ -19,6 +19,10 @@ vi.mock('@/lib/with-observability', () => ({
   withObservability: (handler: any) => handler,
 }));
 
+vi.mock('@/lib/canary-reporter', () => ({
+  canaryConfigured: vi.fn(() => false),
+}));
+
 vi.mock('@/package.json', () => ({
   default: { version: '0.1.0' },
 }));
@@ -64,6 +68,7 @@ describe('/api/health', () => {
     expect(data.diagnostics.prisma_connection_test).toBe(true);
     expect(data.diagnostics.database_url_configured).toBe(true);
     expect(data.diagnostics.connection_latency_ms).toBeGreaterThanOrEqual(0);
+    expect(data.diagnostics.canary_configured).toBe(false);
     expect(data.diagnostics.env_vars).toBeDefined();
     expect(data.diagnostics.env_vars.DATABASE_URL).toBe('configured');
 

--- a/apps/web/__tests__/api/telemetry.integration.test.ts
+++ b/apps/web/__tests__/api/telemetry.integration.test.ts
@@ -135,6 +135,16 @@ describe('/api/telemetry', () => {
       },
       user: { id: AUTH_USER.userId },
     });
+    expect(mockLogger.logError).toHaveBeenCalledWith(
+      'client:error',
+      expect.any(Error),
+      expect.objectContaining({
+        userId: AUTH_USER.userId,
+        url: payload.payload.url,
+        hasStack: true,
+        hasComponentStack: true,
+      })
+    );
   });
 
   it('logs when Sentry forwarding fails but still returns success', async () => {

--- a/apps/web/__tests__/lib/canary-reporter.test.ts
+++ b/apps/web/__tests__/lib/canary-reporter.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = {
+  CANARY_ENDPOINT: process.env.CANARY_ENDPOINT,
+  CANARY_API_KEY: process.env.CANARY_API_KEY,
+  CANARY_INGEST_KEY: process.env.CANARY_INGEST_KEY,
+  CANARY_SERVICE_NAME: process.env.CANARY_SERVICE_NAME,
+  CANARY_ENABLE_IN_TEST: process.env.CANARY_ENABLE_IN_TEST,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  process.env.CANARY_ENDPOINT = 'https://canary.example.test';
+  process.env.CANARY_API_KEY = 'test-canary-key';
+  process.env.CANARY_SERVICE_NAME = 'sploot-test';
+  process.env.CANARY_ENABLE_IN_TEST = '1';
+  process.env.VERCEL_ENV = 'test';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe('canary reporter', () => {
+  it('posts sanitized error payloads to Canary ingest', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportCanaryError } = await import('@/lib/canary-reporter');
+
+    await reportCanaryError({
+      context: 'request:error',
+      traceId: 'trace-123',
+      error: {
+        name: 'TypeError',
+        message: 'Upload failed',
+        stack: 'TypeError: Upload failed',
+      },
+      metadata: {
+        pathname: '/api/upload',
+        authorization: 'Bearer secret',
+        nested: {
+          sessionToken: 'secret-session',
+          safe: 'value',
+        },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://canary.example.test/api/v1/errors',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-canary-key',
+          'X-API-Key': 'test-canary-key',
+        }),
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+
+    expect(body).toMatchObject({
+      service: 'sploot-test',
+      error_class: 'TypeError',
+      message: 'Upload failed',
+      stack_trace: 'TypeError: Upload failed',
+      severity: 'error',
+      context: {
+        source: 'sploot-web',
+        context: 'request:error',
+        trace_id: 'trace-123',
+        environment: 'test',
+      },
+    });
+    expect(body.context.metadata.authorization).toBe('[redacted]');
+    expect(body.context.metadata.nested.sessionToken).toBe('[redacted]');
+    expect(body.context.metadata.nested.safe).toBe('value');
+  });
+
+  it('reports not configured when endpoint or key is missing', async () => {
+    delete process.env.CANARY_ENDPOINT;
+
+    const { canaryConfigured, checkCanaryStatus } = await import('@/lib/canary-reporter');
+
+    expect(canaryConfigured()).toBe(false);
+    await expect(checkCanaryStatus()).resolves.toMatchObject({
+      configured: false,
+      reachable: null,
+      status: 'not_configured',
+    });
+  });
+});

--- a/apps/web/__tests__/lib/observability-logger.test.ts
+++ b/apps/web/__tests__/lib/observability-logger.test.ts
@@ -5,6 +5,7 @@ const originalEnv = {
   NODE_ENV: process.env.NODE_ENV,
   VERCEL_REGION: process.env.VERCEL_REGION,
   VERCEL_URL: process.env.VERCEL_URL,
+  CANARY_ENABLE_IN_TEST: process.env.CANARY_ENABLE_IN_TEST,
 };
 
 type ConsoleSpy = ReturnType<typeof vi.spyOn>;
@@ -14,6 +15,9 @@ let consoleErrorSpy: ConsoleSpy;
 
 async function importLogger(sentryFactory?: () => unknown) {
   vi.doUnmock('@sentry/nextjs');
+  vi.doMock('@/lib/canary-reporter', () => ({
+    reportCanaryError: vi.fn(),
+  }));
   vi.doMock(
     '@sentry/nextjs',
     sentryFactory ??
@@ -72,6 +76,12 @@ afterEach(() => {
     delete process.env.VERCEL_URL;
   } else {
     process.env.VERCEL_URL = originalEnv.VERCEL_URL;
+  }
+
+  if (originalEnv.CANARY_ENABLE_IN_TEST === undefined) {
+    delete process.env.CANARY_ENABLE_IN_TEST;
+  } else {
+    process.env.CANARY_ENABLE_IN_TEST = originalEnv.CANARY_ENABLE_IN_TEST;
   }
 
   vi.doUnmock('@sentry/nextjs');
@@ -138,6 +148,28 @@ describe('observability logger', () => {
         },
       },
     });
+  });
+
+  it('pipes server-side errors into Canary with sanitized context metadata', async () => {
+    process.env.CANARY_ENABLE_IN_TEST = '1';
+    const { logger } = await importLogger();
+    const canary = await import('@/lib/canary-reporter');
+    const err = new Error('upload queue failed');
+
+    logger.logError('canary-signal', err, { requestId: 'req-123' });
+    await flushAsync();
+
+    expect(vi.mocked(canary.reportCanaryError)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: 'canary-signal',
+        traceId: undefined,
+        metadata: { requestId: 'req-123' },
+        error: expect.objectContaining({
+          name: 'Error',
+          message: 'upload queue failed',
+        }),
+      })
+    );
   });
 
   it('logs timing entries with duration and success fields', async () => {

--- a/apps/web/__tests__/lib/with-observability.test.ts
+++ b/apps/web/__tests__/lib/with-observability.test.ts
@@ -195,6 +195,15 @@ describe('withObservability', () => {
         success: false,
       })
     );
+    expect(record?.logger.logError).toHaveBeenCalledWith(
+      'request:server-error-status',
+      expect.any(Error),
+      expect.objectContaining({
+        operation: '/api/chaos',
+        statusCode: 500,
+        success: false,
+      })
+    );
   });
 
   it('logs errors, invokes unstable_rethrow, and rethrows', async () => {

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
 import { kv } from '@vercel/kv';
+import { canaryConfigured } from '@/lib/canary-reporter';
 import { withObservability } from '@/lib/with-observability';
 import { logger } from '@/lib/observability-logger';
 import pkg from '@/package.json';
@@ -18,6 +19,7 @@ interface HealthStatus {
     database_url_configured?: boolean;
     connection_latency_ms?: number;
     env_vars?: Record<string, 'configured' | 'missing'>;
+    canary_configured?: boolean;
   };
   version?: string;
   error?: string;
@@ -171,6 +173,7 @@ async function getHandler(_req: NextRequest) {
           prisma_connection_test: results.db.prisma_test,
           database_url_configured: !!process.env.DATABASE_URL,
           connection_latency_ms: results.db.latency_ms,
+          canary_configured: canaryConfigured(),
           env_vars: envVars,
         },
         version: pkg.version,
@@ -196,6 +199,7 @@ async function getHandler(_req: NextRequest) {
           prisma_connection_test: results.db.prisma_test,
           database_url_configured: !!process.env.DATABASE_URL,
           connection_latency_ms: results.db.latency_ms,
+          canary_configured: canaryConfigured(),
           env_vars: envVars,
         },
       };
@@ -219,6 +223,7 @@ async function getHandler(_req: NextRequest) {
       error: error instanceof Error ? error.message : 'Unknown error',
       diagnostics: {
         database_url_configured: !!process.env.DATABASE_URL,
+        canary_configured: canaryConfigured(),
         env_vars: {
           DATABASE_URL: process.env.DATABASE_URL ? 'configured' : 'missing',
         },

--- a/apps/web/app/api/health/services/route.ts
+++ b/apps/web/app/api/health/services/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { clerkConfigured, blobConfigured, databaseConfigured, replicateConfigured } from '@/lib/env';
 import { prisma } from '@/lib/db';
 import { currentUser } from '@clerk/nextjs/server';
+import { canaryConfigured, checkCanaryStatus } from '@/lib/canary-reporter';
 import { withObservability } from '@/lib/with-observability';
 
 /**
@@ -147,8 +148,33 @@ async function getHandler(req: NextRequest) {
     };
   }
 
+  // Check Canary (agent-facing observability, optional)
+  try {
+    const canary = await checkCanaryStatus();
+    services.canary = {
+      name: 'Agent Observability (Canary)',
+      status: canary.status,
+      configured: canary.configured,
+      message: canary.message,
+      details: {
+        reachable: canary.reachable,
+      },
+    };
+  } catch (error) {
+    services.canary = {
+      name: 'Agent Observability (Canary)',
+      status: 'degraded',
+      configured: canaryConfigured(),
+      message: 'Error checking Canary status',
+      details: process.env.NODE_ENV === 'development' ? String(error) : undefined,
+    };
+  }
+
   // Calculate overall health
-  const statuses = Object.values(services).map(s => s.status);
+  const requiredServices = Object.entries(services)
+    .filter(([key]) => key !== 'canary')
+    .map(([, service]) => service);
+  const statuses = requiredServices.map(s => s.status);
   const overallHealth = statuses.every(s => s === 'healthy') ? 'healthy' :
                         statuses.some(s => s === 'unavailable') ? 'unhealthy' :
                         statuses.some(s => s === 'degraded' || s === 'not_configured') ? 'degraded' :

--- a/apps/web/app/api/telemetry/route.ts
+++ b/apps/web/app/api/telemetry/route.ts
@@ -100,6 +100,14 @@ function forwardErrorTelemetry(payload: ErrorPayload, userId: string): void {
       },
       user: { id: userId },
     });
+
+    logger.logError('client:error', error, {
+      userId,
+      url: payload.url,
+      timestamp: payload.timestamp,
+      hasStack: Boolean(payload.stack),
+      hasComponentStack: Boolean(payload.componentStack),
+    });
   } catch (error) {
     logger.logError('telemetry:sentry-failure', error, { userId, payload });
   }

--- a/apps/web/lib/canary-reporter.ts
+++ b/apps/web/lib/canary-reporter.ts
@@ -1,0 +1,198 @@
+type Severity = 'info' | 'warning' | 'error' | 'critical';
+
+interface CanaryConfig {
+  endpoint: string;
+  apiKey: string;
+  service: string;
+  environment: string;
+}
+
+interface SerializedError {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+interface CanaryReportInput {
+  context: string;
+  error: SerializedError;
+  traceId?: string;
+  metadata?: Record<string, any>;
+  severity?: Severity;
+}
+
+interface CanaryStatus {
+  configured: boolean;
+  reachable: boolean | null;
+  status: 'healthy' | 'degraded' | 'not_configured';
+  message: string;
+}
+
+const REDACTED = '[redacted]';
+const DEFAULT_SERVICE = 'sploot-web';
+const DEFAULT_TIMEOUT_MS = 2500;
+const MAX_STRING_LENGTH = 2000;
+const MAX_ARRAY_LENGTH = 20;
+const MAX_OBJECT_KEYS = 40;
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|cookie|token|secret|password|session|api[-_]?key|dsn|credential)/i;
+
+export function canaryConfigured(): boolean {
+  return getCanaryConfig() !== null;
+}
+
+export async function reportCanaryError(input: CanaryReportInput): Promise<void> {
+  const config = getCanaryConfig();
+  if (!config) {
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    await fetch(`${config.endpoint}/api/v1/errors`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'X-API-Key': config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        service: config.service,
+        error_class: input.error.name || 'Error',
+        message: input.error.message || input.context,
+        stack_trace: input.error.stack,
+        severity: input.severity ?? 'error',
+        context: {
+          source: 'sploot-web',
+          context: input.context,
+          trace_id: input.traceId,
+          environment: config.environment,
+          vercel_region: process.env.VERCEL_REGION,
+          vercel_url: process.env.VERCEL_URL,
+          metadata: sanitizeValue(input.metadata),
+        },
+      }),
+      signal: controller.signal,
+    });
+  } catch {
+    // Canary must never affect the user flow or primary logging path.
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function checkCanaryStatus(): Promise<CanaryStatus> {
+  const config = getCanaryConfig();
+  if (!config) {
+    return {
+      configured: false,
+      reachable: null,
+      status: 'not_configured',
+      message: 'Missing CANARY_ENDPOINT or CANARY_API_KEY',
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${config.endpoint}/api/v1/openapi.json`, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+
+    if (response.ok) {
+      return {
+        configured: true,
+        reachable: true,
+        status: 'healthy',
+        message: 'Canary OpenAPI contract reachable',
+      };
+    }
+
+    return {
+      configured: true,
+      reachable: false,
+      status: 'degraded',
+      message: `Canary returned HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      configured: true,
+      reachable: false,
+      status: 'degraded',
+      message: error instanceof Error ? error.message : 'Canary unreachable',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function getCanaryConfig(): CanaryConfig | null {
+  if (process.env.NODE_ENV === 'test' && process.env.CANARY_ENABLE_IN_TEST !== '1') {
+    return null;
+  }
+
+  const endpoint = normalizeEndpoint(process.env.CANARY_ENDPOINT);
+  const apiKey = process.env.CANARY_API_KEY || process.env.CANARY_INGEST_KEY;
+
+  if (!endpoint || !apiKey) {
+    return null;
+  }
+
+  return {
+    endpoint,
+    apiKey,
+    service: process.env.CANARY_SERVICE_NAME || DEFAULT_SERVICE,
+    environment: process.env.VERCEL_ENV || process.env.NODE_ENV || 'unknown',
+  };
+}
+
+function normalizeEndpoint(endpoint: string | undefined): string | null {
+  if (!endpoint) {
+    return null;
+  }
+
+  try {
+    const url = new URL(endpoint);
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (depth > 4) {
+    return '[truncated]';
+  }
+
+  if (value === null || typeof value === 'undefined') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_LENGTH ? `${value.slice(0, MAX_STRING_LENGTH)}...` : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ARRAY_LENGTH).map(item => sanitizeValue(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_OBJECT_KEYS);
+    return Object.fromEntries(
+      entries.map(([key, item]) => [
+        key,
+        SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : sanitizeValue(item, depth + 1),
+      ])
+    );
+  }
+
+  return String(value);
+}

--- a/apps/web/lib/observability-logger.ts
+++ b/apps/web/lib/observability-logger.ts
@@ -148,6 +148,19 @@ class ObservabilityLoggerImpl implements ObservabilityLogger {
         // Sentry capture should never throw for callers
       }
     });
+
+    void import('./canary-reporter')
+      .then(({ reportCanaryError }) =>
+        reportCanaryError({
+          context,
+          error: serializedError,
+          traceId: this.traceId,
+          metadata,
+        })
+      )
+      .catch(() => {
+        // Canary forwarding is best-effort and must never affect callers.
+      });
   }
 
   logTiming(

--- a/apps/web/lib/with-observability.ts
+++ b/apps/web/lib/with-observability.ts
@@ -112,6 +112,20 @@ export function withObservability(
             duration,
             success,
           });
+
+          if (statusCode >= 500) {
+            logger.logError(
+              'request:server-error-status',
+              new Error(`Request completed with HTTP ${statusCode}`),
+              {
+                ...metadata,
+                operation,
+                statusCode,
+                duration,
+                success,
+              }
+            );
+          }
         } catch {
           // Silently ignore logging failures
         }

--- a/apps/web/scripts/smoke-deployed.mjs
+++ b/apps/web/scripts/smoke-deployed.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 const baseUrl = (process.env.DEPLOYED_SMOKE_URL ?? 'https://www.sploot.app').replace(/\/$/, '');
+const expectCanaryConfigured = process.env.EXPECT_CANARY_CONFIGURED === '1';
 const reportPath = path.resolve(
   process.cwd(),
   process.env.DEPLOYED_SMOKE_REPORT ?? 'docs/deployed-smoke-report.json'
@@ -168,10 +169,14 @@ await record('production health', async () => {
   if (json?.diagnostics?.database_url_configured !== true) {
     throw new Error('expected DATABASE_URL to be configured');
   }
+  if (expectCanaryConfigured && json?.diagnostics?.canary_configured !== true) {
+    throw new Error('expected Canary to be configured');
+  }
 
   return {
     database: json.dependencies.database,
     redis: json.dependencies.redis,
+    canary_configured: json.diagnostics?.canary_configured ?? null,
     database_latency_ms: json.diagnostics?.connection_latency_ms ?? null,
     version: json.version ?? null,
   };
@@ -188,6 +193,9 @@ await record('production service health', async () => {
   if (!json?.services?.database || !json?.services?.blobStorage || !json?.services?.embeddings) {
     throw new Error('expected database, blobStorage, and embeddings service entries');
   }
+  if (expectCanaryConfigured && json.services.canary?.status !== 'healthy') {
+    throw new Error(`expected Canary healthy, got ${json.services.canary?.status}`);
+  }
   if (json.services.database.status !== 'healthy') {
     throw new Error(`expected database healthy, got ${json.services.database.status}`);
   }
@@ -198,6 +206,7 @@ await record('production service health', async () => {
     database: json.services.database.status,
     blob_storage: json.services.blobStorage.status,
     embeddings: json.services.embeddings.status,
+    canary: json.services.canary?.status ?? null,
     can_upload: json.readiness?.canUpload ?? null,
     can_search: json.readiness?.canSearch ?? null,
   };

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -13,13 +13,14 @@ Status conventions:
 
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
-| [007](007-publish-extension-web-store-release.md) | Publish Extension Web Store Release | high | M |
+| _none_ | _No active backlog items_ | - | - |
 
 ## Done
 
 See `_done/` for completed tickets with their `## What Was Built` notes.
 
 Recently completed:
+- [016](_done/016-integrate-canary-agent-observability.md) Integrate Canary Agent Observability
 - [001](_done/001-fix-extension-upload-response-contract.md) Fix Extension Upload Response Contract
 - [002](_done/002-configure-extension-auth-authorized-parties.md) Configure Extension Auth Authorized Parties
 - [003](_done/003-ship-first-class-shuffle-api-contract.md) Ship First-Class Shuffle API Contract

--- a/backlog.d/_done/016-integrate-canary-agent-observability.md
+++ b/backlog.d/_done/016-integrate-canary-agent-observability.md
@@ -1,0 +1,44 @@
+# Integrate Canary agent observability
+
+Priority: high
+Status: done
+Estimate: M
+
+## Goal
+Forward Sploot server and authenticated client failures into Canary, expose Canary configuration in health checks, and make deployed smoke prove the production integration is live.
+
+## Non-Goals
+- Replace Sentry or Vercel Logs as human debugging surfaces.
+- Send browser or extension errors directly to Canary with client-visible secrets.
+- Block upload, search, auth, or telemetry responses when Canary is unavailable.
+- Change Chrome Web Store release behavior.
+
+## Oracle
+- [x] Server-side `logger.logError` forwards sanitized error payloads to Canary when `CANARY_ENDPOINT` and `CANARY_API_KEY` are configured.
+- [x] `withObservability` promotes HTTP 5xx route responses into error reports, not just timing logs.
+- [x] `/api/telemetry` forwards authenticated client error telemetry through the server logger so extension/web client failures can reach Canary without exposing the ingest key.
+- [x] `/api/health` exposes `diagnostics.canary_configured`.
+- [x] `/api/health/services` exposes optional `services.canary` state without making Canary a required Sploot dependency.
+- [x] `EXPECT_CANARY_CONFIGURED=1 pnpm --filter web smoke:deployed` fails if deployed production is missing Canary config or cannot reach Canary.
+- [x] Production Vercel env contains `CANARY_ENDPOINT`, `CANARY_API_KEY`, and `CANARY_SERVICE_NAME`.
+- [x] Local gate evidence captured for lint, type-check, web tests, and extension build.
+
+## What Was Built
+
+- Added `apps/web/lib/canary-reporter.ts` with best-effort Canary ingest, metadata redaction, health probing, production-safe env detection, and test-mode opt-in.
+- Extended `apps/web/lib/observability-logger.ts` so server errors are forwarded to Canary after existing console/Sentry handling.
+- Extended `apps/web/lib/with-observability.ts` so 5xx responses are reported as error events.
+- Extended `apps/web/app/api/telemetry/route.ts` so authenticated client error telemetry reaches Canary through the server.
+- Added Canary health visibility to `/api/health` and `/api/health/services`.
+- Updated deployed smoke and operator docs for the Canary production contract.
+
+## Verification
+
+- `pnpm --filter web exec vitest run __tests__/lib/canary-reporter.test.ts __tests__/lib/observability-logger.test.ts __tests__/lib/with-observability.test.ts __tests__/api/health.test.ts __tests__/api/telemetry.integration.test.ts __tests__/error-scenarios.test.ts`
+- `pnpm --filter web type-check`
+- `pnpm lint`
+- `pnpm type-check`
+- `CI=true pnpm --filter web test`
+- `pnpm --filter extension build`
+
+Ships-backlog: backlog.d/_done/016-integrate-canary-agent-observability.md


### PR DESCRIPTION
## Summary

- forward server-side Sploot errors and 5xx route responses into Canary with sanitized context
- forward authenticated client error telemetry through the server logger so extension/web failures can reach Canary without client secrets
- expose Canary configuration/reachability in health endpoints and deployed smoke, and document production env

## Verification

- pnpm --filter web exec vitest run __tests__/lib/canary-reporter.test.ts __tests__/lib/observability-logger.test.ts __tests__/lib/with-observability.test.ts __tests__/api/health.test.ts __tests__/api/telemetry.integration.test.ts __tests__/error-scenarios.test.ts
- pnpm --filter web type-check
- pnpm lint
- pnpm type-check
- CI=true pnpm --filter web test
- pnpm --filter extension build

Ships-backlog: backlog.d/_done/016-integrate-canary-agent-observability.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Canary agent observability for error tracking and service health monitoring.
  * Health check endpoints now report Canary integration status.
  * Automatic error forwarding to Canary for improved diagnostics.

* **Documentation**
  * Updated setup guides with required Canary configuration variables.
  * Added troubleshooting guidance for Canary integration issues and health diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/misty-step/sploot/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->