### PR TITLE
fix(web): surface degraded search and quota states honestly

### DIFF
--- a/apps/web/__tests__/api/embedding-runtime-gates.test.ts
+++ b/apps/web/__tests__/api/embedding-runtime-gates.test.ts
@@ -91,3 +91,29 @@ describe('embedding runtime gates', () => {
     expect(mocks.createEmbeddingService).not.toHaveBeenCalled();
   });
 });
+
+describe('search degraded-service honesty', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('SPLOOT_EMBEDDINGS_ENABLED', 'true');
+    mocks.getAuth.mockResolvedValue({ userId: 'user-1' });
+    mocks.getSearchResults.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('POST /api/search returns 503, not 200 + empty results, when the embedding service cannot initialize', async () => {
+    mocks.createEmbeddingService.mockImplementation(() => {
+      throw new Error('REPLICATE_API_TOKEN is not configured');
+    });
+
+    const response = await search(jsonRequest('/api/search', { query: 'cat' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toMatch(/unavailable/i);
+    expect(body.results).toBeUndefined();
+  });
+});

--- a/apps/web/__tests__/lib/quota/storage-quota-policy.test.ts
+++ b/apps/web/__tests__/lib/quota/storage-quota-policy.test.ts
@@ -133,4 +133,20 @@ describe('storage quota policy', () => {
     });
     expect(mocks.prisma.$transaction).toHaveBeenCalledTimes(2);
   });
+
+  it('degrades to the default snapshot when the users row is missing (quota FK violation)', async () => {
+    const { Prisma } = await import('@prisma/client');
+    const fkViolation = new Prisma.PrismaClientKnownRequestError(
+      'Foreign key constraint violated: user_storage_quotas_user_id_fkey',
+      { code: 'P2003', clientVersion: 'test' }
+    );
+    mocks.tx.userStorageQuota.upsert.mockRejectedValue(fkViolation);
+
+    await expect(getStorageQuotaSnapshot('user-without-row')).resolves.toEqual({
+      usedBytes: 0,
+      limitBytes: 1024 * 1024 * 1024,
+      remainingBytes: 1024 * 1024 * 1024,
+      reservedBytes: 0,
+    });
+  });
 });

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -87,21 +87,17 @@ async function postHandler(req: NextRequest) {
     try {
       embeddingService = createEmbeddingService();
     } catch (error) {
-      // Failed to initialize embedding service
-
-      // Return empty results when embedding service is unavailable
-      return NextResponse.json({
-        results: [],
-        query,
-        total: 0,
-        limit: effectiveLimit,
-        requestedLimit: limit,
-        processingTime: Date.now() - startTime,
-        requestedThreshold: threshold,
-        threshold,
-        thresholdFallback: false,
-        error: 'Search is currently unavailable. Please configure Replicate API token.',
-      });
+      // Failed to initialize embedding service. A degraded backend must not
+      // masquerade as an honest empty result set (HTTP 200 + results: []
+      // renders as "no matches" in the client).
+      return NextResponse.json(
+        {
+          error: 'Search is temporarily unavailable: embedding service is not configured.',
+          query,
+          processingTime: Date.now() - startTime,
+        },
+        { status: 503 }
+      );
     }
 
     // Generate text embedding for the query

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -678,9 +678,9 @@ function AppPageClient() {
                 searchState={
                   searchLoading ? 'loading' :
                     isTypingRef.current ? 'typing' :
-                      libraryQuery && searchAssets.length > 0 ? 'success' :
-                        libraryQuery && searchAssets.length === 0 ? 'no-results' :
-                          searchError ? 'error' :
+                      searchError ? 'error' :
+                        libraryQuery && searchAssets.length > 0 ? 'success' :
+                          libraryQuery && searchAssets.length === 0 ? 'no-results' :
                             'idle'
                 }
                 resultCount={searchAssets.length}

--- a/apps/web/lib/quota/storage-quota-policy.ts
+++ b/apps/web/lib/quota/storage-quota-policy.ts
@@ -121,8 +121,27 @@ export async function getStorageQuotaSnapshot(userId: string): Promise<StorageQu
     };
   }
 
-  const snapshot = await executeTransactionWithRetry((tx) => readSnapshot(tx, userId));
-  return toPublicSnapshot(snapshot);
+  try {
+    const snapshot = await executeTransactionWithRetry((tx) => readSnapshot(tx, userId));
+    return toPublicSnapshot(snapshot);
+  } catch (error) {
+    // Auth deliberately survives identity-sync failures, so an authenticated
+    // request can reach this read before its users row exists. The quota
+    // upsert then hits the user FK; degrade to the default snapshot instead
+    // of failing the whole stats read.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2003'
+    ) {
+      return {
+        usedBytes: 0,
+        limitBytes: DEFAULT_STORAGE_QUOTA_BYTES,
+        remainingBytes: DEFAULT_STORAGE_QUOTA_BYTES,
+        reservedBytes: 0,
+      };
+    }
+    throw error;
+  }
 }
 
 export async function reserveUploadBytes(


### PR DESCRIPTION
## Summary
- `/api/search` now returns **503** (was HTTP 200 + `results: []` + an `error` field the client never reads) when the embedding service can't initialize — a down search no longer renders as an honest-looking "no matches in the pile".
- Search bar state ternary reordered: `error` outranks `no-results` (previously unreachable).
- `getStorageQuotaSnapshot` degrades to the default quota snapshot on the users-row FK violation (P2003) instead of letting `/api/stats` 500 — auth intentionally survives identity-sync failures, so downstream reads must too.

## Test plan
- [x] New test: search returns 503, not 200+empty, on embedding-init failure
- [x] New test: quota snapshot degrades on P2003
- [x] Full web suite 903/903; type-check green

Backlog: backlog.d/019-make-degraded-search-and-stats-honest.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search API now returns proper error status (503) when the embedding service is unavailable, instead of empty results.
  * Search bar now displays error state with higher priority, ensuring users see failures clearly.
  * Storage quota system now gracefully handles database constraint violations with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->