### PR TITLE
chore(ingestion): adr 0003 twitter verdict + drop dead screenshot shortcut

### DIFF
--- a/apps/extension/CLAUDE.md
+++ b/apps/extension/CLAUDE.md
@@ -256,7 +256,7 @@ Provides high compatibility without user intervention.
 - ✅ CORS-aware image fetching
 
 **Not Implemented (Future Phases):**
-- Screenshot crop tool (keyboard shortcut registered but no UI)
+- Screenshot crop tool (not started; the old dead shortcut registration was removed)
 - Offline upload queue (IndexedDB)
 - Upload retry logic
 - Progress indicator

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -90,15 +90,6 @@ export default defineConfig({
       action: {
         default_popup: 'popup.html',
       },
-      commands: {
-        'capture-screenshot': {
-          suggested_key: {
-            default: 'Ctrl+Shift+S',
-            mac: 'Command+Shift+S',
-          },
-          description: 'Capture screenshot selection',
-        },
-      },
     };
   },
 });

--- a/backlog.d/026-ingest-memes-where-they-live.md
+++ b/backlog.d/026-ingest-memes-where-they-live.md
@@ -1,6 +1,6 @@
 # Ingest memes where they live
 
-Priority: P1 · Status: pending · Estimate: XL
+Priority: P1 · Status: in-progress · Estimate: XL
 
 ## Goal
 
@@ -39,11 +39,22 @@ search, and taste all need library mass.
 
 ## Children
 
-1. PWA share-target: manifest entry + POST receiver route + device QA.
-2. URL import: paste-a-URL field in the upload zone + server-side fetch
-   with size/MIME validation and dedupe.
+1. ~~PWA share-target: manifest entry + POST receiver route + device QA.~~
+   DONE — PR #216, evidence `docs/qa/evidence/2026-06-10-share-target/`.
+   Real-device share-sheet QA remains residual (simulated multipart
+   navigation POSTs only).
+2. ~~URL import: paste-a-URL field in the upload zone + server-side fetch
+   with size/MIME validation and dedupe.~~
+   DONE — PR #217, evidence `docs/qa/evidence/2026-06-10-url-import/`.
 3. Persist the upload queue to IndexedDB; retry on reconnect/refresh.
-4. Bulk import v1: zip/folder of images with progress + dedupe summary.
-5. Decide screenshot capture: build the crop UI or delete the shortcut.
-6. Investigate Twitter/X bookmark import feasibility (API access, cost);
-   emit or kill with a written verdict.
+4. Bulk import v1: zip/folder of images with progress + dedupe summary —
+   per ADR 0003, also accept bookmarks-export JSON/CSV (media URLs routed
+   through the URL-import pipeline).
+5. ~~Decide screenshot capture: build the crop UI or delete the shortcut.~~
+   DONE — dead `capture-screenshot` registration removed from
+   `wxt.config.ts`; crop tool stays future scope.
+6. ~~Investigate Twitter/X bookmark import feasibility; emit or kill with a
+   written verdict.~~
+   DONE — `docs/adr/0003-no-twitter-bookmark-api-integration.md`: no API
+   integration ($200/mo tier, ~800-bookmark cap, account archive excludes
+   bookmarks); ingest exporter JSON/CSV via child 4 instead.

--- a/docs/adr/0003-no-twitter-bookmark-api-integration.md
+++ b/docs/adr/0003-no-twitter-bookmark-api-integration.md
@@ -1,0 +1,49 @@
+# ADR 0003: No Twitter/X bookmark API integration; ingest exports instead
+
+- Status: Accepted
+- Date: 2026-06-10
+
+## Context
+
+The 026 ingestion epic (child 6) asked for a feasibility verdict on
+importing a user's Twitter/X bookmarks, since the vision names "memes
+scattered across Twitter bookmarks" as a core acquisition source.
+
+Findings (researched 2026-06-10):
+
+- The official X API v2 `GET /2/users/{id}/bookmarks` endpoint requires a
+  paid developer tier. Basic is $200/month ($2,100/year); usage-priced
+  reads are ~$0.005 per post. A personal meme app cannot carry that cost,
+  and OAuth onboarding (user authorizes a Sploot X app) adds heavy surface
+  for one import.
+- The official API caps bookmark access at the most recent ~800 bookmarks.
+- X's own account data archive **excludes bookmarks**, so there is no
+  official no-code export either.
+- The working ecosystem answer is browser-side export: userscripts and
+  extensions (twitter-web-exporter, XSaved, Xporter, cookie-based CLIs)
+  that capture the user's own GraphQL traffic on x.com/i/bookmarks and emit
+  JSON/CSV with tweet URLs and media URLs. These are ToS-gray, brittle, and
+  third-party — fine for users to run themselves, wrong for Sploot to ship
+  or depend on server-side.
+
+## Decision
+
+Do not build an X API/OAuth bookmark integration, and do not ship scraping.
+
+Instead, meet the export files where they land:
+
+1. Bulk import (026 child 4) accepts, alongside zips of images, a
+   JSON/CSV bookmarks export from the common exporter tools; Sploot
+   extracts media URLs and ingests each through the existing
+   SSRF-guarded URL-import pipeline (`lib/upload/url-import.ts`) with
+   checksum dedupe.
+2. The Chrome extension's right-click save already works on x.com images
+   today for one-at-a-time saves.
+
+## Consequences
+
+- Zero recurring API cost; no OAuth app review; no scraping liability.
+- Users need a one-time third-party export step, which we document rather
+  than automate.
+- Revisit only if X ships an affordable bookmarks read tier or includes
+  bookmarks in the account archive.


### PR DESCRIPTION
## Summary

Children 5 and 6 of the 026 ingestion epic — both "stop lying" items, no new feature surface.

- **ADR 0003** (`docs/adr/0003-no-twitter-bookmark-api-integration.md`): no X API/OAuth bookmark integration. Researched 2026-06-10: the bookmarks endpoint needs the $200/mo Basic tier, caps at ~800 bookmarks, and X's account archive excludes bookmarks entirely. The working ecosystem path is browser-side exporters (JSON/CSV); bulk import (child 4) will accept those files and route media URLs through the already-shipped SSRF-guarded URL-import pipeline.
- **Extension**: removed the `capture-screenshot` command registration from `wxt.config.ts` — verified no `onCommand` handler exists anywhere, so Cmd+Shift+S was a dead promise in the manifest. Built manifest confirmed to carry no `commands` key. Crop tool stays future scope as a deliberate ticket if ever wanted.
- Ticket 026 children annotated with outcomes (1, 2, 5, 6 done; 3, 4 remaining).

## Verification

`pnpm --filter extension build` green; `dist/chrome-mv3/manifest.json` contains no `commands` key. Docs/backlog otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision document outlining the strategy for importing Twitter/X bookmarks using user-provided export files in JSON or CSV format, routed through the existing import pipeline.

* **Bug Fixes**
  * Removed an unused keyboard shortcut registration for screenshot capture functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->