### PR TITLE
feat(web): feature-true brainrot voice pass across landing and library

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -220,17 +220,33 @@ Interaction rules:
 
 ## 7. Content Voice
 
-Voice is lowercase, direct, and a little funny. Use product language, not agent
-process language.
+The voice is hypermaximalist, terminally online, zoomer meme-culture brainrot —
+delivered deadpan inside Swiss chrome. Lowercase everything except display
+headlines. The product talks like the person whose camera roll it is:
+self-aware, a little feral, never corporate. Every surface gets one moment of
+personality; density of delight, not density of words.
 
-Preferred:
+Lexicon (use naturally, never all at once):
 
 - "no folders. just vibes."
-- "your saves sort themselves."
-- "shuffle the pile"
-- "bangers"
-- "similar saves"
-- "upload chaos"
+- "type the vibe. summon the meme."
+- "bangers", "goated", "unhinged", "feral", "cursed", "brainrot"
+- "the pile" (the library is always the pile)
+- "go touch grass", "zero thoughts", "hall of fame"
+- "upload chaos", "shuffle the pile", "similar saves"
+
+Rules:
+
+- **Feature-true copy.** Visible UI and marketing claims describe what ships
+  today. "self-organizing piles" is north-star direction (Meme Atlas); until
+  clustering ships, piles in copy are search results — piles on demand, not
+  automatic piles. Design polish must not launder unshipped features.
+- Deadpan over exclamation. The humor lands because the chrome is Swiss.
+  Never more than one slang term per sentence; brainrot is seasoning, not soup.
+- Skip slang with a short shelf life or fellow-kids energy (no "rizz", no
+  "skibidi", nothing that reads as a brand doing a bit).
+- Empty states, end-of-list markers, errors, and loading copy are the prime
+  personality slots. Buttons and labels stay short and functional.
 
 Avoid:
 

--- a/apps/web/__tests__/components/landing/process-timeline.test.tsx
+++ b/apps/web/__tests__/components/landing/process-timeline.test.tsx
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 
 import { ProcessTimeline } from "@/components/landing/process-timeline";
 
-const titles = ["upload chaos", "piles appear", "find bangers"];
+const titles = ["upload chaos", "type the vibe", "crown bangers"];
 let intersectionCallback: IntersectionObserverCallback | null = null;
 
 class IntersectionObserverMock implements IntersectionObserver {
@@ -60,10 +60,10 @@ describe("ProcessTimeline", () => {
       screen.getByText("drop in the screenshots, reactions, and groupchat relics."),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("similar saves drift into nearby semantic neighborhoods."),
+      screen.getByText("describe what you remember: \u201ccrying cat,\u201d \u201coffice chaos,\u201d \u201cthat one frog.\u201d"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("type what you remember and pull the exact meme back."),
+      screen.getByText("smash the heart on the goated ones. your hall of fame builds itself."),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/__tests__/components/sploot/atlas-landing-hero.test.tsx
+++ b/apps/web/__tests__/components/sploot/atlas-landing-hero.test.tsx
@@ -8,29 +8,36 @@ describe('AtlasLandingHero', () => {
     render(<AtlasLandingHero />);
 
     expect(screen.getByText('no folders just vibes')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'your saves sort themselves.' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'type the vibe. summon the meme.' })).toBeInTheDocument();
     expect(screen.getByText('messy import pile')).toBeInTheDocument();
-    expect(screen.getByText('automatic piles')).toBeInTheDocument();
+    // Feature-true: sploot does not auto-cluster yet, so piles are framed as
+    // search results, never "automatic piles".
+    expect(screen.getByText('piles on demand')).toBeInTheDocument();
+    expect(screen.queryByText('automatic piles')).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'start your pile' })).toHaveAttribute('href', '/sign-up');
   });
 
-  it('exposes semantic pile previews and banger state', () => {
+  it('frames pile previews as typed queries with banger state', () => {
     render(<AtlasLandingHero />);
 
-    expect(screen.getByLabelText('dramatic reactions, 128 saves')).toBeInTheDocument();
-    expect(screen.getByLabelText('tiny wins, 74 saves')).toBeInTheDocument();
-    expect(screen.getByLabelText('unhinged office, 46 saves')).toBeInTheDocument();
+    expect(screen.getByLabelText('“dramatic reactions”, 128 saves')).toBeInTheDocument();
+    expect(screen.getByLabelText('“tiny wins”, 74 saves')).toBeInTheDocument();
+    expect(screen.getByLabelText('“unhinged office”, 46 saves')).toBeInTheDocument();
     expect(screen.getByLabelText('17 bangers')).toBeInTheDocument();
   });
 
-  it('renders stable command stats for search, piles, and bangers', () => {
+  it('renders command stats without fabricating feature claims', () => {
     render(<AtlasLandingHero />);
 
-    expect(screen.getByText('search')).toBeInTheDocument();
-    expect(screen.getByText('piles')).toBeInTheDocument();
+    expect(screen.getByText('memes')).toBeInTheDocument();
     expect(screen.getByText('bangers')).toBeInTheDocument();
-    expect(screen.getByText('0.18s')).toBeInTheDocument();
-    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(screen.getByText('brainrot')).toBeInTheDocument();
+    expect(screen.getByText('1,312')).toBeInTheDocument();
     expect(screen.getByText('91')).toBeInTheDocument();
+    expect(screen.getByText('∞')).toBeInTheDocument();
+    // The old strip claimed a fake search latency and a pile count for a
+    // clustering feature that does not exist.
+    expect(screen.queryByText('0.18s')).not.toBeInTheDocument();
+    expect(screen.queryByText('piles')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -57,7 +57,7 @@ export default async function Home() {
               </p>
               <div className="flex items-center gap-3">
                 <div className="h-px flex-1 bg-sploot-cyan" />
-                <span className="font-mono text-xs uppercase text-sploot-cyan">automatic piles</span>
+                <span className="font-mono text-xs uppercase text-sploot-cyan">vibe-based retrieval</span>
               </div>
             </div>
 
@@ -119,7 +119,7 @@ export default async function Home() {
               HOW IT WORKS
             </h2>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              from chaos to piles
+              from camera-roll chaos to instant summon
             </p>
           </div>
           <ProcessTimeline />

--- a/apps/web/components/landing/process-timeline.tsx
+++ b/apps/web/components/landing/process-timeline.tsx
@@ -27,15 +27,15 @@ const steps: ProcessStep[] = [
   },
   {
     number: "02",
-    title: "piles appear",
-    description: "similar saves drift into nearby semantic neighborhoods.",
-    icon: AnalyzeIcon,
+    title: "type the vibe",
+    description: "describe what you remember: “crying cat,” “office chaos,” “that one frog.”",
+    icon: SearchIcon,
   },
   {
     number: "03",
-    title: "find bangers",
-    description: "type what you remember and pull the exact meme back.",
-    icon: SearchIcon,
+    title: "crown bangers",
+    description: "smash the heart on the goated ones. your hall of fame builds itself.",
+    icon: AnalyzeIcon,
   },
 ];
 

--- a/apps/web/components/library/empty-state.tsx
+++ b/apps/web/components/library/empty-state.tsx
@@ -103,19 +103,19 @@ export function EmptyState({
         return {
           title: 'no matches in the pile',
           description: searchQuery
-            ? `nothing matches "${searchQuery}". try different words or browse the full library.`
-            : 'nothing matches that search. try different words or browse the full library.',
+            ? `the pile has nothing for "${searchQuery}". the vibe may be too specific. try fewer words.`
+            : 'the pile has nothing for that. the vibe may be too specific. try fewer words.',
         };
       case 'filtered':
         return {
           title: 'no memes match these filters',
-          description: 'try adjusting your filters or clearing them to see all your memes.',
+          description: 'these filters filtered everything. loosen up or clear them.',
         };
       case 'first-use':
       default:
         return {
-          title: 'drop files here',
-          description: 'drag and drop images into your library or start an upload to see them appear instantly.',
+          title: 'the pile awaits',
+          description: 'drag in your most unhinged screenshots and reaction pics. they show up instantly.',
         };
     }
   };

--- a/apps/web/components/library/image-grid.tsx
+++ b/apps/web/components/library/image-grid.tsx
@@ -253,8 +253,8 @@ export function ImageGrid({
         {/* End of list indicator */}
         {!hasMore && assets.length > 0 && (
           <div className="flex justify-center py-6">
-            <span className="inline-block border border-border bg-card px-3 py-1 font-mono text-xs uppercase tracking-wider text-muted-foreground sploot-sticker-shadow">
-              end of the pile
+            <span className="inline-block -rotate-1 border border-border bg-card px-3 py-1 font-mono text-xs uppercase tracking-wider text-muted-foreground sploot-sticker-shadow">
+              end of the pile. go touch grass.
             </span>
           </div>
         )}

--- a/apps/web/components/sploot/atlas-landing-hero.tsx
+++ b/apps/web/components/sploot/atlas-landing-hero.tsx
@@ -15,9 +15,11 @@ const importItems: Array<{ label: string; doodle: MemeDoodleKind; tone: 'cyan' |
   { label: 'chaos', doodle: 'fire', tone: 'coral' },
 ];
 
+// Each pile is a search result: the label is the query you'd type. Sploot
+// does not (yet) cluster unprompted — landing visuals must stay feature-true.
 const piles = [
   {
-    label: 'dramatic reactions',
+    label: '“dramatic reactions”',
     count: 128,
     tone: 'violet' as const,
     selected: true,
@@ -32,7 +34,7 @@ const piles = [
     ],
   },
   {
-    label: 'tiny wins',
+    label: '“tiny wins”',
     count: 74,
     tone: 'cyan' as const,
     items: [
@@ -45,7 +47,7 @@ const piles = [
     ],
   },
   {
-    label: 'unhinged office',
+    label: '“unhinged office”',
     count: 46,
     tone: 'coral' as const,
     items: [
@@ -100,16 +102,16 @@ export function AtlasLandingHero() {
           </StickerTab>
           <div className="space-y-4">
             <h1
-              aria-label="your saves sort themselves."
+              aria-label="type the vibe. summon the meme."
               className="font-display text-[3.25rem] leading-[0.92] tracking-normal text-sploot-ink min-[390px]:text-6xl md:text-8xl lg:text-7xl"
             >
-              <span className="block">your saves</span>
-              <span className="block">sort</span>
-              <span className="block">themselves.</span>
+              <span className="block">type the vibe.</span>
+              <span className="block">summon</span>
+              <span className="block">the meme.</span>
             </h1>
             <p className="mx-auto max-w-xl text-base leading-7 text-muted-foreground md:text-lg lg:mx-0">
-              Sploot turns the memes you already saved into searchable semantic piles, bangers,
-              and nearby weird little neighborhoods.
+              dump years of reaction pics into sploot, type &ldquo;sad cat thumbs up,&rdquo; and
+              the exact one materializes. zero folders. zero scrolling. zero thoughts.
             </p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
@@ -122,16 +124,16 @@ export function AtlasLandingHero() {
           </div>
           <div className="grid min-w-0 grid-cols-3 overflow-hidden border border-sploot-ink bg-sploot-command-surface text-left font-mono text-[0.68rem] sploot-tabular sm:text-xs">
             <div className="min-w-0 border-r border-sploot-ink p-3">
-              <span className="block truncate text-muted-foreground">search</span>
-              <span className="font-bold text-sploot-cyan">0.18s</span>
+              <span className="block truncate text-muted-foreground">memes</span>
+              <span className="font-bold text-sploot-cyan">1,312</span>
             </div>
             <div className="min-w-0 border-r border-sploot-ink p-3">
-              <span className="block truncate text-muted-foreground">piles</span>
-              <span className="font-bold text-sploot-violet">24</span>
-            </div>
-            <div className="min-w-0 p-3">
               <span className="block truncate text-muted-foreground">bangers</span>
               <span className="font-bold text-sploot-coral">91</span>
+            </div>
+            <div className="min-w-0 p-3">
+              <span className="block truncate text-muted-foreground">brainrot</span>
+              <span className="font-bold text-sploot-violet">∞</span>
             </div>
           </div>
         </div>
@@ -140,7 +142,7 @@ export function AtlasLandingHero() {
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <Sparkles className="h-4 w-4 text-sploot-violet" aria-hidden="true" />
-              <StickerTab tone="violet" tilt="right">automatic piles</StickerTab>
+              <StickerTab tone="violet" tilt="right">piles on demand</StickerTab>
             </div>
             <Shuffle className="h-5 w-5 text-sploot-cyan" aria-hidden="true" />
           </div>

--- a/backlog.d/025-build-automatic-semantic-piles.md
+++ b/backlog.d/025-build-automatic-semantic-piles.md
@@ -1,0 +1,38 @@
+# Build automatic semantic piles
+
+Priority: P1 · Status: pending · Estimate: L
+
+## Goal
+
+The library actually sorts itself: assets cluster into labeled semantic piles
+without the user typing a query, making "self-organizing piles" a shipped
+feature instead of north-star copy.
+
+## Oracle
+
+- [ ] An authenticated user with ≥50 embedded assets sees named piles (label +
+      count + thumbnails) generated without typing anything, on a real surface
+      (pile rail, sheet, or grid grouping — decided in shaping).
+- [ ] Clusters come from the existing CLIP embeddings in pgvector (no new
+      embedding provider); recomputation is incremental or cheap enough to run
+      on upload/cron.
+- [ ] Labels are auto-generated (e.g. nearest text anchors to the cluster
+      centroid) and lowercase product voice.
+- [ ] Landing copy may then truthfully say "automatic piles" — flip the
+      feature-true framing in `DESIGN.md` §7 and the hero back from
+      "piles on demand".
+- [ ] `pnpm lint:design` and full web suite green; live render evidence of
+      piles on desktop + mobile.
+
+## Notes
+
+This is the product's stated north star (`vision.md`, Meme Atlas direction in
+`design-contract.md`). The 2026-06-10 audit confirmed no clustering code
+exists; landing claims were recast as search-result piles until this ships.
+
+Technical sketch: k-means or graph community detection over `asset_embeddings`
+vectors (768-dim CLIP), k chosen by heuristic or silhouette; store
+`pile_id`/`pile_label` per asset (or a piles table); label via cosine-nearest
+phrases from a curated anchor list embedded once. UX questions (navigation
+surface vs. background organization, pile pinning, overlap handling) need
+`/shape` before building.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -13,7 +13,7 @@ Status conventions:
 
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
-| _(empty — run `/groom` to refill)_ | | | |
+| [025](025-build-automatic-semantic-piles.md) | Build Automatic Semantic Piles | P1 | L |
 
 ## Done
 

--- a/design-contract.md
+++ b/design-contract.md
@@ -25,6 +25,8 @@ usable contract; this file is the provenance ledger.
 | `apps/web/components/library/image-tile.tsx` | Similarity and banger states now use Sploot cyan/violet/coral roles instead of generic green/yellow. | observed | high | keep | Aligns core image tile affordances with the semantic token system. |
 
 | Live local screenshots, June 10, 2026 design pass (`/app` grid, search, upload, mobile dock at 1440px and 390px) | Core workbench surfaces verified rendered: motion utilities (`animate-sploot-stamp/pop/slide-up`), muted skeletons, context-aware empty states, capped tile cascade, keyboard-focusable tiles, compacted desktop header. | observed | high | keep | Captured against seeded local data via the qa-local auth harness. |
+| User direction, June 10, 2026 | The design system voice is hypermaximalist, zoomer meme-culture brainrot — delightful, deadpan, terminally online. | provided | high | keep | Codified in DESIGN.md §7; applies to all surfaces going forward. |
+| Code audit, June 10, 2026 | No clustering feature exists (no grouping API or code); "your saves sort themselves" and "automatic piles" overclaimed. Landing copy recast to feature-true: piles are search results ("piles on demand") until Meme Atlas clustering ships. | observed | high | keep | Feature-true copy rule added to DESIGN.md §7; auto-piles tracked as backlog 025. |
 
 ## Migration Exceptions
 


### PR DESCRIPTION
## Summary
- **Honesty**: landing claimed clustering that doesn't exist ("your saves sort themselves", "automatic piles", fake "0.18s" latency, "24 piles"). All recast as what actually ships: hero is now "type the vibe. summon the meme.", piles are framed as typed-query results ("piles on demand", quoted labels), stats strip shows memes / bangers / brainrot ∞.
- **Voice**: DESIGN.md §7 rewritten — the system voice is hypermaximalist zoomer meme-culture brainrot, deadpan inside Swiss chrome, with a lexicon, a hard **feature-true copy** rule, and banned fellow-kids slang. Provenance rows added to design-contract.md.
- **Library sprinkles**: "end of the pile. go touch grass.", "the pile awaits" first-use state, brainrot search/filter empty states.
- **Backlog 025** emitted: build automatic semantic piles for real (clustering over existing CLIP embeddings), so the original claim can return as truth.

## Evidence
- Desktop + mobile renders verified: new hero, quoted pile stickers, how-it-works steps (01 upload chaos / 02 type the vibe / 03 crown bangers).
- Tests updated to pin the feature-true contract (asserts "automatic piles" and "0.18s" are absent). 912/912 green, lint:design ✅, type-check ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated brand design voice and standards documentation.

* **Content Updates**
  * Refreshed landing page messaging and "How it Works" section.
  * Updated process timeline and hero section copy.
  * Revised empty state messages across library views.
  * Updated end-of-list messaging and metrics display.

* **Backlog**
  * Added new feature documentation for semantic pile generation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->