### PR TITLE
fix(web): sync rotated database env names

### DIFF
--- a/apps/web/scripts/db-sync-env.sh
+++ b/apps/web/scripts/db-sync-env.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Sync DB URLs from environment variables into Vercel envs.
 # Usage:
-#   POSTGRES_URL=... POSTGRES_URL_NON_POOLING=... scripts/db-sync-env.sh prod
-#   POSTGRES_URL=... POSTGRES_URL_NON_POOLING=... scripts/db-sync-env.sh preview
+#   DATABASE_URL=... DATABASE_URL_DIRECT=... scripts/db-sync-env.sh prod
+#   DATABASE_URL=... DATABASE_URL_DIRECT=... scripts/db-sync-env.sh preview
 #
 # Requires: vercel CLI logged in, project linked, env vars set.
 
@@ -15,19 +15,16 @@ case "$target" in
   *) echo "Usage: db-sync-env.sh prod|preview" >&2; exit 1 ;;
 esac
 
-url="${POSTGRES_URL:-}"
-url_np="${POSTGRES_URL_NON_POOLING:-}"
+url="${DATABASE_URL:-}"
+url_direct="${DATABASE_URL_DIRECT:-}"
 
-if [ -z "$url" ] || [ -z "$url_np" ]; then
-  echo "POSTGRES_URL and POSTGRES_URL_NON_POOLING must be set" >&2
+if [ -z "$url" ] || [ -z "$url_direct" ]; then
+  echo "DATABASE_URL and DATABASE_URL_DIRECT must be set" >&2
   exit 1
 fi
 
 echo "👉 syncing $vercel_env env..."
-printf "%s" "$url" | vercel env add POSTGRES_URL "$vercel_env" --force >/dev/null
-printf "%s" "$url_np" | vercel env add POSTGRES_URL_NON_POOLING "$vercel_env" --force >/dev/null
-# keep aliases used in code
-printf "%s" "$url" | vercel env add POSTGRES_DATABASE_URL "$vercel_env" --force >/dev/null
-printf "%s" "$url_np" | vercel env add POSTGRES_DATABASE_URL_UNPOOLED "$vercel_env" --force >/dev/null
+printf "%s" "$url" | vercel env add DATABASE_URL "$vercel_env" --force >/dev/null
+printf "%s" "$url_direct" | vercel env add DATABASE_URL_DIRECT "$vercel_env" --force >/dev/null
 
 echo "✅ synced $vercel_env DB URLs"


### PR DESCRIPTION
## Summary
- update the DB env sync helper to write DATABASE_URL and DATABASE_URL_DIRECT
- stop writing deprecated POSTGRES_URL aliases during future rotations

## Verification
- bash -n apps/web/scripts/db-sync-env.sh
- bash scripts/validate-env-vars.sh (from apps/web)
- pnpm secrets:check
- pnpm secrets:gitleaks
- pre-push: gitleaks, secrets, typecheck

## Incident follow-up
This keeps the rotation path aligned with the Prisma/DATABASE_URL invariant after the Neon exposure response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal database environment configuration management to improve deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->