### PR TITLE
fix(web): dedupe upload success toasts

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,2 +1,3 @@
 {"date":"2026-06-03","pr":null,"branch":"chore/omp-harness","correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["claude","codex","grok"]}
 {"date":"2026-06-03","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":8,"verdict":"ship","providers":["claude","thinktank","codex","gemini"]}
+{"date":"2026-06-08","pr":null,"branch":"fix/upload-success-toast-dedup","correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["pi","agy"]}

--- a/apps/web/__tests__/components/upload/use-upload-completion.test.tsx
+++ b/apps/web/__tests__/components/upload/use-upload-completion.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  useUploadCompletion,
+  type UploadCompletionFile,
+  type UploadCompletionStats,
+} from '@/components/upload/use-upload-completion';
+
+const uploadedFile = (
+  overrides: Partial<UploadCompletionFile> = {},
+): UploadCompletionFile => ({
+  id: 'file-1',
+  status: 'success',
+  assetId: 'asset-1',
+  ...overrides,
+});
+
+describe('useUploadCompletion', () => {
+  it('reports a finished upload batch once even if the parent rerenders with a new callback', async () => {
+    const firstComplete = vi.fn();
+    const files = [uploadedFile()];
+    const { rerender } = renderHook(
+      ({ onComplete }) => useUploadCompletion(files, onComplete),
+      {
+        initialProps: {
+          onComplete: firstComplete,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(firstComplete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(firstComplete).toHaveBeenCalledWith({
+      uploaded: 1,
+      duplicates: 0,
+      failed: 0,
+    });
+
+    const secondComplete = vi.fn();
+    rerender({ onComplete: secondComplete });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(firstComplete).toHaveBeenCalledTimes(1);
+    expect(secondComplete).not.toHaveBeenCalled();
+  });
+
+  it('resets after the completed batch is cleared', async () => {
+    const firstComplete = vi.fn();
+    const { rerender } = renderHook(
+      ({
+        files,
+        onComplete,
+      }: {
+        files: UploadCompletionFile[];
+        onComplete: (stats: UploadCompletionStats) => void;
+      }) => useUploadCompletion(files, onComplete),
+      {
+        initialProps: {
+          files: [uploadedFile()],
+          onComplete: firstComplete,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(firstComplete).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({
+      files: [],
+      onComplete: firstComplete,
+    });
+
+    const secondComplete = vi.fn();
+    rerender({
+      files: [uploadedFile({ id: 'file-2', assetId: 'asset-2' })],
+      onComplete: secondComplete,
+    });
+
+    await waitFor(() => {
+      expect(secondComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/components/upload/upload-zone.tsx
+++ b/apps/web/components/upload/upload-zone.tsx
@@ -18,6 +18,7 @@ import { EmbeddingStatusIndicator } from '@/components/upload/embedding-status-i
 import { UploadBatchProgressCard } from '@/components/upload/upload-batch-progress-card';
 import { UploadDropZone } from '@/components/upload/upload-drop-zone';
 import { UploadFileList } from '@/components/upload/upload-file-list';
+import { useUploadCompletion } from '@/components/upload/use-upload-completion';
 import {
   getUploadNetworkClient,
   UploadError,
@@ -113,6 +114,7 @@ export function UploadZone({
   const uploadQueueManager = getUploadQueueManager();
   const uploadNetworkClient = useMemo(() => getUploadNetworkClient(), []);
   const { validateFile, allowedFileTypes } = useFileValidation();
+  const hasExternalUploadCompletion = Boolean(onUploadComplete);
 
   const getMultipartSizeError = useCallback(
     (file: File) =>
@@ -180,43 +182,7 @@ export function UploadZone({
     });
   }, [uploadQueueManager]);
 
-  // Track when all uploads complete
-  useEffect(() => {
-    if (!onUploadComplete) return;
-
-    const filesArray = Array.from(fileMetadata.values());
-    const hasActiveUploads = filesArray.some(
-      (file) =>
-        file.status === 'uploading' ||
-        file.status === 'pending' ||
-        file.status === 'queued',
-    );
-
-    const successfulUploads = filesArray.filter(
-      (file) => file.status === 'success',
-    );
-    const duplicates = filesArray.filter((file) => file.status === 'duplicate');
-    const failed = filesArray.filter((file) => file.status === 'error');
-
-    // Trigger callback when all uploads are done and we have at least one file
-    if (
-      filesArray.length > 0 &&
-      !hasActiveUploads &&
-      (successfulUploads.length > 0 || duplicates.length > 0)
-    ) {
-      // Only trigger once when uploads complete
-      const stats = {
-        uploaded: successfulUploads.length,
-        duplicates: duplicates.length,
-        failed: failed.length,
-      };
-
-      // Small delay to ensure UI updates first
-      setTimeout(() => {
-        onUploadComplete(stats);
-      }, 100);
-    }
-  }, [fileMetadata, onUploadComplete]);
+  useUploadCompletion(filesArray, onUploadComplete);
 
   // Keep ref in sync with state to avoid stale closures in async retry logic
   useEffect(() => {
@@ -255,8 +221,6 @@ export function UploadZone({
         (!f.needsEmbedding || f.embeddingStatus === 'ready'),
     ).length;
 
-    // Check if all processing is complete
-    const allComplete = successful + failed === filesArray.length;
     const allReady = ready + failed === filesArray.length;
 
     setUploadStats({
@@ -289,7 +253,7 @@ export function UploadZone({
           const successCount = currentFiles.filter(
             (f) => f.status === 'success' || f.status === 'duplicate',
           ).length;
-          if (successCount > 0) {
+          if (successCount > 0 && !hasExternalUploadCompletion) {
             showToast(
               `✓ ${successCount} ${successCount === 1 ? 'file' : 'files'} uploaded successfully`,
               'success',
@@ -304,7 +268,7 @@ export function UploadZone({
 
       return () => clearTimeout(clearTimer);
     }
-  }, [fileMetadata]);
+  }, [fileMetadata, hasExternalUploadCompletion]);
 
   // Auto-remove failed uploads after 3 seconds with fade-out animation and toast
   useEffect(() => {
@@ -627,7 +591,6 @@ export function UploadZone({
 
         try {
           await uploadFileToServer(fileId);
-          uploadStatsRef.current.successful++;
           logger.debug(`[Upload] Retry successful for ${metadata.name}`);
         } catch (error) {
           // Re-check metadata exists before retry logic (may have been removed)
@@ -732,7 +695,6 @@ export function UploadZone({
           const fileId = uploadQueue.shift()!;
           const uploadPromise = uploadFileToServer(fileId)
             .then(() => {
-              uploadStatsRef.current.successful++;
               activeUploads.delete(uploadPromise);
             })
             .catch((error) => {
@@ -959,6 +921,13 @@ export function UploadZone({
             }
           });
           return newMap;
+        });
+
+        fileMetadataRef.current = new Map(fileMetadataRef.current);
+        newFiles.forEach((metadata) => {
+          if (!fileMetadataRef.current.has(metadata.id)) {
+            fileMetadataRef.current.set(metadata.id, metadata);
+          }
         });
 
         // Stats will be automatically updated by the effect that watches fileMetadata changes

--- a/apps/web/components/upload/use-upload-completion.ts
+++ b/apps/web/components/upload/use-upload-completion.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+export type UploadCompletionStatus =
+  | 'pending'
+  | 'uploading'
+  | 'success'
+  | 'error'
+  | 'queued'
+  | 'duplicate';
+
+export interface UploadCompletionFile {
+  id: string;
+  status: UploadCompletionStatus;
+  assetId?: string;
+}
+
+export interface UploadCompletionStats {
+  uploaded: number;
+  duplicates: number;
+  failed: number;
+}
+
+export type UploadCompletionCallback = (
+  stats: UploadCompletionStats,
+) => void;
+
+export function useUploadCompletion(
+  files: UploadCompletionFile[],
+  onUploadComplete?: UploadCompletionCallback,
+) {
+  const latestOnUploadCompleteRef = useRef(onUploadComplete);
+  const completedBatchNotificationRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    latestOnUploadCompleteRef.current = onUploadComplete;
+  }, [onUploadComplete]);
+
+  useEffect(() => {
+    if (files.length === 0) {
+      completedBatchNotificationRef.current = null;
+      return;
+    }
+
+    const onComplete = latestOnUploadCompleteRef.current;
+    if (!onComplete) return;
+
+    const hasActiveUploads = files.some(
+      (file) =>
+        file.status === 'uploading' ||
+        file.status === 'pending' ||
+        file.status === 'queued',
+    );
+
+    const successfulUploads = files.filter(
+      (file) => file.status === 'success',
+    );
+    const duplicates = files.filter((file) => file.status === 'duplicate');
+    const failed = files.filter((file) => file.status === 'error');
+
+    if (
+      hasActiveUploads ||
+      (successfulUploads.length === 0 && duplicates.length === 0)
+    ) {
+      return;
+    }
+
+    const completionKey = files
+      .map((file) => `${file.id}:${file.status}:${file.assetId ?? ''}`)
+      .join('|');
+
+    if (completedBatchNotificationRef.current === completionKey) return;
+    completedBatchNotificationRef.current = completionKey;
+
+    const stats = {
+      uploaded: successfulUploads.length,
+      duplicates: duplicates.length,
+      failed: failed.length,
+    };
+
+    const timer = setTimeout(() => {
+      latestOnUploadCompleteRef.current?.(stats);
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [files]);
+}


### PR DESCRIPTION
## Summary
- Extract upload completion notification dedupe into `useUploadCompletion`
- Keep dashboard upload completion callbacks to one call per completed batch, even when parent callbacks rerender
- Suppress duplicate internal success toast when the dashboard owns upload completion
- Replace mock-heavy component regression with focused hook coverage

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm --filter web test`
- `pnpm --filter extension build`
- pre-commit: gitleaks, secrets, typecheck, commitlint
- pre-push: gitleaks, secrets, typecheck

Closed: none
Trace-waiver: no backlog ticket or external transcript artifact for this hotfix; PR body carries review and QA evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upload completion notifications are now properly deduplicated, eliminating duplicate success toasts when batch uploads finish processing

* **Tests**
  * Added comprehensive tests validating upload completion notification behavior and callback accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->