### PR TITLE
chore(omp): tighten ship-gate docs + gitignore harness traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ sentry.properties
 
 # Vercel
 .vercel
+
+# Harness Kit runtime traces (delegation receipts) — local-only, not committed
+.harness-kit/traces/*.jsonl
+.harness-kit/traces/provider-lanes/

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,0 +1,1 @@
+{"date":"2026-06-03","pr":null,"branch":"chore/omp-harness","correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["claude","codex","grok"]}

--- a/.omp/README.md
+++ b/.omp/README.md
@@ -32,7 +32,7 @@ near every turn so they survive long sessions.
 - `extension.mdc` → `apps/extension/**`
 
 **Slash commands (`.omp/commands/`).**
-- `/gate` — full CI-parity ship gate, per-step ✅/❌
+- `/gate` — CI-parity ship gate (4 steps; CI adds more), per-step ✅/❌
 - `/typecheck` — monorepo `tsc --noEmit` triage
 - `/test-web` — web Vitest via the CI `test` script (`CI=1`, run-once)
 - `/db` — Prisma/Neon ops with the `DATABASE_URL` guardrail

--- a/.omp/RULES.md
+++ b/.omp/RULES.md
@@ -16,5 +16,6 @@ contract: read `AGENTS.md` (loaded as context) and `CLAUDE.md`.
   Closure = move to `backlog.d/_done/` with `Status: done`, a `## What Was
   Built` note, and a conventional-commit `Backlog:`/`Closes-backlog:` trailer.
 - **Ship gate = CI parity:** `pnpm lint && pnpm type-check && pnpm --filter web
-  test && pnpm --filter extension build` (run the web step as `CI=1 pnpm
-  --filter web test` so Vitest stays one-shot under omp's PTY).
+  test && pnpm --filter extension build` (run the web step as `CI=1 pnpm --filter
+  web test` so Vitest stays one-shot under omp's PTY). CI adds a frozen install,
+  `db:migrate`, and extension lint/test on top, so green local ≈ (not =) green CI.

--- a/.omp/commands/gate.md
+++ b/.omp/commands/gate.md
@@ -3,17 +3,19 @@ Run the sploot ship gate — CI parity — and report pass/fail per step.
 Run these in order, from the repo root, and do not stop at the first failure —
 run all four so I see the full picture:
 
-1. `pnpm lint`
-2. `pnpm type-check`
+1. `pnpm lint`              (Turbo → web + extension + common)
+2. `pnpm type-check`        (Turbo → web + extension + common)
 3. `CI=1 pnpm --filter web test`  (the exact CI test script; `CI=1` forces
    Vitest run-once so it can't drop into watch mode under omp's interactive PTY)
 4. `pnpm --filter extension build`
 
-DB-backed web tests need `DATABASE_URL` pointing at a pgvector-capable Postgres.
-If it is unset, say so and label those results "DB path unverified" rather than
-treating skips as passes.
+This is the local ship gate AGENTS.md defines. DB-backed web tests need
+`DATABASE_URL` pointing at a pgvector-capable Postgres. If it is unset, say so
+and label those results "DB path unverified" rather than treating skips as passes.
 
 Then summarize: a ✅/❌ table of the four steps, and for any ❌ the exact failing
 command + the first real error. Do NOT propose lowering a gate to get green —
-diagnose env/DB/migration/WXT/auth setup instead. This mirrors the GitHub
-`merge-gate` job and the Lefthook pre-commit/pre-push hooks.
+diagnose env/DB/migration/WXT/auth setup instead. GitHub CI adds checks on top
+of these four — a frozen-lockfile install, `pnpm --filter web db:migrate`,
+extension lint/test, and the `merge-gate` aggregate job — so a green local gate
+is necessary but not a 100% guarantee CI is green.


### PR DESCRIPTION
Follow-up polish on the omp harness merged in #187, from a `/code-review` → `/refactor` → `/ci` → `/agent-readiness` pass.

## What changed (18 lines, docs/config only)
- **`gate.md` / `RULES.md` / `README.md`**: keep the repo's canonical **4-step** local ship gate (lint, type-check, web test, extension build), but drop the imprecise *"full CI-parity / mirrors merge-gate"* wording. Now states that CI adds a frozen-lockfile install, `db:migrate`, and extension lint/test on top, so a green local gate is necessary but not a 100% guarantee CI is green. Annotates that `pnpm lint`/`type-check` fan out via Turbo to all three packages. Consistent with `AGENTS.md` L31 and `CLAUDE.md`.
- **`.gitignore`**: ignore `.harness-kit/traces/` runtime delegation receipts (mirrors the source harness-kit repo; local-only, not committed).
- **`.groom/review-scores.ndjson`**: record the code-review verdict (ship).

## Review evidence
- Adversarial review: `codex` (gpt-5.5) + `grok` (grok-4.3) + 2 internal fresh-context lanes. **No blocking findings.** Every script/path/env-var/export claim verified against the live repo.
- A fresh-context agent-readiness pass caught an over-correction in an earlier draft (a 5-step gate) and this PR realigns to the merged #187's canonical 4-step gate.
- **CI parity verified green locally**: `pnpm lint` ✅, `pnpm type-check` ✅, `CI=1 pnpm --filter web test` ✅ **875/875** on `pgvector/pgvector:pg15`, `pnpm --filter extension test` ✅ 18/18, `pnpm --filter extension build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude build trace artifacts.
  * Added internal review score record.

* **Documentation**
  * Refined ship gate command documentation with clearer step descriptions and reporting requirements.
  * Clarified CI-parity semantics for testing and build processes, including database path requirements and additional CI-only checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->