### PR TITLE
fix(web): yeet stale signed-out landing

### DIFF
--- a/apps/web/__tests__/components/library/mobile-feed-layout.test.tsx
+++ b/apps/web/__tests__/components/library/mobile-feed-layout.test.tsx
@@ -5,6 +5,7 @@ import { ImageTile } from '@/components/library/image-tile';
 import {
   IMAGE_GRID_BREAKPOINT_COLS,
   IMAGE_GRID_SCROLL_CLASS,
+  getMobileFeedDockPaddingClass,
 } from '@/components/library/image-grid-layout';
 import type { Asset } from '@/lib/types';
 
@@ -48,9 +49,14 @@ describe('mobile meme feed layout contract', () => {
   });
 
   it('reserves mobile scroll space for the bottom command rail', () => {
-    expect(IMAGE_GRID_SCROLL_CLASS).toContain('pb-24');
+    expect(IMAGE_GRID_SCROLL_CLASS).toContain('pb-[calc(6rem+env(safe-area-inset-bottom))]');
     expect(IMAGE_GRID_SCROLL_CLASS).toContain('sm:p-2');
     expect(IMAGE_GRID_SCROLL_CLASS).toContain('md:p-6');
+  });
+
+  it('lifts the mobile feed above the retry row only when retry is visible', () => {
+    expect(getMobileFeedDockPaddingClass(0)).toBeUndefined();
+    expect(getMobileFeedDockPaddingClass(2)).toBe('pb-[calc(9rem+env(safe-area-inset-bottom))]');
   });
 
   it('keeps mobile tile actions thumb-sized and hides technical metadata', () => {

--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -21,6 +21,46 @@ vi.mock('@clerk/nextjs/server', () => {
 import middleware, { config } from '@/middleware';
 
 describe('middleware auth boundary', () => {
+  it.each([
+    ['/', 'https://www.sploot.app/'],
+    ['/app?from=apex', 'https://www.sploot.app/app?from=apex'],
+    ['/sign-in', 'https://www.sploot.app/sign-in'],
+  ])(
+    'canonicalizes apex browser route %s before auth checks',
+    async (requestPath, expectedLocation) => {
+      const protect = vi.fn();
+
+      const response = await middleware(
+        { protect } as any,
+        {
+          method: 'GET',
+          nextUrl: { pathname: new URL(requestPath, 'https://sploot.app').pathname },
+          url: `https://sploot.app${requestPath}`,
+        } as any
+      );
+
+      expect(response?.status).toBe(308);
+      expect(response?.headers.get('location')).toBe(expectedLocation);
+      expect(protect).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not canonicalize apex json api routes in middleware', async () => {
+    const protect = vi.fn();
+
+    const response = await middleware(
+      { protect } as any,
+      {
+        method: 'GET',
+        nextUrl: { pathname: '/api/assets' },
+        url: 'https://sploot.app/api/assets?limit=1',
+      } as any
+    );
+
+    expect(response).toBeUndefined();
+    expect(protect).not.toHaveBeenCalled();
+  });
+
   it.each(['/app', '/app/search', '/app/upload'])(
     'protects %s and sends unauthenticated users to /sign-in',
     async (pathname) => {

--- a/apps/web/__tests__/next-config.test.ts
+++ b/apps/web/__tests__/next-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@ducanh2912/next-pwa', () => ({
+  default: (options: Record<string, unknown>) => (config: Record<string, unknown>) => ({
+    ...config,
+    __pwaOptions: options,
+  }),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  withSentryConfig: (config: Record<string, unknown>, options: Record<string, unknown>) => ({
+    ...config,
+    __sentryOptions: options,
+  }),
+}));
+
+describe('next config auth-sensitive pwa caching', () => {
+  it('does not cache the auth-dependent start url document', async () => {
+    const config = (await import('../next.config')).default as {
+      __pwaOptions: {
+        cacheStartUrl?: boolean;
+        dynamicStartUrl?: boolean;
+        workboxOptions?: {
+          runtimeCaching?: Array<{ options?: { cacheName?: string } }>;
+        };
+      };
+    };
+
+    expect(config.__pwaOptions.cacheStartUrl).toBe(false);
+    expect(config.__pwaOptions.dynamicStartUrl).toBe(false);
+    expect(config.__pwaOptions.workboxOptions?.runtimeCaching?.map((entry) => entry.options?.cacheName))
+      .toEqual(['user-images', 'api-search']);
+  });
+});

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { useAssets, useSearchAssets } from '@/hooks/use-assets';
 import { useAuthActions } from '@/lib/auth/client';
 import { ImageGrid } from '@/components/library/image-grid';
+import { getMobileFeedDockPaddingClass } from '@/components/library/image-grid-layout';
 import { ImageGridErrorBoundary } from '@/components/library/image-grid-error-boundary';
 import { MobileCommandDock } from '@/components/chrome/mobile-command-dock';
 import { AssetIntegrityBanner } from '@/components/library/asset-integrity-banner';
@@ -410,7 +411,10 @@ function AppPageClient() {
     enabled: true,
   });
 
-  const gridContainerClassName = 'h-full overflow-y-auto overflow-x-hidden';
+  const gridContainerClassName = cn(
+    'h-full overflow-y-auto overflow-x-hidden',
+    getMobileFeedDockPaddingClass(failedEmbeddings.length)
+  );
   const handleBangersFilterChange = useCallback((filter: FilterType) => {
     if (filter === 'bangers') {
       if (!bangersOnly) toggleBangers();

--- a/apps/web/components/library/image-grid-layout.ts
+++ b/apps/web/components/library/image-grid-layout.ts
@@ -6,4 +6,11 @@ export const IMAGE_GRID_BREAKPOINT_COLS = Object.freeze({
   640: 1,
 });
 
-export const IMAGE_GRID_SCROLL_CLASS = 'h-full overflow-auto px-0 pt-2 pb-24 sm:p-2 md:p-6';
+export const IMAGE_GRID_SCROLL_CLASS =
+  'h-full overflow-auto px-0 pt-2 pb-[calc(6rem+env(safe-area-inset-bottom))] sm:p-2 md:p-6';
+
+export function getMobileFeedDockPaddingClass(failedEmbeddingsCount: number) {
+  return failedEmbeddingsCount > 0
+    ? 'pb-[calc(9rem+env(safe-area-inset-bottom))]'
+    : undefined;
+}

--- a/apps/web/docs/API.md
+++ b/apps/web/docs/API.md
@@ -9,7 +9,7 @@ follow standard HTTP conventions; operational routes define their own contracts.
 ## Base URL
 
 ```
-Production: https://<your-vercel-project>.vercel.app/api
+Production: https://www.sploot.app/api
 Development: http://localhost:3001/api
 ```
 
@@ -22,6 +22,13 @@ their own auth contracts.
 
 ### Auth Boundary
 
+- browser page traffic on `https://sploot.app` redirects to
+  `https://www.sploot.app` before auth checks, so signed-in users do not get
+  dumped into the wrong-host landing page. api routes stay on their requested
+  host and keep json auth responses.
+- `apps/web/next.config.ts` keeps PWA start-url document caching off because
+  `/` is auth-dependent; the service worker may cache images and search data,
+  but not the signed-out landing document.
 - `apps/web/middleware.ts` protects only `/app(.*)` and redirects signed-out requests to `/sign-in`.
 - Clerk middleware still matches API routes so Clerk server auth can resolve,
   but API routes enforce auth in route handlers rather than middleware.

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,11 +1,45 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { NextResponse, type NextRequest } from 'next/server'
 
 // Define protected routes that require authentication
 const isProtectedRoute = createRouteMatcher([
   '/app(.*)'
 ])
 
+const CANONICAL_WEB_ORIGIN = 'https://www.sploot.app'
+
+function isBrowserNavigationMethod(method: string | undefined) {
+  return method === undefined || method === 'GET' || method === 'HEAD'
+}
+
+function isJsonApiRoute(pathname: string) {
+  return pathname.startsWith('/api') || pathname.startsWith('/trpc')
+}
+
+export function getCanonicalWebRedirectUrl(req: Pick<NextRequest, 'method'> & { url?: string }) {
+  if (!req.url) {
+    return null
+  }
+
+  const url = new URL(req.url)
+
+  if (url.hostname !== 'sploot.app') {
+    return null
+  }
+
+  if (!isBrowserNavigationMethod(req.method) || isJsonApiRoute(url.pathname)) {
+    return null
+  }
+
+  return new URL(`${url.pathname}${url.search}`, CANONICAL_WEB_ORIGIN)
+}
+
 export default clerkMiddleware(async (auth, req) => {
+  const canonicalUrl = getCanonicalWebRedirectUrl(req)
+  if (canonicalUrl) {
+    return NextResponse.redirect(canonicalUrl, 308)
+  }
+
   if (isProtectedRoute(req)) {
     await auth.protect({ unauthenticatedUrl: new URL('/sign-in', req.url).toString() })
   }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -52,6 +52,11 @@ const pwaConfig = withPWA({
   register: true,
   reloadOnOnline: true,
   disable: process.env.NODE_ENV === "development",
+  // The root/start document is auth-dependent: signed-out users see landing,
+  // signed-in users redirect to /app. Never let the service worker replay the
+  // signed-out document after the Clerk session changes.
+  cacheStartUrl: false,
+  dynamicStartUrl: false,
   workboxOptions: {
     disableDevLogs: true,
     skipWaiting: true,


### PR DESCRIPTION
## what changed
- canonicalize apex browser page traffic to `https://www.sploot.app` before auth checks
- keep api routes out of middleware canonicalization so json 401 contracts stay intact
- disable pwa start-url document caching so the service worker cannot replay the signed-out landing page after clerk state changes
- document the auth boundary and add middleware/pwa config regressions

## proof
- `pnpm --filter web exec vitest run __tests__/middleware.test.ts __tests__/next-config.test.ts __tests__/api/auth-unauthorized-contracts.test.ts __tests__/lib/auth/verify-bearer.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web type-check`
- `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`
- `curl -sS -I https://sploot.app/` currently returns `307` to `https://www.sploot.app/`
- `pnpm --filter web build` compiled the pwa worker and showed only `user-images` plus `api-search` runtime caches, then failed prerender at `/` because local `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is unset

## note
- direct `HEAD:master` push was blocked by branch protection because `merge-gate` is required, so this PR is the protected-branch path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domain canonicalization: sploot.app now redirects to www.sploot.app before authentication checks
  * Improved mobile feed layout with dynamic safe-area-aware spacing

* **Bug Fixes**
  * Fixed service worker to prevent caching of auth-dependent content

* **Documentation**
  * Updated API documentation with production endpoint and auth boundary details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->