### PR TITLE
chore(backlog): archive shipped tickets 019-024

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -13,18 +13,19 @@ Status conventions:
 
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
-| [019](019-make-degraded-search-and-stats-honest.md) | Make Degraded Search And Stats Honest | P1 | M |
-| [020](020-clear-open-dependabot-vulnerabilities.md) | Clear Open Dependabot Vulnerabilities | P1 | S |
-| [021](021-make-landing-piles-show-real-memes.md) | Make Landing Piles Show Real Memes | P2 | M |
-| [022](022-prune-stale-agent-docs.md) | Prune Stale Agent Docs | P2 | S |
-| [023](023-one-command-design-qa-seed.md) | One-Command Design QA Seed | P2 | S |
-| [024](024-cache-text-query-embeddings.md) | Cache Text-Query Embeddings | P2 | M |
+| _(empty — run `/groom` to refill)_ | | | |
 
 ## Done
 
 See `_done/` for completed tickets with their `## What Was Built` notes.
 
 Recently completed:
+- [019](_done/019-make-degraded-search-and-stats-honest.md) Make Degraded Search And Stats Honest
+- [020](_done/020-clear-open-dependabot-vulnerabilities.md) Clear Open Dependabot Vulnerabilities
+- [021](_done/021-make-landing-piles-show-real-memes.md) Make Landing Piles Show Real Memes
+- [022](_done/022-prune-stale-agent-docs.md) Prune Stale Agent Docs
+- [023](_done/023-one-command-design-qa-seed.md) One-Command Design QA Seed
+- [024](_done/024-cache-text-query-embeddings.md) Cache Text-Query Embeddings
 - [018](_done/018-agent-friendly-auth-and-qa-harness.md) Agent-Friendly Auth And QA Harness
 - [017](_done/017-open-web-signin-from-extension.md) Open Web Sign-In From Extension
 - [016](_done/016-integrate-canary-agent-observability.md) Integrate Canary Agent Observability

--- a/backlog.d/_done/019-make-degraded-search-and-stats-honest.md
+++ b/backlog.d/_done/019-make-degraded-search-and-stats-honest.md
@@ -1,6 +1,6 @@
 # Make degraded search and stats honest
 
-Priority: P1 · Status: pending · Estimate: M
+Priority: P1 · Status: done · Estimate: M
 
 ## Goal
 
@@ -38,3 +38,10 @@ Evidence (verified 2026-06-10):
 Fix at the API layer first (status codes are the contract); client banner
 second. Do not weaken the auth-boundary grace — make downstream consumers
 survive it.
+
+## What Was Built
+
+PR #208 (`7c2587a`). /api/search returns 503 on embedding-init failure;
+search bar state ternary ranks error above no-results; quota snapshot
+degrades to defaults on the users-row FK violation (P2003). Regression
+tests for both paths.

--- a/backlog.d/_done/020-clear-open-dependabot-vulnerabilities.md
+++ b/backlog.d/_done/020-clear-open-dependabot-vulnerabilities.md
@@ -1,6 +1,6 @@
 # Clear open Dependabot vulnerabilities
 
-Priority: P1 · Status: pending · Estimate: S
+Priority: P1 · Status: done · Estimate: S
 
 ## Goal
 
@@ -32,3 +32,11 @@ Dependabot's bump run for shell-quote
 (`actions/runs/27251498043`) concluded `failure` — likely pnpm workspace
 lockfile handling. Bump via pnpm directly (overrides in root `package.json`
 where the dep is transitive), one PR for the lot.
+
+## What Was Built
+
+PR #206 (`b759152`). pnpm overrides pin shell-quote >=1.8.4 (critical) and
+tmp >=0.2.6 (high) — the only vulnerable resolutions actually in the
+lockfile. next/vitest/ws/postcss alerts verified stale or already patched;
+some reference the deleted apps/extension/pnpm-lock.yaml and will close on
+Dependabot rescan.

--- a/backlog.d/_done/021-make-landing-piles-show-real-memes.md
+++ b/backlog.d/_done/021-make-landing-piles-show-real-memes.md
@@ -1,6 +1,6 @@
 # Make landing piles show real memes
 
-Priority: P2 · Status: pending · Estimate: M
+Priority: P2 · Status: done · Estimate: M
 
 ## Goal
 
@@ -28,3 +28,11 @@ the component grammar is in place; this is content + composition work.
 Options: bundled sample memes (license-safe), generated caption cards, or a
 small inline SVG meme set. Structural redesign of the section flow was
 explicitly deferred from the 2026-06-10 design pass.
+
+## What Was Built
+
+PR #211 (`7116a6b`). New MemeDoodle component (10 inline-SVG zine glyphs);
+hero import pile and all ClusterPiles show doodle+caption content.
+ProcessTimeline steps visible by default with observer-added entrance
+animation, fixing the blank HOW IT WORKS section. Desktop+mobile renders
+verified.

--- a/backlog.d/_done/022-prune-stale-agent-docs.md
+++ b/backlog.d/_done/022-prune-stale-agent-docs.md
@@ -1,6 +1,6 @@
 # Prune stale agent docs
 
-Priority: P2 · Status: pending · Estimate: S
+Priority: P2 · Status: done · Estimate: S
 
 ## Goal
 
@@ -29,3 +29,10 @@ Stale harness prose is an agent hazard: a cold agent reading
 design lint now rejects, and a pointer to a tracker file that doesn't exist.
 Keep the database/observability sections — those are accurate and
 load-bearing.
+
+## What Was Built
+
+PR #207 (`c87987b`). Root CLAUDE.md points at backlog.d/ instead of the
+missing TASK.md; apps/web/CLAUDE.md design section defers to DESIGN.md and
+real scripts; PROMPT.md deleted (its health-route fix had shipped);
+AGENTS.md debt-map path fixed.

--- a/backlog.d/_done/023-one-command-design-qa-seed.md
+++ b/backlog.d/_done/023-one-command-design-qa-seed.md
@@ -1,6 +1,6 @@
 # One-command design QA seed
 
-Priority: P2 · Status: pending · Estimate: S
+Priority: P2 · Status: done · Estimate: S
 
 ## Goal
 
@@ -28,3 +28,10 @@ dismissing the client integrity banner (`use-assets.ts` validates URLs contain
 Options: a dev/QA-only allowlist for local seed URLs in both validators, or
 seed with constraint-shaped URLs proxied by a dev-only route. Builds directly
 on the 018 qa-local auth harness; this is the data half that 018 left out.
+
+## What Was Built
+
+PR #209 (`59f62de`). pnpm --filter web qa:seed / --teardown: QA user +
+generated PNG fixtures with CHECK-compliant URLs on a reserved
+sploot-qa-seed host; QA-only image loader maps the host to static files.
+Verified rendered at /app under qa-local auth. Documented in docs/AUTH.md.

--- a/backlog.d/_done/024-cache-text-query-embeddings.md
+++ b/backlog.d/_done/024-cache-text-query-embeddings.md
@@ -1,6 +1,6 @@
 # Cache text-query embeddings
 
-Priority: P2 · Status: pending · Estimate: M
+Priority: P2 · Status: done · Estimate: M
 
 ## Goal
 
@@ -27,3 +27,10 @@ instances. A small Postgres table keyed by `hash(model, normalized_query)`
 (or Vercel KV) gives cross-instance reuse and survives deploys. Normalize the
 query (trim/lowercase/collapse whitespace) before hashing. Invalidate by model
 name so an embedding-model upgrade naturally misses.
+
+## What Was Built
+
+PR #210 (`4358100`). text_embedding_cache table as persistent L2 inside
+CacheService (fail-soft, 30-day TTL, opportunistic pruning), keyed by
+(model, normalized query). clear/invalidate propagate to L2. Live p50
+against Replicate unverified (no token locally); mechanism proven by tests.


### PR DESCRIPTION
Backlog-only: tickets 019–024 shipped via PRs #206–#211; move to `_done/` with What Was Built notes, empty the Active index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked backlog items 019–024 as completed with summary details
  * Restructured "Recently completed" section from table to bullet-point format in backlog tracker

<!-- end of auto-generated comment: release notes by coderabbit.ai -->