### PR TITLE
chore(backlog): emit groomed tickets 026-030 from 2026-06-10 session

### DIFF
--- a/backlog.d/026-ingest-memes-where-they-live.md
+++ b/backlog.d/026-ingest-memes-where-they-live.md
@@ -1,0 +1,49 @@
+# Ingest memes where they live
+
+Priority: P1 · Status: pending · Estimate: XL
+
+## Goal
+
+A user whose memes are scattered across their phone, Twitter bookmarks, and
+random URLs can get them into Sploot from where they already are — ingestion
+stops being "drag a file onto a desktop browser tab."
+
+## Oracle
+
+- [ ] On Android (and iOS where supported), sharing an image from another
+      app's native share sheet to the installed Sploot PWA saves it to the
+      library (manifest `share_target` + receiving route, verified on a real
+      device or emulator).
+- [ ] The web upload surface accepts a pasted image URL and ingests the
+      remote image server-side (with existing checksum dedupe applied).
+- [ ] A bulk import path exists for at least one "scattered collection"
+      source (zip/folder of images at minimum; Twitter/X bookmarks if API
+      access proves viable) with progress UI and dedupe.
+- [ ] The extension's registered Cmd+Shift+S screenshot shortcut either has a
+      working capture UI or the dead manifest registration is removed.
+- [ ] Offline/failed uploads survive a page refresh (queue persisted to
+      IndexedDB, not memory).
+- [ ] Full web suite + extension build green; live evidence per shipped child.
+
+## Notes
+
+Vision targets "people with meme collections scattered across Twitter
+bookmarks, Google Photos, camera rolls" — but the 2026-06-10 ingestion audit
+found only desktop drag-drop/paste/picker and the Chrome right-click menu.
+No share_target in `apps/web/public/manifest.json`, no URL import, no bulk
+import, in-memory-only upload queue, and a screenshot shortcut registered in
+`wxt.config.ts` with no UI behind it. Checksum dedupe
+(`lib/upload/deduplication-service.ts`) already exists and de-risks every
+bulk path. Ingestion is upstream of every other differentiator: piles,
+search, and taste all need library mass.
+
+## Children
+
+1. PWA share-target: manifest entry + POST receiver route + device QA.
+2. URL import: paste-a-URL field in the upload zone + server-side fetch
+   with size/MIME validation and dedupe.
+3. Persist the upload queue to IndexedDB; retry on reconnect/refresh.
+4. Bulk import v1: zip/folder of images with progress + dedupe summary.
+5. Decide screenshot capture: build the crop UI or delete the shortcut.
+6. Investigate Twitter/X bookmark import feasibility (API access, cost);
+   emit or kill with a written verdict.

--- a/backlog.d/027-delete-dead-enterprise-infrastructure.md
+++ b/backlog.d/027-delete-dead-enterprise-infrastructure.md
@@ -1,0 +1,32 @@
+# Delete dead enterprise infrastructure from apps/web
+
+Priority: P2 · Status: pending · Estimate: S
+
+## Goal
+
+The web app stops carrying ~1,200+ lines of unreachable or test-only
+infrastructure that no production code path uses.
+
+## Oracle
+
+- [ ] `apps/web/app/test-shadcn-batch{1..4}/` routes deleted (production
+      routes today, importers: none outside generated `.next` types).
+- [ ] `lib/metrics-collector.ts` + its test deleted (only importer is its
+      own test).
+- [ ] `lib/distributed-queue.ts`, `hooks/use-distributed-queue.ts`, and
+      their tests deleted (hook has zero importers; queue's only importer is
+      the hook).
+- [ ] `components/upload-test.tsx` deleted (zero importers).
+- [ ] `components/search/search-bar-with-results.tsx` and
+      `search-bar-compact.tsx` deleted or wired in (exported from the barrel
+      but never imported; delete unless a live use is found).
+- [ ] `pnpm --filter web type-check`, lint, and full test suite green;
+      `/app` renders and uploads still work (QA harness smoke).
+
+## Notes
+
+2026-06-10 grug-lane audit, importer claims re-verified by grep. Out of
+scope (live but debatably overbuilt — do not touch here):
+`connection-pool.ts`, `circuit-breaker.ts`, `observability-logger.ts`. If
+the connection-pool/priority-queue machinery keeps growing, emit a separate
+simplification ticket with profiling evidence first.

--- a/backlog.d/028-make-animated-memes-first-class.md
+++ b/backlog.d/028-make-animated-memes-first-class.md
@@ -1,0 +1,39 @@
+# Make animated memes first-class
+
+Priority: P2 · Status: pending · Estimate: L
+
+## Goal
+
+GIFs and short videos behave like memes, not frozen frames — the library
+plays what the user saved.
+
+## Oracle
+
+- [ ] A GIF in the library animates where it matters (grid hover-to-play or
+      always-on, full animation on the detail page) instead of rendering its
+      static thumbnail; perf stays acceptable on a 200-asset grid.
+- [ ] Short video upload (mp4/webm, size-capped) is accepted end-to-end:
+      validation in `@sploot/common` constants, blob storage, poster-frame
+      thumbnail extraction, playback on detail page, sensible grid tile.
+- [ ] Search/embedding pipeline handles animated assets without erroring
+      (embed poster/first frame; documented as the chosen approach).
+- [ ] Extension right-click save works on a GIF and the result animates in
+      the library.
+- [ ] Full web suite green; live render evidence (grid + detail, desktop +
+      mobile) showing animation.
+
+## Notes
+
+Vision lists multimedia as near-term ("memes aren't just images anymore").
+Today `image/gif` is in the upload allowlist but grid tiles render
+`thumbnailUrl` (sharp-generated static frame) and there is no `video/*`
+support anywhere. A user uploading 20 reaction GIFs sees a wall of frozen
+frames — silent degradation of a core meme format.
+
+## Children
+
+1. Animate GIFs: serve original blob for GIF tiles/detail (or hover-swap),
+   measure grid perf, pick always-on vs hover.
+2. Video upload v1: MIME/size validation, poster-frame extraction, storage.
+3. Video playback: detail-page player + grid tile treatment.
+4. Embedding strategy for animated assets (poster frame) + tests.

--- a/backlog.d/029-build-the-taste-engine.md
+++ b/backlog.d/029-build-the-taste-engine.md
@@ -1,0 +1,42 @@
+# Build the taste engine
+
+Priority: P3 · Status: pending · Estimate: XL
+
+## Goal
+
+Sploot starts acting like "the meme app that knows your taste": the user's
+bangers and behavior shape what the app surfaces, building toward
+taste-matched generation.
+
+## Oracle
+
+- [ ] Shuffle has a taste-weighted mode: assets similar (cosine, existing
+      CLIP embeddings) to the user's favorited bangers surface more often
+      than uniform random, behind a visible toggle; uniform shuffle remains
+      default.
+- [ ] A "your taste" surface exists (even minimal): what the app thinks the
+      user finds funny, derived from banger embedding centroids — lowercase
+      product voice, no new embedding provider.
+- [ ] A written feasibility verdict on taste-matched generation (provider,
+      cost per image, prompt-from-centroid approach) lives in `docs/adr/`
+      before any generation code is written.
+- [ ] Full web suite green; live evidence of taste-weighted shuffle
+      returning visibly different results from uniform on a seeded library.
+
+## Notes
+
+Vision's north star sentence is literally "the meme app that knows your
+taste," and generation is its named future — but zero taste code exists
+beyond the favorite boolean. The cheap first step needs no new
+infrastructure: banger embeddings already live in pgvector, so
+taste-weighted shuffle and a taste profile are similarity math over
+existing vectors. Generation (child 3+) stays gated on the ADR; this epic
+is deliberately sequenced so the first two children ship value even if
+generation is killed. Raw idea — needs `/shape` before any child is built.
+
+## Children
+
+1. Taste-weighted shuffle (banger-centroid similarity reweighting + toggle).
+2. Minimal taste profile surface ("sploot thinks you like…").
+3. Generation feasibility ADR (providers, cost, safety, prompt strategy).
+4. Taste-matched generation v1 — only if the ADR survives.

--- a/backlog.d/030-retriage-resurfaced-dependabot-alerts.md
+++ b/backlog.d/030-retriage-resurfaced-dependabot-alerts.md
@@ -1,0 +1,29 @@
+# Re-triage resurfaced Dependabot alerts
+
+Priority: P2 · Status: pending · Estimate: S
+
+## Goal
+
+The default branch shows zero actionable open Dependabot alerts: real
+vulnerabilities patched, stale alerts dismissed with reasons.
+
+## Oracle
+
+- [ ] vitest critical advisories resolved (bump or override past the
+      affected range; suite still green).
+- [ ] shell-quote and tmp alerts dismissed as stale if the lockfile-resolved
+      versions (1.8.4 / 0.2.6 via #206 overrides) sit outside the affected
+      ranges — with a dismissal reason — or actually fixed if not.
+- [ ] ws, next, postcss, and turbo alerts each triaged: patched, overridden,
+      or dismissed with a written reason.
+- [ ] `gh api repos/misty-step/sploot/dependabot/alerts --jq
+      '[.[] | select(.state=="open")] | length'` returns 0.
+
+## Notes
+
+Found during the 2026-06-10 groom: push output reported 13 open alerts
+(4 critical) despite ticket 020 and PR #206 addressing this in early June.
+Verified live: shell-quote/tmp overrides ARE in the lockfile, so those four
+alerts are probably stale scans; the two vitest criticals (resolved 4.1.7)
+are new and real until proven otherwise. Consider enabling a CI/audit gate
+so resurfaced alerts surface in a PR check instead of a groom session.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -18,6 +18,7 @@ Status conventions:
 | [027](027-delete-dead-enterprise-infrastructure.md) | Delete Dead Enterprise Infrastructure | P2 | S |
 | [028](028-make-animated-memes-first-class.md) | Make Animated Memes First-Class (epic) | P2 | L |
 | [029](029-build-the-taste-engine.md) | Build The Taste Engine (epic, raw) | P3 | XL |
+| [030](030-retriage-resurfaced-dependabot-alerts.md) | Re-Triage Resurfaced Dependabot Alerts | P2 | S |
 
 ## Done
 

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -14,6 +14,10 @@ Status conventions:
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
 | [025](025-build-automatic-semantic-piles.md) | Build Automatic Semantic Piles | P1 | L |
+| [026](026-ingest-memes-where-they-live.md) | Ingest Memes Where They Live (epic) | P1 | XL |
+| [027](027-delete-dead-enterprise-infrastructure.md) | Delete Dead Enterprise Infrastructure | P2 | S |
+| [028](028-make-animated-memes-first-class.md) | Make Animated Memes First-Class (epic) | P2 | L |
+| [029](029-build-the-taste-engine.md) | Build The Taste Engine (epic, raw) | P3 | XL |
 
 ## Done
 


### PR DESCRIPTION
## Summary

/groom session output: tidy was clean (only 025 open, nothing to archive), so this is the strategic harvest from three parallel investigation lanes (simplification, product-gap vs vision, ingestion), with every load-bearing claim re-verified against the live repo.

- **026 — Ingest memes where they live (epic, P1/XL):** vision targets scattered collections, but ingestion is desktop drag-drop + Chrome right-click only. No PWA share_target, no URL import, no bulk import, in-memory upload queue, dead screenshot shortcut.
- **027 — Delete dead enterprise infrastructure (P2/S):** ~1,200+ lines verified unreachable: test-shadcn-batch1..4 routes, metrics-collector, distributed-queue + orphaned hook, upload-test.tsx, two unused search components.
- **028 — Make animated memes first-class (epic, P2/L):** GIFs upload fine but grid renders static sharp thumbnails; no video support anywhere.
- **029 — Build the taste engine (epic, P3/XL, raw):** zero taste code behind the "knows your taste" north star; first children (taste-weighted shuffle, taste profile) need only existing pgvector embeddings.
- **030 — Re-triage resurfaced Dependabot alerts (P2/S):** 13 open alerts incl. 2 new vitest criticals; shell-quote/tmp overrides from #206 verified in lockfile, so those are likely stale scans.

## Verification

Backlog-only change; pre-commit gates (gitleaks, typecheck, secrets) green on commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal backlog planning documents outlining planned initiatives for future development, including meme ingestion improvements, infrastructure cleanup, animated media support, recommendation engine features, and dependency management updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->