### PR TITLE
feat(web): motion system and core-surface design pass

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -183,6 +183,31 @@ Implemented product wrappers live in `apps/web/components/sploot`:
 New product surfaces should compose these wrappers before creating one-off
 sticker, pile, banger, or atlas treatments.
 
+### Motion
+
+Motion tokens live in `apps/web/app/globals.css` and are the only sanctioned
+timing values:
+
+| Token | Value | Use |
+|---|---|---|
+| `--sploot-motion-fast` | 75ms | Hover/press feedback |
+| `--sploot-motion-base` | 150ms | Tile lifts, pops, small reveals |
+| `--sploot-motion-panel` | 240ms | Panels, sheets, stamps |
+| `--sploot-motion-cluster` | 360ms | Grid reshuffle/cluster moves |
+| `--sploot-ease-out` | cubic-bezier(0.2, 0.8, 0.2, 1) | Default deceleration |
+| `--sploot-ease-snap` | cubic-bezier(0.34, 1.56, 0.64, 1) | Sticker/stamp overshoot |
+
+Named utilities:
+
+- `.animate-sploot-stamp`: banger/favorite stamp punch (scale-down rotate-in).
+- `.animate-sploot-pop`: sticker tabs and labels appearing.
+- `.animate-sploot-slide-up`: panels, sheets, and docks entering.
+- Grid tiles cascade with `fadeInScale` staggered at 30ms per tile, capped at
+  15 tiles so paginated content never waits.
+
+A global `prefers-reduced-motion: reduce` override collapses all animations
+and transitions; do not add per-component opt-outs.
+
 Interaction rules:
 
 - Motion must explain sorting, clustering, uploading, or selection.

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -643,12 +643,12 @@ function AppPageClient() {
   return (
     <div className="flex h-[calc(100vh-48px)] md:h-[calc(100vh-56px)] flex-col">
       {/* Container with ultra-wide support - max-width at 1920px+ */}
-      <div className="border-b-[3px] border-sploot-cyan px-3 pb-3 pt-3 md:border-b-[6px] md:px-10 md:pb-8 md:pt-8 2xl:px-12">
+      <div className="border-b-[3px] border-sploot-cyan px-3 pb-3 pt-3 md:px-10 md:pb-4 md:pt-4 2xl:px-12">
         <div className="mx-auto w-full max-w-7xl 2xl:max-w-[1920px]">
-          <header className="flex flex-col gap-2 md:gap-6">
+          <header className="flex flex-col gap-2 md:gap-3">
             {/* Terminal-style status bar */}
             {stats.total > 0 && (
-              <div className="hidden md:flex font-mono text-sm brutalist-border border-border bg-card p-3 items-center gap-4 flex-wrap">
+              <div className="hidden md:flex font-mono text-xs brutalist-border border-border bg-card px-3 py-1.5 items-center gap-4 flex-wrap">
                 <div className="flex items-center gap-2">
                   <span className="text-muted-foreground uppercase">MEMES:</span>
                   <span className="font-bold text-sploot-cyan">{stats.total.toLocaleString()}</span>
@@ -771,14 +771,14 @@ function AppPageClient() {
 
             {(!isSearching && tagIdParam) && (
               <div className="flex flex-wrap items-center gap-2">
-                <StickerTab tone="violet">
+                <StickerTab tone="violet" className="animate-sploot-pop">
                   filtering tag #{activeTagName ?? tagIdParam.slice(0, 6)}
                 </StickerTab>
               </div>
             )}
 
             {showUploadPanel && (
-              <div className="border border-dashed border-border bg-muted p-3 md:p-5">
+              <div className="animate-sploot-slide-up border border-dashed border-border bg-muted p-3 md:p-5">
                 <UploadZone
                   isOnDashboard={true}
                   onUploadComplete={(stats) => {
@@ -891,6 +891,10 @@ function AppPageClient() {
                   onScrollContainerReady={handleScrollContainerReady}
                   onUploadClick={() => setShowUploadPanel(true)}
                   showSimilarityScores={isSearching}
+                  emptyStateVariant={
+                    isSearching ? 'search' : (bangersOnly || tagIdParam) ? 'filtered' : 'first-use'
+                  }
+                  emptyStateSearchQuery={isSearching ? trimmedLibraryQuery : undefined}
                 />
               </ImageGridErrorBoundary>
             </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -73,6 +73,8 @@
   --sploot-motion-base: 150ms;
   --sploot-motion-panel: 240ms;
   --sploot-motion-cluster: 360ms;
+  --sploot-ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --sploot-ease-snap: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 @theme inline {
@@ -234,6 +236,69 @@
   animation: accentGlow 2s ease-in-out infinite;
 }
 
+/* Sploot motion system: animations explain sorting, stamping, and selection.
+   Durations come from --sploot-motion-*; easings from --sploot-ease-*. */
+@keyframes splootStamp {
+  0% {
+    opacity: 0;
+    transform: scale(1.6) rotate(-12deg);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(0.88) rotate(3deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+.animate-sploot-stamp {
+  animation: splootStamp var(--sploot-motion-panel) var(--sploot-ease-snap);
+}
+
+@keyframes splootPopIn {
+  from {
+    opacity: 0;
+    transform: scale(0.85) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.animate-sploot-pop {
+  animation: splootPopIn var(--sploot-motion-base) var(--sploot-ease-snap);
+}
+
+@keyframes splootSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-sploot-slide-up {
+  animation: splootSlideUp var(--sploot-motion-panel) var(--sploot-ease-out);
+}
+
+/* Reduced motion: collapse all animation and transition theatrics. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* shadcn/ui animations provided by tailwindcss-animate plugin */
 /* Radix UI components use: animate-in, animate-out, fade-in, fade-out, zoom-in, slide-in, etc. */
 
@@ -384,13 +449,13 @@ select:focus-visible {
 .masonry-grid {
   display: flex;
   width: 100%;
-  gap: 24px; /* Horizontal gap between columns - increased for breathing room */
+  gap: 16px; /* Horizontal gap between columns - archive-workbench density */
 }
 
 .masonry-grid-column {
   display: flex;
   flex-direction: column;
-  gap: 24px; /* Vertical gap between tiles within a column - increased for breathing room */
+  gap: 16px; /* Vertical gap between tiles within a column - archive-workbench density */
 }
 
 .masonry-item {

--- a/apps/web/components/library/empty-state.tsx
+++ b/apps/web/components/library/empty-state.tsx
@@ -101,15 +101,15 @@ export function EmptyState({
     switch (variant) {
       case 'search':
         return {
-          title: 'no results found',
+          title: 'no matches in the pile',
           description: searchQuery
-            ? `No memes match "${searchQuery}". Try different search terms or browse your full library.`
-            : 'No memes match your search. Try different terms or browse your full library.',
+            ? `nothing matches "${searchQuery}". try different words or browse the full library.`
+            : 'nothing matches that search. try different words or browse the full library.',
         };
       case 'filtered':
         return {
           title: 'no memes match these filters',
-          description: 'Try adjusting your filters or clearing them to see all your memes.',
+          description: 'try adjusting your filters or clearing them to see all your memes.',
         };
       case 'first-use':
       default:

--- a/apps/web/components/library/image-grid.tsx
+++ b/apps/web/components/library/image-grid.tsx
@@ -9,6 +9,7 @@ import { EmptyState } from './empty-state';
 import { cn } from '@/lib/utils';
 import { trackBrokenImageRatio, setupCLSTracking } from '@/lib/performance-metrics';
 import type { Asset } from '@/lib/types';
+import type { EmptyStateVariant } from './empty-state';
 import { IMAGE_GRID_BREAKPOINT_COLS, IMAGE_GRID_SCROLL_CLASS } from './image-grid-layout';
 
 interface ImageGridProps {
@@ -23,6 +24,8 @@ interface ImageGridProps {
   onScrollContainerReady?: (node: HTMLDivElement | null) => void;
   onUploadClick?: () => void;
   showSimilarityScores?: boolean;
+  emptyStateVariant?: EmptyStateVariant;
+  emptyStateSearchQuery?: string;
 }
 
 export function ImageGrid({
@@ -37,6 +40,8 @@ export function ImageGrid({
   onScrollContainerReady,
   onUploadClick,
   showSimilarityScores = false,
+  emptyStateVariant = 'first-use',
+  emptyStateSearchQuery,
 }: ImageGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [showingTransition, setShowingTransition] = useState(false);
@@ -168,7 +173,12 @@ export function ImageGrid({
   if (assets.length === 0 && !loading) {
     return (
       <div className="animate-fade-in">
-        <EmptyState variant="first-use" onUploadClick={onUploadClick} showUploadButton={false} />
+        <EmptyState
+          variant={emptyStateVariant}
+          searchQuery={emptyStateSearchQuery}
+          onUploadClick={onUploadClick}
+          showUploadButton={false}
+        />
       </div>
     );
   }
@@ -176,7 +186,7 @@ export function ImageGrid({
   // Render column-based masonry layout
   // Perfect vertical spacing within each column, natural tile flow
   return (
-    <div className="h-full">
+    <div className="h-full bg-sploot-workbench">
       <div
         ref={setContainerRef}
         className={cn(IMAGE_GRID_SCROLL_CLASS, containerClassName)}
@@ -192,7 +202,8 @@ export function ImageGrid({
               key={asset.id}
               className="masonry-item"
               style={{
-                animation: `fadeInScale 300ms ease-out ${index * 30}ms forwards`,
+                // Cap the cascade so late/paginated tiles never wait seconds
+                animation: `fadeInScale 300ms var(--sploot-ease-out) ${Math.min(index, 15) * 30}ms forwards`,
                 opacity: 0,
               }}
             >
@@ -214,7 +225,7 @@ export function ImageGrid({
         {/* Loading indicator */}
         {loading && (
           <div className="py-8 text-center">
-            <div className="inline-flex items-center gap-2 text-green-600">
+            <div className="inline-flex items-center gap-2 text-sploot-cyan">
               <svg
                 className="animate-spin h-5 w-5"
                 fill="none"
@@ -241,8 +252,10 @@ export function ImageGrid({
 
         {/* End of list indicator */}
         {!hasMore && assets.length > 0 && (
-          <div className="py-6 text-center font-mono text-xs tracking-wide text-muted-foreground/60">
-            no more memes in this view
+          <div className="flex justify-center py-6">
+            <span className="inline-block border border-border bg-card px-3 py-1 font-mono text-xs uppercase tracking-wider text-muted-foreground sploot-sticker-shadow">
+              end of the pile
+            </span>
           </div>
         )}
       </div>

--- a/apps/web/components/library/image-tile.tsx
+++ b/apps/web/components/library/image-tile.tsx
@@ -338,8 +338,18 @@ function ImageTileComponent({
   return (
     <>
       <div
+        role="button"
+        tabIndex={0}
+        aria-label={`open ${asset.filename || asset.pathname?.split('/').pop() || 'meme'}`}
         onClick={onClick || (() => onSelect?.(asset))}
-        className="group overflow-hidden cursor-pointer hover:opacity-95 transition-all border border-border hover:shadow-lg hover:shadow-black/5"
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            (onClick || (() => onSelect?.(asset)))();
+          }
+        }}
+        className="group overflow-hidden cursor-pointer border border-border transition-all duration-[var(--sploot-motion-base)] hover:-translate-y-0.5 hover:border-sploot-ink hover:shadow-[3px_3px_0_var(--sploot-ink)]"
       >
         <div className="relative">
           {/* Image container */}
@@ -450,7 +460,7 @@ function ImageTileComponent({
                       aria-label={asset.favorite ? 'remove banger' : 'mark as banger'}
                     >
                       {asset.favorite ? (
-                        <BangerStamp className="pointer-events-none min-h-0 border-0 bg-transparent p-0 text-current" />
+                        <BangerStamp className="pointer-events-none min-h-0 border-0 bg-transparent p-0 text-current animate-sploot-stamp" />
                       ) : (
                         <Heart className="h-5 w-5 sm:h-4 sm:w-4" />
                       )}

--- a/apps/web/components/search/search-loading-screen.tsx
+++ b/apps/web/components/search/search-loading-screen.tsx
@@ -16,7 +16,7 @@ export function SearchLoadingScreen({ query }: SearchLoadingScreenProps) {
         <div className="border-b px-6 py-4">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">
-              <Loader2 className="size-5 animate-spin text-green-500" />
+              <Loader2 className="size-5 animate-spin text-sploot-cyan" />
               <span className="font-mono text-sm text-muted-foreground">searching for</span>
             </div>
             <span className="font-mono text-sm">&ldquo;{query}&rdquo;</span>
@@ -37,9 +37,9 @@ export function SearchLoadingScreen({ query }: SearchLoadingScreenProps) {
           {/* Progress indicator */}
           <div className="mt-8 flex flex-col items-center justify-center gap-4">
             <div className="flex items-center gap-3">
-              <div className="h-2 w-2 rounded-full bg-green-500 animate-pulse" />
-              <div className="h-2 w-2 rounded-full bg-green-500 animate-pulse" style={{ animationDelay: '150ms' }} />
-              <div className="h-2 w-2 rounded-full bg-green-500 animate-pulse" style={{ animationDelay: '300ms' }} />
+              <div className="h-2 w-2 bg-sploot-cyan animate-pulse" />
+              <div className="h-2 w-2 bg-sploot-violet animate-pulse" style={{ animationDelay: '150ms' }} />
+              <div className="h-2 w-2 bg-sploot-coral animate-pulse" style={{ animationDelay: '300ms' }} />
             </div>
             <p className="font-mono text-sm text-muted-foreground">
               finding your memes...

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn("bg-muted animate-pulse rounded-md", className)}
       {...props}
     />
   )

--- a/apps/web/hooks/use-assets.ts
+++ b/apps/web/hooks/use-assets.ts
@@ -42,8 +42,10 @@ export function useAssets(options: UseAssetsOptions = {}) {
 
   const loadAssets = useCallback(
     async (reset = false) => {
-      // Use refs to check current state without causing recreations
-      if (loadingRef.current || (!hasMoreRef.current && !reset)) return;
+      // Use refs to check current state without causing recreations.
+      // Reset loads (initial load, refresh, filter changes) always proceed and
+      // take over any in-flight request; only pagination loads are deduped.
+      if (!reset && (loadingRef.current || !hasMoreRef.current)) return;
 
       // Cancel any in-flight request
       if (abortControllerRef.current) {
@@ -216,8 +218,10 @@ export function useAssets(options: UseAssetsOptions = {}) {
           }
         }
       } finally {
-        // Only update loading state if this request wasn't aborted
-        if (!controller.signal.aborted) {
+        // Reset loading unless a newer request has taken over. Checking
+        // ownership (not signal.aborted) means an unmount-abort can't strand
+        // loading=true forever (e.g. StrictMode's dev mount/unmount/remount).
+        if (abortControllerRef.current === controller) {
           loadingRef.current = false;
           setLoading(false);
         }
@@ -395,10 +399,16 @@ export function useAssets(options: UseAssetsOptions = {}) {
     return () => {
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
+        abortControllerRef.current = null;
       }
       if (authRetryTimeoutRef.current) {
         clearTimeout(authRetryTimeoutRef.current);
       }
+      // Allow a remount to auto-load again; the aborted request above never
+      // delivered data, so the next mount must not be blocked by hasLoadedRef
+      // (StrictMode remounts the same hook state in development).
+      loadingRef.current = false;
+      hasLoadedRef.current = false;
     };
   }, []);
 

--- a/design-contract.md
+++ b/design-contract.md
@@ -24,6 +24,8 @@ usable contract; this file is the provenance ledger.
 | `apps/web/components/chrome/navbar.tsx` | App chrome now uses `PileMark` instead of abstract overlapping circles. | observed | high | keep | Carries self-organizing pile metaphor into authenticated navigation. |
 | `apps/web/components/library/image-tile.tsx` | Similarity and banger states now use Sploot cyan/violet/coral roles instead of generic green/yellow. | observed | high | keep | Aligns core image tile affordances with the semantic token system. |
 
+| Live local screenshots, June 10, 2026 design pass (`/app` grid, search, upload, mobile dock at 1440px and 390px) | Core workbench surfaces verified rendered: motion utilities (`animate-sploot-stamp/pop/slide-up`), muted skeletons, context-aware empty states, capped tile cascade, keyboard-focusable tiles, compacted desktop header. | observed | high | keep | Captured against seeded local data via the qa-local auth harness. |
+
 ## Migration Exceptions
 
 These are known places where the current repo does not yet satisfy the full

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -110,3 +110,14 @@ Live CSS tokens:
 - `--sploot-motion-base`: hover, focus, and menu open.
 - `--sploot-motion-panel`: sheets, inspectors, and search overlays.
 - `--sploot-motion-cluster`: sorting, clustering, and upload queue movement.
+- `--sploot-ease-out`: default deceleration curve for reveals and lifts.
+- `--sploot-ease-snap`: overshoot curve for sticker and stamp moments.
+
+Named animation utilities (defined in `globals.css`):
+
+- `.animate-sploot-stamp`: banger/favorite stamp punch.
+- `.animate-sploot-pop`: sticker tabs and labels appearing.
+- `.animate-sploot-slide-up`: panels, sheets, and docks entering.
+
+A global `prefers-reduced-motion: reduce` rule collapses all animations and
+transitions; components must not re-implement their own opt-outs.

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -91,7 +91,22 @@ for (const token of [
   assertIncludes(cssPath, token, 'Sploot semantic token');
 }
 
-for (const phrase of ['--sploot-ink', '--sploot-cyan', '--sploot-touch-target']) {
+for (const token of [
+  '--sploot-motion-fast',
+  '--sploot-motion-base',
+  '--sploot-motion-panel',
+  '--sploot-motion-cluster',
+  '--sploot-ease-out',
+  '--sploot-ease-snap',
+  'animate-sploot-stamp',
+  'animate-sploot-pop',
+  'animate-sploot-slide-up',
+  'prefers-reduced-motion: reduce',
+]) {
+  assertIncludes(cssPath, token, 'Sploot motion system');
+}
+
+for (const phrase of ['--sploot-ink', '--sploot-cyan', '--sploot-touch-target', '--sploot-ease-snap', 'animate-sploot-stamp']) {
   assertIncludes('docs/design/tokens.md', phrase, 'documented design token');
 }
 
@@ -110,7 +125,9 @@ for (const [path, phrases] of Object.entries({
   'apps/web/components/search/search-bar.tsx': ['--sploot-touch-target'],
   'apps/web/components/chrome/mobile-command-dock.tsx': ['--sploot-touch-target'],
   'apps/web/components/library/image-tile.tsx': ['BangerStamp', 'border-sploot-violet', 'text-sploot-cyan'],
-  'apps/extension/entrypoints/popup/App.tsx': ['#0891B2', "borderRadius: '0'"],
+  // The popup adopts tokens through its stylesheet: App.tsx must import the
+  // token-driven style.css and use its semantic panel classes.
+  'apps/extension/entrypoints/popup/App.tsx': ["import './style.css'", 'auth-panel'],
   'apps/extension/entrypoints/popup/style.css': ['--sploot-cyan', '--sploot-coral', '--radius-square: 0px'],
   'apps/web/app/page.tsx': ['AtlasLandingHero'],
 })) {


### PR DESCRIPTION
## Summary

- **fix(web)**: Reset loads now take over in-flight requests instead of being dropped; an unmount-abort (StrictMode's dev remount cycle) no longer leaves `loading=true` permanently with an all-skeleton grid.
- **fix(design-lint)**: The popup's inline Clerk theming was removed in f6a9012, silently leaving `lint:design` red on stale markers. Now asserts the stylesheet-driven adoption. Also requires motion tokens, named animation utilities, and the `prefers-reduced-motion` guard in `globals.css` and `tokens.md`.
- **feat(web)**: Full design pass over upload, search, and scroll on desktop and mobile — motion system (easing tokens, named animation utilities, global reduced-motion override), capped tile cascade, 16px masonry density, workbench grid-paper texture, hard-ink hover lift on tiles, keyboard-focusable image tiles, banger stamp punch animation, muted skeletons, token-colored search loading screen, context-aware empty states with lowercase product voice, compacted desktop chrome so memes start higher in the viewport.

## Test plan

- [ ] `pnpm lint:design` passes (design system lint)
- [ ] `pnpm --filter web type-check` passes
- [ ] `pnpm --filter web lint` passes
- [ ] `CI=1 pnpm --filter web test -- --run` — 901 tests pass
- [ ] `/app` grid loads without permanent skeletons in dev (StrictMode remount safe)
- [ ] Search loading shows cyan/violet/coral dots, not green
- [ ] Empty grid with no search shows first-use state; searching shows search-variant empty state
- [ ] Image tiles reachable via keyboard (Tab + Enter/Space opens tile)
- [ ] Banger stamp shows punch animation on favorite toggle
- [ ] Upload panel slides up on mobile
- [ ] `prefers-reduced-motion: reduce` collapses all animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a comprehensive motion system with custom animations (stamp, pop-in, slide-up) and accessibility-first reduced-motion support.
  * Enhanced image tiles with keyboard navigation (Enter/Space to select).

* **Improvements**
  * Redesigned desktop dashboard header with improved layout and spacing.
  * Updated empty-state messaging for search, filtered, and initial views.
  * Refined loading indicators and skeleton styling across the UI.
  * Capped animation delays for paginated tile sequences to prevent excessive wait times.

* **Documentation**
  * Added Motion system section to design specifications with token definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->