### PR TITLE
chore: add oh-my-pi (omp) harness for sploot

### DIFF
--- a/.omp/README.md
+++ b/.omp/README.md
@@ -1,0 +1,52 @@
+# sploot oh-my-pi (omp) harness
+
+Repo-local config for the [`omp`](https://github.com/can1357/oh-my-pi) coding
+agent. omp reads this `.omp/` dir at priority 100 (above inherited `.claude/`
+etc.), walking up from the cwd so it works from any subdir of the monorepo.
+
+## Run it
+
+```bash
+omp                       # interactive TUI, in repo root
+omp "wire up X"           # interactive with a starting prompt
+omp -p "run the gate"     # non-interactive (print and exit)
+```
+
+## What's configured
+
+**Models (global — `~/.omp/agent/config.yml`).** Everything routes through
+OpenRouter (built-in; uses `OPENROUTER_API_KEY`). Default anchor is
+`google/gemini-3.5-flash`; on quota/rate-limit it fails over through the chain
+`minimax-m3 → grok-build-0.1 → grok-4.3 → kimi-latest → deepseek-v4-pro →
+deepseek-v4-flash → glm-5.1`, then reverts when the primary's cooldown expires.
+Role split: `slow`→grok-4.3, `plan`→deepseek-v4-pro, `task`→minimax-m3, the
+rest→gemini-3.5-flash. Switch live with `/model`, `Ctrl+P`, or `--slow`/`--plan`.
+
+**Context.** omp natively loads `AGENTS.md` + `CLAUDE.md` (monorepo hierarchy
+aware). `.omp/RULES.md` holds the critical-few invariants and is re-injected
+near every turn so they survive long sessions.
+
+**Scoped rules (`.omp/rules/`).** Fire only when you touch the matching paths:
+- `prisma-db.mdc` → `apps/web/prisma/**`, db libs, api routes
+- `common-contract.mdc` → `packages/common/**`
+- `extension.mdc` → `apps/extension/**`
+
+**Slash commands (`.omp/commands/`).**
+- `/gate` — full CI-parity ship gate, per-step ✅/❌
+- `/typecheck` — monorepo `tsc --noEmit` triage
+- `/test-web` — web Vitest via the CI `test` script (`CI=1`, run-once)
+- `/db` — Prisma/Neon ops with the `DATABASE_URL` guardrail
+- `/backlog` — show `backlog.d/` queue + closure protocol
+- `/ext-release` — Chrome Web Store release-packet validation
+
+**Search.** Exa (root `.mcp.json`, native to omp) + Brave (`BRAVE_API_KEY`).
+**LSP.** On for the TS monorepo (diagnostics on edit); format-on-write off so it
+never fights eslint/prettier or the gate.
+
+## Extending
+
+- Add a command: drop `.omp/commands/<name>.md` (file body = the prompt).
+- Add a scoped rule: `.omp/rules/<name>.mdc` with `globs:` frontmatter.
+- Unpack omp's bundled task agents into the repo: `omp agents unpack --project`.
+- Custom tools / hooks / extensions: `.omp/tools/`, `.omp/hooks/<type>/`,
+  `.omp/extensions/<name>/` (see omp's `examples/`).

--- a/.omp/RULES.md
+++ b/.omp/RULES.md
@@ -1,0 +1,20 @@
+# Sploot — sticky invariants
+
+These are re-injected every turn. Violating one breaks prod or the build. Full
+contract: read `AGENTS.md` (loaded as context) and `CLAUDE.md`.
+
+- **pnpm + Turborepo only.** Never `npm`/`yarn`. Base branch is `origin/master`.
+- **Prisma reads `DATABASE_URL`** at Rust-engine init — never invent aliases
+  (`POSTGRES_URL`, etc.). Pooled Neon URL needs `pgbouncer=true` + `-pooler`.
+- **Never lower a gate** to go green. No skipped tests, loosened lint, weakened
+  thresholds. Diagnose env/DB/migration/WXT/auth setup instead.
+- **`@sploot/common` is the source of truth** for upload limits, MIME
+  validation, and shared API types. Change it there, then update both apps.
+- **Web deploy (Vercel) and extension release (Chrome Web Store) are separate
+  surfaces.** Do not couple them.
+- **Work tracking lives in `backlog.d/`** (local markdown), not GitHub Issues.
+  Closure = move to `backlog.d/_done/` with `Status: done`, a `## What Was
+  Built` note, and a conventional-commit `Backlog:`/`Closes-backlog:` trailer.
+- **Ship gate = CI parity:** `pnpm lint && pnpm type-check && pnpm --filter web
+  test && pnpm --filter extension build` (run the web step as `CI=1 pnpm
+  --filter web test` so Vitest stays one-shot under omp's PTY).

--- a/.omp/commands/backlog.md
+++ b/.omp/commands/backlog.md
@@ -1,0 +1,14 @@
+Show the sploot work backlog and explain how to close an item.
+
+`backlog.d/` is the source of truth for work (not GitHub Issues). Do this:
+
+1. Read `backlog.d/README.md` (the human-readable index / active queue).
+2. List active items: the `backlog.d/*.md` files (excluding `_done/` and
+   `README.md`). If only `_done/` and `README.md` exist, the queue is empty.
+3. List recently completed items in `backlog.d/_done/`.
+
+Closure protocol for an item: move it to `backlog.d/_done/` with `Status:
+done`, add a `## What Was Built` note, and link it from the commit/PR with a
+conventional trailer — `Backlog: backlog.d/<id>-<slug>.md`,
+`Closes-backlog:`, or `Ships-backlog:`. Keep `backlog.d/README.md` aligned with
+the active queue.

--- a/.omp/commands/db.md
+++ b/.omp/commands/db.md
@@ -1,0 +1,18 @@
+Prisma / Neon database operations for apps/web.
+
+CRITICAL: Prisma's Rust engine reads `DATABASE_URL` before Node starts —
+runtime env edits are too late in serverless. Never use an alias like
+`POSTGRES_URL`. The pooled Neon URL must include `-pooler` host + `pgbouncer=true`.
+
+Available scripts (run via `pnpm --filter web <script>`):
+- `db:migrate:dev`  — create + apply a dev migration (`prisma migrate dev`)
+- `db:migrate`      — apply migrations in deploy mode (`prisma migrate deploy`)
+- `db:push`         — push schema without a migration (prototyping only)
+- `db:generate`     — regenerate the Prisma client
+- `db:studio`       — open Prisma Studio
+- `db:seed`         — seed data
+- `db:sync` / `db:fingerprint` / `db:drift` — env sync + drift checks
+
+Tell me which operation you want. Before any schema change, confirm
+`DATABASE_URL` is set and pointed at the intended environment, and prefer a
+named migration (`db:migrate:dev`) over `db:push` for anything that ships.

--- a/.omp/commands/ext-release.md
+++ b/.omp/commands/ext-release.md
@@ -1,0 +1,17 @@
+Validate the Chrome extension release packet for apps/extension.
+
+Run `pnpm --filter extension release:check` (runs
+`scripts/validate-store-release.mjs`). It checks the store listing + assets are
+release-ready.
+
+Related surfaces to verify when prepping a Web Store submission:
+- `apps/extension/STORE_LISTING.md` — listing copy/metadata
+- `apps/extension/store-assets/` — screenshots/icons/promo art
+- Production build: `pnpm --filter extension build:prod` (or
+  `build:prod:unpacked` to include the CRX key), then `zip:prod`
+- Env must use the matching Clerk key: `pk_live_*` + `https://www.sploot.app`
+  for prod, `pk_test_*` + localhost for dev (`VITE_CLERK_PUBLISHABLE_KEY`,
+  `VITE_API_BASE_URL`, `VITE_CLERK_SYNC_HOST`).
+
+Remember: the extension release is a separate surface from the Vercel web
+deploy. Report what passed, what's missing, and the exact remediation.

--- a/.omp/commands/gate.md
+++ b/.omp/commands/gate.md
@@ -1,0 +1,19 @@
+Run the sploot ship gate — CI parity — and report pass/fail per step.
+
+Run these in order, from the repo root, and do not stop at the first failure —
+run all four so I see the full picture:
+
+1. `pnpm lint`
+2. `pnpm type-check`
+3. `CI=1 pnpm --filter web test`  (the exact CI test script; `CI=1` forces
+   Vitest run-once so it can't drop into watch mode under omp's interactive PTY)
+4. `pnpm --filter extension build`
+
+DB-backed web tests need `DATABASE_URL` pointing at a pgvector-capable Postgres.
+If it is unset, say so and label those results "DB path unverified" rather than
+treating skips as passes.
+
+Then summarize: a ✅/❌ table of the four steps, and for any ❌ the exact failing
+command + the first real error. Do NOT propose lowering a gate to get green —
+diagnose env/DB/migration/WXT/auth setup instead. This mirrors the GitHub
+`merge-gate` job and the Lefthook pre-commit/pre-push hooks.

--- a/.omp/commands/test-web.md
+++ b/.omp/commands/test-web.md
@@ -1,0 +1,13 @@
+Run the web app's Vitest suite (one-shot) and report results.
+
+Use `CI=1 pnpm --filter web test` — the exact CI test script (ci.yml runs
+`pnpm --filter web test`), with `CI=1` forcing Vitest's run-once mode. Without
+it, omp runs bash in a PTY so bare `vitest` would drop into watch and hang.
+For a single file: `CI=1 pnpm --filter web test <path/to/file.test.ts>`.
+
+Integration tests that hit Postgres/pgvector need `DATABASE_URL`. CI runs them
+against a `pgvector/pgvector:pg15` service. Locally, if `DATABASE_URL` is unset
+those tests skip — report skipped DB tests explicitly; a skip is not a pass.
+
+On failure: show the failing test names + assertion diffs, find the root cause,
+and fix the behavior (not the assertion).

--- a/.omp/commands/typecheck.md
+++ b/.omp/commands/typecheck.md
@@ -1,0 +1,8 @@
+Type-check the whole monorepo and triage failures.
+
+Run `pnpm type-check` (Turbo fans out to web `tsc --noEmit`, extension `tsc
+--noEmit`, and `@sploot/common`).
+
+If it fails, group errors by package, show the file:line for each, and fix the
+root cause — do not silence with `any`, `@ts-ignore`, or by relaxing
+`tsconfig`. Re-run until clean.

--- a/.omp/rules/common-contract.mdc
+++ b/.omp/rules/common-contract.mdc
@@ -1,0 +1,22 @@
+---
+description: "@sploot/common is the shared source of truth — change it here, then both apps"
+globs:
+  - "packages/common/**"
+alwaysApply: false
+---
+
+# @sploot/common contract
+
+- `packages/common/src/` is the **single source of truth** for upload limits,
+  MIME validation (`isValidMimeType`, `UPLOAD`), and shared API response types
+  (`SplootApiUploadResponse`, etc.). Both `apps/web` and `apps/extension` import
+  from `@sploot/common`.
+- Add shared code by: (1) put it in `packages/common/src/`, (2) export it from
+  `packages/common/src/index.ts`, (3) import via `import { X } from
+  '@sploot/common'`.
+- Changing a constant or type here is a contract change — update **both**
+  consumers (web API routes/handlers and the extension api-client) in the same
+  change, and keep `apps/web/docs/API.md` in sync if route behavior shifts.
+- The extension resolves this package via the WXT alias in `wxt.config.ts`
+  (`@sploot/common` → `../../packages/common/src`); web resolves it through the
+  workspace. Don't break either resolution path.

--- a/.omp/rules/extension.mdc
+++ b/.omp/rules/extension.mdc
@@ -1,0 +1,22 @@
+---
+description: WXT/React Chrome extension — Clerk env matching and release packet
+globs:
+  - "apps/extension/**"
+alwaysApply: false
+---
+
+# Chrome extension (apps/extension, WXT + React)
+
+- Clerk publishable key **must match the environment**: `pk_test_*` with
+  localhost for dev, `pk_live_*` with `https://www.sploot.app` for prod. A
+  mismatched key is the classic auth-fails-silently bug. Keys live in
+  `.env` (dev) / `.env.production` (prod): `VITE_CLERK_PUBLISHABLE_KEY`,
+  `VITE_API_BASE_URL`, `VITE_CLERK_SYNC_HOST`.
+- Builds go through WXT, not a generic bundler: `build` (dev),
+  `build:prod` / `build:prod:unpacked`, `zip:prod`. `lint` and `type-check`
+  are both `tsc --noEmit`.
+- The Web Store release packet is gated by `pnpm --filter extension
+  release:check` (`scripts/validate-store-release.mjs`) plus
+  `STORE_LISTING.md` and `store-assets/`. Extension release ≠ web deploy.
+- Shared upload/MIME/type logic comes from `@sploot/common` — don't fork it
+  into the extension.

--- a/.omp/rules/prisma-db.mdc
+++ b/.omp/rules/prisma-db.mdc
@@ -1,0 +1,25 @@
+---
+description: Prisma / Neon / pgvector database invariants for apps/web
+globs:
+  - "apps/web/prisma/**"
+  - "apps/web/lib/db*"
+  - "apps/web/lib/**/db*"
+  - "apps/web/app/api/**"
+alwaysApply: false
+---
+
+# Database (apps/web)
+
+- Prisma's Rust engine reads **`DATABASE_URL`** at init, before Node runs. Never
+  introduce alias env names (`POSTGRES_URL`, etc.) — they are read too late in
+  serverless and silently break.
+- The pooled Neon connection string needs `-pooler` in the host and
+  `pgbouncer=true` in the query string; direct (migration) URLs do not.
+- Schema changes ship as **named migrations** (`pnpm --filter web db:migrate:dev`),
+  not `db:push`. CI applies `prisma migrate deploy` against
+  `pgvector/pgvector:pg15`.
+- Vector search uses pgvector. Embedding-writing paths (scheduler / rate-limit)
+  are a known production risk — test scheduling and cost controls directly, do
+  not mock them away.
+- Serverless connection health: stale Prisma connections have caused health
+  incidents — surface runtime evidence when touching DB health paths.


### PR DESCRIPTION
## What

Repo-local config so the [`omp`](https://github.com/can1357/oh-my-pi) coding agent works the sploot monorepo with full context instead of starting cold each session. Tooling/config only — **no product code, no dependency, no CI changes** (additive `.omp/` dir).

- `.omp/RULES.md` — sticky critical invariants (pnpm-only, `DATABASE_URL`, don't lower gates, `@sploot/common` source of truth, backlog closure), re-injected each turn
- `.omp/rules/*.mdc` — path-scoped guardrails that fire only in-scope: `prisma-db` (`apps/web/prisma/**`, db libs, api routes), `common-contract` (`packages/common/**`), `extension` (`apps/extension/**`)
- `.omp/commands/*` — slash commands mapped to real scripts: `/gate` (CI-parity ship gate), `/typecheck`, `/test-web` (`CI=1` one-shot), `/db` (Prisma/Neon ops), `/backlog`, `/ext-release`
- `.omp/README.md` — documents the harness

## Why

`omp` natively loads `AGENTS.md`/`CLAUDE.md`; this adds only what those don't cover — sticky invariants, path-scoped rules, and repo-aware commands. Model routing lives in the contributor's global `~/.omp` (not in the repo).

## Verification

- `omp -p` from the repo resolves context + the new sticky rule; `/backlog` slash command discovered and executes
- A fresh-context adversarial critic reviewed config + every file; one gate-parity drift was caught and fixed (`CI=1 pnpm --filter web test`, matching `ci.yml`)
- Local `pnpm turbo run type-check` green (lefthook pre-commit/pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive harness documentation with setup, discovery, and extension guidance.
  * Added command guides for database operations, testing, releases, and validation procedures.
  * Added scoped rule definitions establishing project invariants and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->