### PR TITLE
fix(web): run migrations on deploy + survive schema drift in identity sync

### DIFF
--- a/apps/web/hooks/use-assets.ts
+++ b/apps/web/hooks/use-assets.ts
@@ -129,11 +129,14 @@ export function useAssets(options: UseAssetsOptions = {}) {
             403: 'Forbidden - Access denied',
             404: 'API endpoint not found',
             500: 'Server error - Please try again',
-            503: 'Service unavailable - Database may be offline',
+            503: 'Service temporarily unavailable - Please try again',
           };
 
-          const specificMessage = statusMessages[response.status]
-            || `${errorMessage} (HTTP ${response.status})`;
+          // Prefer the server's own error message; fall back to the generic
+          // per-status text only when the response carried no usable detail.
+          const specificMessage = (errorDetails && errorMessage !== 'Failed to fetch assets')
+            ? errorMessage
+            : (statusMessages[response.status] || `${errorMessage} (HTTP ${response.status})`);
 
           throw new Error(specificMessage);
         }

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -257,6 +257,25 @@ export async function syncUser(clerkUserId: string, email: string) {
 }
 
 async function syncClerkIdentity(clerkUserId: string, userId: string, email: string) {
+  try {
+    await syncClerkIdentityStrict(clerkUserId, userId, email);
+  } catch (e) {
+    // Identity mirroring is a secondary index of the Clerk linkage; the user
+    // row itself synced fine. Schema drift here (e.g. migration not yet
+    // applied) must not fail auth for every signed-in user.
+    // Incident 2026-06-09: missing user_identities table 503'd the whole app.
+    if (e instanceof Prisma.PrismaClientKnownRequestError && (e.code === 'P2021' || e.code === 'P2022')) {
+      logger.error('syncClerkIdentity skipped: schema out of date', {
+        code: e.code,
+        clerkUserId,
+      });
+      return;
+    }
+    throw e;
+  }
+}
+
+async function syncClerkIdentityStrict(clerkUserId: string, userId: string, email: string) {
   await prisma.userIdentity.upsert({
     where: {
       unique_provider_subject: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "PORT=${PORT:-3001} next dev",
-    "build": "next build",
+    "build": "node scripts/migrate-deploy.mjs && next build",
     "start": "next start",
     "lint": "next lint && pnpm auth:guard",
     "type-check": "tsc --noEmit",

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Run `prisma migrate deploy` before the production build so schema and code
+// cannot ship apart (incident 2026-06-09: user_identities migration never ran).
+//
+// Prisma migrations need a direct (non-pooler) connection. Prefer
+// DATABASE_URL_DIRECT when set; otherwise derive it from DATABASE_URL by
+// stripping the Neon `-pooler` host suffix and the `pgbouncer` query param.
+import { execSync } from 'node:child_process';
+
+const pooled = process.env.DATABASE_URL;
+
+if (!pooled) {
+  console.log('[migrate-deploy] DATABASE_URL not set; skipping migrations (local/CI build without database).');
+  process.exit(0);
+}
+
+function deriveDirectUrl(raw) {
+  const url = new URL(raw);
+  url.hostname = url.hostname.replace('-pooler.', '.');
+  url.searchParams.delete('pgbouncer');
+  return url.toString();
+}
+
+const directUrl = process.env.DATABASE_URL_DIRECT || deriveDirectUrl(pooled);
+
+console.log('[migrate-deploy] running prisma migrate deploy...');
+execSync('prisma migrate deploy', {
+  stdio: 'inherit',
+  env: { ...process.env, DATABASE_URL: directUrl },
+});
+console.log('[migrate-deploy] migrations applied.');


### PR DESCRIPTION
Incident 2026-06-09: the user_identities migration shipped in code but never
ran in production (build was bare 'next build'), so every signed-in user sync
threw P2021, tripped the user-sync circuit breaker, and /api/assets returned
503 'Account sync in progress' — surfaced to users as 'database may be offline'.

Three fixes:
- scripts/migrate-deploy.mjs runs prisma migrate deploy before next build,
  deriving a direct (non-pooler) URL from DATABASE_URL
- syncClerkIdentity tolerates P2021/P2022 so schema drift degrades to a logged
  warning instead of bricking auth
- use-assets surfaces the server's error message instead of mapping every 503
  to 'database may be offline'

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for asset fetch failures with clearer error messages.
  * Enhanced database identity synchronization reliability with better schema mismatch handling.

* **Chores**
  * Updated build process to include database migration deployment before production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->