### PR TITLE
feat(web): fill landing piles with meme doodles and unhide how-it-works

### DIFF
--- a/apps/web/__tests__/components/landing/process-timeline.test.tsx
+++ b/apps/web/__tests__/components/landing/process-timeline.test.tsx
@@ -96,22 +96,24 @@ describe("ProcessTimeline", () => {
     expect(screen.getByText("03")).toBeInTheDocument();
   });
 
-  it("fades steps into view with staggered delays when intersecting", () => {
+  it("keeps steps visible before intersecting and animates them in with staggered delays after", () => {
     render(<ProcessTimeline />);
     const articlesBefore = screen.getAllByRole("article");
 
+    // Content must never be hidden waiting on the observer: no JS, aborted
+    // scroll, or screenshots would otherwise see a blank section.
     articlesBefore.forEach((article) => {
-      expect(article.className).toContain("opacity-0");
-      expect(article.className).toContain("translate-y-8");
+      expect(article.className).not.toContain("opacity-0");
+      expect(article.className).not.toContain("animate-sploot-slide-up");
     });
 
     triggerIntersection();
 
     const articlesAfter = screen.getAllByRole("article");
     articlesAfter.forEach((article, index) => {
-      expect(article.className).toContain("opacity-100");
-      expect(article.className).toContain("translate-y-0");
-      expect(article.style.transitionDelay).toBe(`${index * 150}ms`);
+      expect(article.className).toContain("animate-sploot-slide-up");
+      expect(article.style.animationDelay).toBe(`${index * 150}ms`);
+      expect(article.style.animationFillMode).toBe("backwards");
     });
   });
 });

--- a/apps/web/components/landing/process-timeline.tsx
+++ b/apps/web/components/landing/process-timeline.tsx
@@ -128,14 +128,16 @@ function TimelineStep({
           "bg-sploot-paper border border-sploot-ink",
           "p-6",
           cascadeOffset[index] ?? "md:mt-0",
-          "transition-all duration-700 ease-out",
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8",
-          prefersReducedMotion && "translate-y-0 opacity-100 transition-none"
+          // Content is visible by default; the observer only adds the
+          // entrance animation. Hiding behind opacity-0 left the section
+          // blank whenever the observer never fired (no JS, screenshots,
+          // aborted scroll).
+          isVisible && !prefersReducedMotion && "animate-sploot-slide-up"
         )}
         style={
           prefersReducedMotion || !isVisible
             ? undefined
-            : { transitionDelay: `${transitionDelayMs}ms` }
+            : { animationDelay: `${transitionDelayMs}ms`, animationFillMode: "backwards" }
         }
       >
         {/* Top accent bar */}
@@ -173,14 +175,12 @@ function TimelineStep({
         <span
           className={cn(
             "hidden md:block text-3xl text-sploot-violet font-bold",
-            "transition-all duration-700 ease-out",
-            isVisible ? "opacity-100" : "opacity-0",
-            prefersReducedMotion && "opacity-100 transition-none"
+            isVisible && !prefersReducedMotion && "animate-sploot-pop"
           )}
           style={
             prefersReducedMotion || !isVisible
               ? undefined
-              : { transitionDelay: `${transitionDelayMs + 100}ms` }
+              : { animationDelay: `${transitionDelayMs + 100}ms`, animationFillMode: "backwards" }
           }
           aria-hidden="true"
         >

--- a/apps/web/components/sploot/atlas-landing-hero.tsx
+++ b/apps/web/components/sploot/atlas-landing-hero.tsx
@@ -3,14 +3,16 @@ import { Shuffle, Sparkles, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ClusterPile } from './cluster-pile';
 import { StickerTab } from './sticker-tab';
+import { MemeDoodle, type MemeDoodleKind } from './meme-doodle';
+import { cn } from '@/lib/utils';
 
-const importItems = [
-  { label: 'reaction', tone: 'cyan' as const },
-  { label: 'groupchat', tone: 'coral' as const },
-  { label: 'cat?', tone: 'lime' as const },
-  { label: 'drake', tone: 'violet' as const },
-  { label: 'screenshot', tone: 'ink' as const },
-  { label: 'chaos', tone: 'coral' as const },
+const importItems: Array<{ label: string; doodle: MemeDoodleKind; tone: 'cyan' | 'coral' | 'violet' | 'lime' | 'ink' }> = [
+  { label: 'reaction', doodle: 'sob', tone: 'cyan' },
+  { label: 'groupchat', doodle: 'bubble', tone: 'coral' },
+  { label: 'cat?', doodle: 'cat', tone: 'lime' },
+  { label: 'cursed', doodle: 'skull', tone: 'violet' },
+  { label: 'screenshot', doodle: 'eyes', tone: 'ink' },
+  { label: 'chaos', doodle: 'fire', tone: 'coral' },
 ];
 
 const piles = [
@@ -21,12 +23,12 @@ const piles = [
     selected: true,
     bangers: 17,
     items: [
-      { label: 'nope', tone: 'violet' as const },
-      { label: 'sigh', tone: 'cyan' as const },
-      { label: 'panic', tone: 'coral' as const },
-      { label: 'same', tone: 'lime' as const },
-      { label: 'why', tone: 'violet' as const },
-      { label: 'fine', tone: 'ink' as const },
+      { label: 'nope', doodle: 'skull' as const, tone: 'violet' as const },
+      { label: 'sigh', doodle: 'sob' as const, tone: 'cyan' as const },
+      { label: 'panic', doodle: 'fire' as const, tone: 'coral' as const },
+      { label: 'same', doodle: 'eyes' as const, tone: 'lime' as const },
+      { label: 'why', doodle: 'bubble' as const, tone: 'violet' as const },
+      { label: 'fine', doodle: 'fire' as const, tone: 'ink' as const },
     ],
   },
   {
@@ -34,12 +36,12 @@ const piles = [
     count: 74,
     tone: 'cyan' as const,
     items: [
-      { label: 'yes', tone: 'cyan' as const },
-      { label: 'chef', tone: 'lime' as const },
-      { label: 'done', tone: 'cyan' as const },
-      { label: 'ship', tone: 'violet' as const },
-      { label: 'clean', tone: 'ink' as const },
-      { label: 'nice', tone: 'coral' as const },
+      { label: 'yes', doodle: 'sparkle' as const, tone: 'cyan' as const },
+      { label: 'chef', doodle: 'hundred' as const, tone: 'lime' as const },
+      { label: 'done', doodle: 'check' as const, tone: 'cyan' as const },
+      { label: 'ship', doodle: 'check' as const, tone: 'violet' as const },
+      { label: 'clean', doodle: 'sparkle' as const, tone: 'ink' as const },
+      { label: 'nice', doodle: 'hundred' as const, tone: 'coral' as const },
     ],
   },
   {
@@ -47,12 +49,12 @@ const piles = [
     count: 46,
     tone: 'coral' as const,
     items: [
-      { label: 'email', tone: 'coral' as const },
-      { label: 'slack', tone: 'violet' as const },
-      { label: 'zoom', tone: 'ink' as const },
-      { label: 'oops', tone: 'lime' as const },
-      { label: 'later', tone: 'cyan' as const },
-      { label: 'wild', tone: 'coral' as const },
+      { label: 'email', doodle: 'bubble' as const, tone: 'coral' as const },
+      { label: 'slack', doodle: 'eyes' as const, tone: 'violet' as const },
+      { label: 'zoom', doodle: 'sob' as const, tone: 'ink' as const },
+      { label: 'oops', doodle: 'fire' as const, tone: 'lime' as const },
+      { label: 'later', doodle: 'zzz' as const, tone: 'cyan' as const },
+      { label: 'wild', doodle: 'cat' as const, tone: 'coral' as const },
     ],
   },
 ];
@@ -75,9 +77,17 @@ export function AtlasLandingHero() {
               {importItems.map((item, index) => (
                 <div
                   key={`${item.label}-${index}`}
-                  className="min-w-0 overflow-hidden border border-sploot-ink bg-sploot-paper-warm p-2 font-mono text-[0.62rem] font-bold uppercase text-sploot-ink aspect-[4/5]"
+                  className={cn(
+                    'relative min-w-0 overflow-hidden border border-sploot-ink bg-sploot-paper-warm p-2 font-mono text-[0.62rem] font-bold uppercase text-sploot-ink aspect-[4/5]',
+                    index % 2 === 0 ? 'rotate-1' : '-rotate-1'
+                  )}
                 >
-                  <div className="flex h-full items-end break-all">{item.label}</div>
+                  <div className="absolute inset-0 p-3 pb-6 text-sploot-ink">
+                    <MemeDoodle kind={item.doodle} />
+                  </div>
+                  <span className="absolute bottom-1 left-1 bg-sploot-ink px-1 text-sploot-paper">
+                    {item.label}
+                  </span>
                 </div>
               ))}
             </div>

--- a/apps/web/components/sploot/cluster-pile.tsx
+++ b/apps/web/components/sploot/cluster-pile.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { BangerStamp } from './banger-stamp';
 import { StickerTab } from './sticker-tab';
+import { MemeDoodle, type MemeDoodleKind } from './meme-doodle';
 
 interface ClusterPileProps {
   label: string;
@@ -13,6 +14,7 @@ interface ClusterPileProps {
     label: string;
     src?: string;
     alt?: string;
+    doodle?: MemeDoodleKind;
     tone?: 'cyan' | 'coral' | 'violet' | 'lime' | 'ink';
   }>;
   className?: string;
@@ -73,6 +75,15 @@ export function ClusterPile({
                   className="object-cover"
                 />
                 <span className="absolute bottom-1 left-1 bg-black/80 px-1 text-white">
+                  {item.label}
+                </span>
+              </>
+            ) : item.doodle ? (
+              <>
+                <div className="absolute inset-0 p-2.5 pb-4">
+                  <MemeDoodle kind={item.doodle} />
+                </div>
+                <span className="absolute bottom-1 left-1 bg-sploot-ink px-1 text-sploot-paper">
                   {item.label}
                 </span>
               </>

--- a/apps/web/components/sploot/meme-doodle.tsx
+++ b/apps/web/components/sploot/meme-doodle.tsx
@@ -1,0 +1,140 @@
+import { cn } from '@/lib/utils';
+
+export type MemeDoodleKind =
+  | 'cat'
+  | 'skull'
+  | 'fire'
+  | 'sob'
+  | 'eyes'
+  | 'sparkle'
+  | 'check'
+  | 'hundred'
+  | 'bubble'
+  | 'zzz';
+
+interface MemeDoodleProps {
+  kind: MemeDoodleKind;
+  className?: string;
+}
+
+/**
+ * Hand-drawn-style meme glyphs for pile tiles and landing collage moments.
+ * Pure inline SVG in the zine linework grammar: currentColor strokes, square
+ * caps off, round joins on. License-safe stand-ins for real thumbnails on
+ * signed-out surfaces.
+ */
+export function MemeDoodle({ kind, className }: MemeDoodleProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={cn('h-full w-full', className)}
+    >
+      {kind === 'cat' && (
+        <>
+          <path d="M12 18 L9 8 L18 13" />
+          <path d="M36 18 L39 8 L30 13" />
+          <circle cx="24" cy="26" r="13" />
+          <circle cx="19" cy="24" r="1" fill="currentColor" />
+          <circle cx="29" cy="24" r="1" fill="currentColor" />
+          <path d="M21 31 Q24 34 27 31" />
+          <path d="M4 26 L11 27 M5 32 L12 31" />
+          <path d="M44 26 L37 27 M43 32 L36 31" />
+        </>
+      )}
+      {kind === 'skull' && (
+        <>
+          <path d="M24 7 C14 7 10 14 10 21 C10 26 12 29 15 31 L15 38 L33 38 L33 31 C36 29 38 26 38 21 C38 14 34 7 24 7 Z" />
+          <circle cx="18" cy="21" r="3.5" fill="currentColor" />
+          <circle cx="30" cy="21" r="3.5" fill="currentColor" />
+          <path d="M20 38 L20 33 M24 38 L24 33 M28 38 L28 33" />
+        </>
+      )}
+      {kind === 'fire' && (
+        <>
+          <path d="M24 5 C26 12 33 14 33 23 C33 30 29 35 24 35 C19 35 15 30 15 23 C15 18 18 16 19 12 C21 15 23 15 24 5 Z" />
+          <path d="M24 26 C25 29 27 29 27 32 C27 34 26 35 24 35 C22 35 21 34 21 32 C21 30 23 29 24 26 Z" />
+          <path d="M10 42 L38 42" />
+        </>
+      )}
+      {kind === 'sob' && (
+        <>
+          <circle cx="24" cy="24" r="16" />
+          <path d="M16 20 L21 22 M32 20 L27 22" />
+          <path d="M18 26 L18 36 M30 26 L30 36" strokeWidth="3.5" />
+          <path d="M19 33 Q24 29 29 33" />
+        </>
+      )}
+      {kind === 'eyes' && (
+        <>
+          <ellipse cx="15" cy="24" rx="8" ry="10" />
+          <ellipse cx="33" cy="24" rx="8" ry="10" />
+          <circle cx="17.5" cy="26" r="3" fill="currentColor" />
+          <circle cx="35.5" cy="26" r="3" fill="currentColor" />
+        </>
+      )}
+      {kind === 'sparkle' && (
+        <>
+          <path d="M24 6 L27 20 L41 24 L27 28 L24 42 L21 28 L7 24 L21 20 Z" />
+          <path d="M37 8 L38 12 L42 13 L38 14 L37 18 L36 14 L32 13 L36 12 Z" strokeWidth="1.8" />
+        </>
+      )}
+      {kind === 'check' && (
+        <>
+          <rect x="8" y="8" width="32" height="32" />
+          <path d="M15 25 L21 31 L33 17" strokeWidth="3.5" />
+        </>
+      )}
+      {kind === 'hundred' && (
+        <>
+          <text
+            x="24"
+            y="26"
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontFamily="monospace"
+            fontWeight="bold"
+            fontSize="17"
+            stroke="none"
+            fill="currentColor"
+          >
+            100
+          </text>
+          <path d="M9 36 L39 36" strokeWidth="3" />
+          <path d="M12 41 L36 41" strokeWidth="3" />
+        </>
+      )}
+      {kind === 'bubble' && (
+        <>
+          <rect x="6" y="9" width="36" height="24" />
+          <path d="M14 33 L14 41 L23 33" />
+          <text
+            x="24"
+            y="21"
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontFamily="monospace"
+            fontWeight="bold"
+            fontSize="13"
+            stroke="none"
+            fill="currentColor"
+          >
+            ?!
+          </text>
+        </>
+      )}
+      {kind === 'zzz' && (
+        <>
+          <path d="M8 30 L20 30 L8 42 L20 42" />
+          <path d="M22 18 L32 18 L22 28 L32 28" strokeWidth="2.2" />
+          <path d="M32 8 L40 8 L32 16 L40 16" strokeWidth="1.8" />
+        </>
+      )}
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- New `MemeDoodle` sploot component: 10 inline-SVG zine-linework meme glyphs (cat, skull, fire, sob, eyes, sparkle, check, 100, speech bubble, zzz). Hero import-pile tiles and all three `ClusterPile`s now show doodle + caption-bar content instead of empty pastel rectangles. License-safe, token-colored, crisp at retina.
- `ClusterPile` gains a `doodle` item variant alongside the existing `src` image variant.
- HOW IT WORKS was blank whenever the IntersectionObserver didn't fire (no JS, screenshots, aborted scroll) because steps defaulted to `opacity-0`. Steps are now visible by default; the observer only adds the staggered `animate-sploot-slide-up` entrance. Reduced-motion unaffected.

## Evidence
- Rendered desktop (1440px) and mobile (390px) screenshots verified: pile tiles show doodle content with caption bars; HOW IT WORKS shows all three steps in an unscrolled full-page capture.
- `pnpm lint:design` ✅, type-check ✅, 901/901 tests (timeline test updated to assert the visible-by-default contract).

Backlog: backlog.d/021-make-landing-piles-show-real-memes.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added decorative hand-drawn doodle graphics (cats, skulls, fire icons, and more) to import cards and cluster tiles for enhanced visual interest.
  * Introduced smooth entrance animations with staggered timing for process timeline steps and arrow connectors.

* **Tests**
  * Updated process timeline tests to verify new animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->