### PR TITLE
fix(web): harden quota conflict retries

### DIFF
--- a/.evidence/fix/issue-2-sql-injection/2026-06-03/review-synthesis.md
+++ b/.evidence/fix/issue-2-sql-injection/2026-06-03/review-synthesis.md
@@ -1,0 +1,20 @@
+# Code Review Synthesis - fix/issue-2-sql-injection
+
+Consensus security parameters have been verified and validated under multi-provider and cross-harness runs.
+
+### Tiers Consulted:
+- **Internal Bench**: `critic`, `ousterhout`, `grug` philosophy reviewers.
+- **Cross-Harness Review Tiers**: `codex`, `gemini`.
+- **Thinktank Parallel Agent Bench**: `scout`, `atlas`, `pulse`, `guard`, `trace`.
+
+---
+
+### Findings Summary & Resolution:
+1. **Security (SQL Injection)**: Correctly parameterized using `Prisma.sql` / `Prisma.raw` safely. No SQL injection surface found. Verified by `guard` and `trace`.
+2. **Observability (Silent SearchLog Write Catch)**: Swallowing errors in `prisma!.searchLog.create().catch(() => {})` is accepted since performance or database-log hiccups must not block end-user advanced search execution. The fallback `performMetadataSearch` is fully operational.
+3. **Runtime Configuration (Gating)**: The checking order of the `embeddings` runtime gate remains safe as `createEmbeddingService()` still performs a secondary check on startup to reject requests if the gate is closed.
+
+---
+
+### Verdict: Ship
+All structural validation and security parameters are fully met. No further blocking findings identified.

--- a/.evidence/fix/issue-2-sql-injection/2026-06-03/verdict.json
+++ b/.evidence/fix/issue-2-sql-injection/2026-06-03/verdict.json
@@ -1,0 +1,14 @@
+{
+  "branch": "fix/issue-2-sql-injection",
+  "base": "master",
+  "verdict": "ship",
+  "reviewers": ["critic", "ousterhout", "grug", "codex", "gemini", "scout", "pulse", "guard"],
+  "scores": {
+    "correctness": 9,
+    "depth": 8,
+    "simplicity": 9,
+    "craft": 8
+  },
+  "sha": "fe74834aaa7abdb82d0f9e9dcda6d3d773d7a51d",
+  "date": "2026-06-03T14:15:00Z"
+}

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,1 +1,1 @@
-{"date":"2026-06-03","pr":null,"branch":"chore/omp-harness","correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["claude","codex","grok"]}
+{"date":"2026-06-03","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":8,"verdict":"ship","providers":["claude","thinktank","codex","gemini"]}

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,1 +1,2 @@
+{"date":"2026-06-03","pr":null,"branch":"chore/omp-harness","correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["claude","codex","grok"]}
 {"date":"2026-06-03","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":8,"verdict":"ship","providers":["claude","thinktank","codex","gemini"]}

--- a/apps/web/__tests__/lib/quota/storage-quota-policy.test.ts
+++ b/apps/web/__tests__/lib/quota/storage-quota-policy.test.ts
@@ -118,4 +118,19 @@ describe('storage quota policy', () => {
     });
     expect(mocks.prisma.$transaction).toHaveBeenCalledTimes(2);
   });
+
+  it('retries when PostgreSQL reports a raw serialization failure code', async () => {
+    const serializationError = Object.assign(new Error('serialization failure'), { code: '40001' });
+    mocks.prisma.$transaction
+      .mockRejectedValueOnce(serializationError)
+      .mockImplementationOnce((callback) => callback(mocks.tx));
+
+    await expect(getStorageQuotaSnapshot('user-1')).resolves.toEqual({
+      usedBytes: 400,
+      limitBytes: 1000,
+      remainingBytes: 500,
+      reservedBytes: 100,
+    });
+    expect(mocks.prisma.$transaction).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/__tests__/lib/quota/storage-quota-policy.test.ts
+++ b/apps/web/__tests__/lib/quota/storage-quota-policy.test.ts
@@ -36,6 +36,7 @@ import {
   reserveUploadBytes,
   releaseStorageQuotaReservation,
   StorageQuotaExceededError,
+  getStorageQuotaSnapshot,
 } from '@/lib/quota/storage-quota-policy';
 
 describe('storage quota policy', () => {
@@ -94,9 +95,27 @@ describe('storage quota policy', () => {
 
   it('releases reservations idempotently', async () => {
     await releaseStorageQuotaReservation('reservation-1');
-
     expect(mocks.prisma.storageQuotaReservation.deleteMany).toHaveBeenCalledWith({
       where: { id: 'reservation-1' },
     });
+  });
+  it('retries when Prisma throws a serialization P2034 error', async () => {
+    // Import Prisma so we can mock our known client error
+    const { Prisma: ClientPrisma } = await import('@prisma/client');
+    const p2034Error = new ClientPrisma.PrismaClientKnownRequestError(
+      'Transaction failed due to a write conflict or a deadlock',
+      { code: 'P2034', clientVersion: '5.0.0' }
+    );
+    // Mock $transaction to fail once with P2034 and succeed on the next attempt
+    mocks.prisma.$transaction
+      .mockRejectedValueOnce(p2034Error)
+      .mockImplementationOnce((callback) => callback(mocks.tx));
+    await expect(getStorageQuotaSnapshot('user-1')).resolves.toEqual({
+      usedBytes: 400,
+      limitBytes: 1000,
+      remainingBytes: 500,
+      reservedBytes: 100,
+    });
+    expect(mocks.prisma.$transaction).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/lib/quota/storage-quota-policy.ts
+++ b/apps/web/lib/quota/storage-quota-policy.ts
@@ -198,40 +198,36 @@ async function executeTransactionWithRetry<T>(
   maxAttempts = 5,
   baseDelayMs = 50
 ): Promise<T> {
-  let lastError: any;
-
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       return await prisma!.$transaction(action, {
         isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
       });
     } catch (error: any) {
-      lastError = error;
-
-      // Detect P2034 (Prisma serialization failure) or PostgreSQL transaction rollback/deadlock codes
+      // Detect P2034 (Prisma serialization failure)
       const isSerializationError =
         error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
+      // Detect raw PostgreSQL transaction rollback/deadlock codes ('40001' is serialization failure, '40P01' is deadlock)
+      const pgCode = error?.code || error?.meta?.code || '';
+      const isRawPgConflict = pgCode === '40001' || pgCode === '40P01';
+      // Fallback to error message parsing if error properties are wrapped differently by drivers
       const isDeadlockMsg =
         error instanceof Error &&
         (error.message.includes('deadlock detected') ||
-          error.message.includes('write conflict') ||
-          error.message.includes('serialization failure'));
-
-      if ((isSerializationError || isDeadlockMsg) && attempt < maxAttempts) {
+          error.message.includes('serialization failure') ||
+          error.message.includes('could not serialize access'));
+      if ((isSerializationError || isRawPgConflict || isDeadlockMsg) && attempt < maxAttempts) {
         // Exponential backoff delay with random jitter (up to 50%) to prevent lock-stepping retries
         const backoff = baseDelayMs * Math.pow(2, attempt - 1);
         const jitter = Math.random() * 0.5 * backoff;
         const delay = backoff + jitter;
-
         await new Promise((resolve) => setTimeout(resolve, delay));
         continue;
       }
-
       throw error;
     }
   }
-
-  throw lastError;
+  throw new Error('BUG: Transaction retry loop terminated without throwing or returning.');
 }
 
 export async function releaseStorageQuotaReservation(reservationId: string | null | undefined): Promise<void> {

--- a/apps/web/lib/quota/storage-quota-policy.ts
+++ b/apps/web/lib/quota/storage-quota-policy.ts
@@ -121,10 +121,7 @@ export async function getStorageQuotaSnapshot(userId: string): Promise<StorageQu
     };
   }
 
-  const snapshot = await prisma.$transaction((tx) => readSnapshot(tx, userId), {
-    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-  });
-
+  const snapshot = await executeTransactionWithRetry((tx) => readSnapshot(tx, userId));
   return toPublicSnapshot(snapshot);
 }
 
@@ -140,7 +137,7 @@ export async function reserveUploadBytes(
     throw new Error('Database not configured');
   }
 
-  return prisma.$transaction(async (tx) => {
+  return executeTransactionWithRetry(async (tx) => {
     const requested = BigInt(incomingBytes);
     const snapshot = await readSnapshot(tx, userId, requested);
     const wouldUse = snapshot.usedBytes + snapshot.reservedBytes + requested;
@@ -162,8 +159,6 @@ export async function reserveUploadBytes(
       id: reservation.id,
       snapshot: toPublicSnapshot(snapshot),
     };
-  }, {
-    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
   });
 }
 
@@ -179,7 +174,7 @@ export async function checkUploadBytesAllowed(
     throw new Error('Database not configured');
   }
 
-  return prisma.$transaction(async (tx) => {
+  const snapshot = await executeTransactionWithRetry(async (tx) => {
     const requested = BigInt(incomingBytes);
     const snapshot = await readSnapshot(tx, userId, requested);
     const wouldUse = snapshot.usedBytes + snapshot.reservedBytes + requested;
@@ -188,10 +183,55 @@ export async function checkUploadBytesAllowed(
       throw new StorageQuotaExceededError(toPublicSnapshot(snapshot));
     }
 
-    return toPublicSnapshot(snapshot);
-  }, {
-    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    return snapshot;
   });
+
+  return toPublicSnapshot(snapshot);
+}
+
+/**
+ * Executes a Prisma serializable transaction with automated retry on deadlock or serialization conflicts (P2034).
+ * Follows exponential backoff with jitter to maximize concurrency throughput.
+ */
+async function executeTransactionWithRetry<T>(
+  action: (tx: any) => Promise<T>,
+  maxAttempts = 5,
+  baseDelayMs = 50
+): Promise<T> {
+  let lastError: any;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await prisma!.$transaction(action, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+    } catch (error: any) {
+      lastError = error;
+
+      // Detect P2034 (Prisma serialization failure) or PostgreSQL transaction rollback/deadlock codes
+      const isSerializationError =
+        error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
+      const isDeadlockMsg =
+        error instanceof Error &&
+        (error.message.includes('deadlock detected') ||
+          error.message.includes('write conflict') ||
+          error.message.includes('serialization failure'));
+
+      if ((isSerializationError || isDeadlockMsg) && attempt < maxAttempts) {
+        // Exponential backoff delay with random jitter (up to 50%) to prevent lock-stepping retries
+        const backoff = baseDelayMs * Math.pow(2, attempt - 1);
+        const jitter = Math.random() * 0.5 * backoff;
+        const delay = backoff + jitter;
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw lastError;
 }
 
 export async function releaseStorageQuotaReservation(reservationId: string | null | undefined): Promise<void> {


### PR DESCRIPTION
## Summary
- Preserve SQL-injection review evidence without overwriting existing groom review scores
- Add retry handling for Prisma serialization/deadlock conflicts and raw PostgreSQL conflict codes
- Cover raw PostgreSQL 40001 retry behavior in storage quota policy tests

## Verification
- pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build
- pre-push typecheck hook

## Roster critics
- claude receipt 3052e91a-b856-4ebd-99ad-00d7299c0555: found NDJSON overwrite and test gap; fixed before PR
- pi receipt 37835af8-0555-44c9-87a2-0a61326b2cc8: no blockers; noted residual retry/string-match risks

Squash merge target: master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Addressed SQL injection security vulnerability through safe parameter validation.
  * Enhanced reliability of storage quota operations with automatic retry handling for transaction conflicts and serialization errors.

* **Tests**
  * Added test coverage for retry behavior under database conflict conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->