### PR TITLE
feat(web): personal upload tokens for iOS share-sheet ingestion (033)

### DIFF
--- a/apps/web/__tests__/api/auth-unauthorized-contracts.test.ts
+++ b/apps/web/__tests__/api/auth-unauthorized-contracts.test.ts
@@ -132,6 +132,13 @@ function makeRequest(pathname: string, method: string): NextRequest {
   return new NextRequest(`http://localhost:3000${pathname}`, { method });
 }
 
+function makeTokenRequest(pathname: string, method: string): NextRequest {
+  return new NextRequest(`http://localhost:3000${pathname}`, {
+    method,
+    headers: { authorization: 'Bearer splt_smoke_token' },
+  });
+}
+
 describe('auth error contracts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -256,5 +263,38 @@ describe('auth error contracts', () => {
       expect(response.status).toBe(401);
       await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
     }
+  });
+});
+
+// End-to-end confirmation of the upload-only guarantee proven at the unit level
+// in upload-token-scope.test.ts: a personal upload token is inert on every route
+// that did not opt in with `allowUploadToken`. A `splt_` bearer presented to a
+// door-2 route (server.ts, which never reaches the verifier) and to an
+// upload-adjacent route that stayed Clerk-only must still return the stable 401.
+describe('personal upload tokens authenticate only on opt-in routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAuth.mockResolvedValue({ userId: null, sessionId: null, getToken: vi.fn() });
+    mocks.getAuthWithUser.mockResolvedValue({
+      userId: null,
+      sessionId: null,
+      getToken: vi.fn(),
+      syncStatus: 'skipped',
+    });
+    mocks.requireUserIdWithSync.mockRejectedValue(new Error('Unauthorized'));
+    mocks.verifyBearerOrThrow.mockRejectedValue(new Error('Unauthorized'));
+  });
+
+  it('rejects a splt_ token on the door-2 route DELETE /api/assets/[id]', async () => {
+    const context = { params: Promise.resolve({ id: 'asset-123' }) };
+    const response = await deleteAsset(makeTokenRequest('/api/assets/asset-123', 'DELETE'), context);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('rejects a splt_ token on the Clerk-only route POST /api/upload/check', async () => {
+    const response = await checkUpload(makeTokenRequest('/api/upload/check', 'POST'));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
   });
 });

--- a/apps/web/__tests__/api/upload-token-opt-in.test.ts
+++ b/apps/web/__tests__/api/upload-token-opt-in.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * Wiring proof: /api/upload must actually opt into upload-token auth, otherwise
+ * the whole feature is inert. The resolver-level scope test
+ * (upload-token-scope.test.ts) proves the gate; this proves the route passes
+ * allowUploadToken: true through it.
+ */
+
+const mocks = vi.hoisted(() => ({
+  authenticateRequest: vi.fn(),
+  ingestImage: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ unstable_rethrow: vi.fn() }));
+vi.mock('@/lib/auth/request-auth', () => ({ authenticateRequest: mocks.authenticateRequest }));
+vi.mock('@/lib/auth/api', () => ({
+  isUnauthorizedAuthError: () => false,
+  unauthorizedResponse: () => Response.json({ error: 'Unauthorized' }, { status: 401 }),
+}));
+vi.mock('@/lib/env', () => ({ blobConfigured: true }));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('@/lib/with-observability', () => ({ withObservability: (handler: any) => handler }));
+vi.mock('@/lib/runtime-gates', () => ({
+  getRuntimeGate: () => ({ name: 'uploads', enabled: true }),
+  runtimeGateResponse: () => Response.json({ error: 'disabled' }, { status: 503 }),
+}));
+vi.mock('@/lib/upload/ingest-image', () => ({ ingestImage: mocks.ingestImage }));
+vi.mock('@/lib/quota/storage-quota-policy', () => ({
+  StorageQuotaExceededError: class StorageQuotaExceededError extends Error {},
+  storageQuotaError: () => ({ error: 'quota' }),
+}));
+
+import { POST } from '@/app/api/upload/route';
+
+function multipartReq(): NextRequest {
+  const form = new FormData();
+  form.append('file', new File([new Uint8Array([1, 2, 3])], 'meme.png', { type: 'image/png' }));
+  return new NextRequest('http://localhost:3000/api/upload', { method: 'POST', body: form });
+}
+
+beforeEach(() => {
+  mocks.authenticateRequest.mockReset();
+  mocks.ingestImage.mockReset();
+});
+
+describe('/api/upload opts into upload-token auth', () => {
+  it('calls authenticateRequest with { allowUploadToken: true }', async () => {
+    mocks.authenticateRequest.mockResolvedValue({
+      status: 'authenticated',
+      principal: { userId: 'u1' },
+      syncStatus: 'skipped',
+    });
+    mocks.ingestImage.mockResolvedValue({ kind: 'created', asset: { id: 'a1' } });
+
+    const res = await POST(multipartReq(), {} as any);
+
+    expect(res.status).toBe(201);
+    expect(mocks.authenticateRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ allowUploadToken: true })
+    );
+  });
+
+  it('returns the stable 401 when the token is rejected', async () => {
+    mocks.authenticateRequest.mockResolvedValue({ status: 'unauthenticated', reason: 'upload-token-invalid' });
+
+    const res = await POST(multipartReq(), {} as any);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(mocks.ingestImage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/api/upload-tokens.test.ts
+++ b/apps/web/__tests__/api/upload-tokens.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateRequest: vi.fn(),
+  findMany: vi.fn(),
+  count: vi.fn(),
+  create: vi.fn(),
+  updateMany: vi.fn(),
+  mintUploadToken: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/request-auth', () => ({ authenticateRequest: mocks.authenticateRequest }));
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    uploadToken: {
+      findMany: mocks.findMany,
+      count: mocks.count,
+      create: mocks.create,
+      updateMany: mocks.updateMany,
+    },
+  },
+}));
+vi.mock('@/lib/auth/upload-token', () => ({ mintUploadToken: mocks.mintUploadToken }));
+
+import { NextRequest } from 'next/server';
+import { GET, POST } from '@/app/api/upload-tokens/route';
+import { DELETE } from '@/app/api/upload-tokens/[id]/route';
+
+const USER = 'user_1';
+
+function authed() {
+  mocks.authenticateRequest.mockResolvedValue({
+    status: 'authenticated',
+    principal: { userId: USER },
+    syncStatus: 'skipped',
+  });
+}
+
+function unauthed() {
+  mocks.authenticateRequest.mockResolvedValue({ status: 'unauthenticated', reason: 'x' });
+}
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/upload-tokens', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function getReq(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/upload-tokens');
+}
+
+function deleteReq(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/upload-tokens/tok_1', { method: 'DELETE' });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) }) as any;
+
+beforeEach(() => {
+  Object.values(mocks).forEach(m => m.mockReset());
+});
+
+describe('POST /api/upload-tokens (mint)', () => {
+  it('returns the plaintext token exactly once and persists only the hash', async () => {
+    authed();
+    mocks.count.mockResolvedValue(0);
+    mocks.mintUploadToken.mockResolvedValue({
+      token: 'splt_PLAINTEXT_ONCE',
+      prefix: 'splt_abc123',
+      tokenHash: 'a'.repeat(64),
+    });
+    mocks.create.mockResolvedValue({
+      id: 'tok_1',
+      name: 'phone',
+      prefix: 'splt_abc123',
+      createdAt: new Date('2026-06-18T00:00:00Z'),
+    });
+
+    const res = await POST(postReq({ name: 'phone' }), {} as any);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.token).toBe('splt_PLAINTEXT_ONCE');
+
+    // Persists hash + prefix, NEVER the plaintext.
+    const createArg = mocks.create.mock.calls[0][0];
+    expect(createArg.data.tokenHash).toBe('a'.repeat(64));
+    expect(createArg.data.prefix).toBe('splt_abc123');
+    expect(JSON.stringify(createArg.data)).not.toContain('splt_PLAINTEXT_ONCE');
+  });
+
+  it('rejects a missing/blank name with 400', async () => {
+    authed();
+    const res = await POST(postReq({ name: '   ' }), {} as any);
+    expect(res.status).toBe(400);
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('enforces the active-token cap with 422', async () => {
+    authed();
+    mocks.count.mockResolvedValue(10);
+    const res = await POST(postReq({ name: 'eleventh' }), {} as any);
+    expect(res.status).toBe(422);
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    unauthed();
+    const res = await POST(postReq({ name: 'phone' }), {} as any);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+  });
+});
+
+describe('GET /api/upload-tokens (list)', () => {
+  it('lists metadata and never selects the secret hash or plaintext', async () => {
+    authed();
+    mocks.findMany.mockResolvedValue([
+      { id: 'tok_1', name: 'phone', prefix: 'splt_abc123', lastUsedAt: null, createdAt: new Date() },
+    ]);
+
+    const res = await GET(getReq(), {} as any);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0]).not.toHaveProperty('tokenHash');
+
+    // The query must be scoped to the caller and exclude the hash.
+    const findArg = mocks.findMany.mock.calls[0][0];
+    expect(findArg.where).toEqual({ userId: USER, revokedAt: null });
+    expect(findArg.select.tokenHash).toBeUndefined();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    unauthed();
+    const res = await GET(getReq(), {} as any);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/upload-tokens/[id] (revoke)', () => {
+  it('soft-revokes only the caller\'s own un-revoked token', async () => {
+    authed();
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await DELETE(deleteReq(), ctx('tok_1'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    const arg = mocks.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: 'tok_1', userId: USER, revokedAt: null });
+    expect(arg.data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('is idempotent: revoking a missing/already-revoked token still succeeds', async () => {
+    authed();
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await DELETE(deleteReq(), ctx('tok_gone'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    unauthed();
+    const res = await DELETE(deleteReq(), ctx('tok_1'));
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/__tests__/lib/auth/upload-token-scope.test.ts
+++ b/apps/web/__tests__/lib/auth/upload-token-scope.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The real scope falsifier. "Upload-only" is not proven by hitting routes that
+ * can't reach the token branch — it is proven here: the branch is entered ONLY
+ * when a route opts in with allowUploadToken, and the verifier is never even
+ * called otherwise. Plus a guard that the second auth door (server.ts) stays
+ * token-blind.
+ */
+
+const mocks = vi.hoisted(() => ({
+  verifyUploadToken: vi.fn(),
+}));
+
+// Keep the real extractUploadToken / prefix; stub only the verifier so we can
+// assert whether the branch was entered.
+vi.mock('@/lib/auth/upload-token', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/upload-token')>();
+  return { ...actual, verifyUploadToken: mocks.verifyUploadToken };
+});
+
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '@/lib/auth/request-auth';
+
+// Empty env → no Clerk config, so the ONLY path that can authenticate this
+// request is the upload-token branch. If it stays unauthenticated, the branch
+// did not fire.
+const ENV_NO_CLERK: Record<string, string | undefined> = {};
+
+function requestWithToken(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/anything', {
+    headers: { authorization: 'Bearer splt_valid' },
+  });
+}
+
+const VALID_PRINCIPAL = {
+  userId: 'user_42',
+  provider: 'upload-token' as const,
+  providerSubject: 'user_42',
+  source: 'upload-token' as const,
+  credentialKind: 'upload-token' as const,
+};
+
+beforeEach(() => {
+  mocks.verifyUploadToken.mockReset();
+});
+
+describe('upload-token scope is deny-by-default', () => {
+  it('does NOT enter the token branch under the default policy', async () => {
+    const result = await authenticateRequest(requestWithToken(), { env: ENV_NO_CLERK });
+
+    expect(mocks.verifyUploadToken).not.toHaveBeenCalled();
+    expect(result.status).toBe('unauthenticated');
+  });
+
+  it('does NOT enter the token branch when allowUploadToken is explicitly false', async () => {
+    const result = await authenticateRequest(requestWithToken(), {
+      allowUploadToken: false,
+      env: ENV_NO_CLERK,
+    });
+
+    expect(mocks.verifyUploadToken).not.toHaveBeenCalled();
+    expect(result.status).toBe('unauthenticated');
+  });
+
+  it('enters the branch and authenticates only when a route opts in', async () => {
+    mocks.verifyUploadToken.mockResolvedValue(VALID_PRINCIPAL);
+
+    const result = await authenticateRequest(requestWithToken(), {
+      allowUploadToken: true,
+      env: ENV_NO_CLERK,
+    });
+
+    expect(mocks.verifyUploadToken).toHaveBeenCalledWith('splt_valid');
+    expect(result.status).toBe('authenticated');
+  });
+
+  it('rejects a bad token on an opted-in route without falling through to Clerk', async () => {
+    mocks.verifyUploadToken.mockResolvedValue(null);
+
+    const result = await authenticateRequest(requestWithToken(), {
+      allowUploadToken: true,
+      env: ENV_NO_CLERK,
+    });
+
+    expect(result.status).toBe('unauthenticated');
+    if (result.status === 'unauthenticated') {
+      expect(result.reason).toBe('upload-token-invalid');
+    }
+  });
+});
+
+describe('the second auth door stays token-blind', () => {
+  it('lib/auth/server.ts contains no upload-token reference', () => {
+    // Tests run with cwd = apps/web (pnpm --filter web test).
+    const serverPath = resolve(process.cwd(), 'lib/auth/server.ts');
+    const source = readFileSync(serverPath, 'utf8');
+    expect(source).not.toMatch(/splt_|upload-token|allowUploadToken|verifyUploadToken/);
+  });
+});

--- a/apps/web/__tests__/lib/auth/upload-token.test.ts
+++ b/apps/web/__tests__/lib/auth/upload-token.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  updateMany: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    uploadToken: {
+      findFirst: mocks.findFirst,
+      updateMany: mocks.updateMany,
+    },
+  },
+}));
+
+vi.mock('@/lib/observability-logger', () => ({
+  logger: { logError: vi.fn(), logInfo: vi.fn(), logTiming: vi.fn() },
+}));
+
+import {
+  mintUploadToken,
+  extractUploadToken,
+  hashUploadToken,
+  verifyUploadToken,
+  UPLOAD_TOKEN_PREFIX,
+} from '@/lib/auth/upload-token';
+
+beforeEach(() => {
+  mocks.findFirst.mockReset();
+  mocks.updateMany.mockReset();
+  mocks.updateMany.mockResolvedValue({ count: 1 });
+});
+
+describe('mintUploadToken', () => {
+  it('produces a splt_-prefixed token whose hash matches and a non-secret prefix', async () => {
+    const minted = await mintUploadToken();
+    expect(minted.token.startsWith(UPLOAD_TOKEN_PREFIX)).toBe(true);
+    expect(minted.prefix.startsWith(UPLOAD_TOKEN_PREFIX)).toBe(true);
+    expect(minted.token.startsWith(minted.prefix)).toBe(true);
+    expect(minted.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(await hashUploadToken(minted.token)).toBe(minted.tokenHash);
+  });
+
+  it('produces a unique token and hash each call', async () => {
+    const a = await mintUploadToken();
+    const b = await mintUploadToken();
+    expect(a.token).not.toBe(b.token);
+    expect(a.tokenHash).not.toBe(b.tokenHash);
+  });
+});
+
+describe('extractUploadToken', () => {
+  const tok = 'splt_abc123';
+
+  it('returns the token for a splt_ Bearer header', () => {
+    expect(extractUploadToken(new Headers({ authorization: `Bearer ${tok}` }))).toBe(tok);
+  });
+
+  it('is case-insensitive on the Bearer scheme', () => {
+    expect(extractUploadToken(new Headers({ authorization: `bearer ${tok}` }))).toBe(tok);
+  });
+
+  it('returns null for a Clerk session JWT (eyJ…), never mistaking it for a token', () => {
+    expect(extractUploadToken(new Headers({ authorization: 'Bearer eyJhbGciOi.payload.sig' }))).toBeNull();
+  });
+
+  it('returns null when there is no Authorization header', () => {
+    expect(extractUploadToken(new Headers())).toBeNull();
+  });
+
+  it('returns null for a non-Bearer scheme', () => {
+    expect(extractUploadToken(new Headers({ authorization: `Basic ${tok}` }))).toBeNull();
+  });
+});
+
+describe('verifyUploadToken', () => {
+  it('resolves a valid token to an upload-token principal', async () => {
+    mocks.findFirst.mockResolvedValue({ id: 'tok_1', userId: 'user_42' });
+
+    const principal = await verifyUploadToken('splt_valid');
+
+    expect(principal).toEqual({
+      userId: 'user_42',
+      provider: 'upload-token',
+      providerSubject: 'user_42',
+      source: 'upload-token',
+      credentialKind: 'upload-token',
+    });
+  });
+
+  it('bumps last-used best-effort, guarded on revokedAt: null', async () => {
+    mocks.findFirst.mockResolvedValue({ id: 'tok_1', userId: 'user_42' });
+
+    await verifyUploadToken('splt_valid');
+
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: { id: 'tok_1', revokedAt: null },
+      data: expect.objectContaining({ lastUsedAt: expect.any(Date) }),
+    });
+  });
+
+  it('only queries un-revoked rows (revoked ≡ unknown)', async () => {
+    mocks.findFirst.mockResolvedValue(null);
+
+    await verifyUploadToken('splt_x');
+
+    expect(mocks.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ revokedAt: null }) })
+    );
+  });
+
+  it('returns null for a revoked or unknown token', async () => {
+    mocks.findFirst.mockResolvedValue(null);
+    expect(await verifyUploadToken('splt_revoked_or_unknown')).toBeNull();
+  });
+
+  it('is throw-safe: a DB error resolves to null, never throws (→ 401, not 500)', async () => {
+    mocks.findFirst.mockRejectedValue(new Error('relation "upload_tokens" does not exist'));
+    await expect(verifyUploadToken('splt_x')).resolves.toBeNull();
+  });
+});

--- a/apps/web/app/api/upload-tokens/[id]/route.ts
+++ b/apps/web/app/api/upload-tokens/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuthenticatedApi } from '@/lib/auth/with-authenticated-api';
+import { withObservability } from '@/lib/with-observability';
+import type { RouteContext } from '@/lib/with-observability';
+import { prisma } from '@/lib/db';
+
+/**
+ * DELETE /api/upload-tokens/[id] - revoke a personal upload token.
+ *
+ * Session-authenticated (default policy; an upload token cannot revoke tokens).
+ * Soft revoke (sets revoked_at). Ownership-checked and idempotent: the update is
+ * scoped to the caller's own, not-already-revoked token, so revoking a token
+ * that is missing, already revoked, or owned by someone else is a no-op that
+ * still returns success and reveals nothing.
+ */
+const deleteHandler = withAuthenticatedApi(
+  async (_req: NextRequest, context: RouteContext, { principal }) => {
+    if (!prisma) {
+      return NextResponse.json({ error: 'Database unavailable' }, { status: 503 });
+    }
+
+    const { id } = await context.params;
+    if (!id) {
+      return NextResponse.json({ error: 'token not found' }, { status: 404 });
+    }
+
+    await prisma.uploadToken.updateMany({
+      where: { id, userId: principal.userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+
+    return NextResponse.json({ success: true });
+  }
+);
+
+export const DELETE = withObservability(deleteHandler, { operation: 'upload-tokens:revoke' });

--- a/apps/web/app/api/upload-tokens/route.ts
+++ b/apps/web/app/api/upload-tokens/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuthenticatedApi } from '@/lib/auth/with-authenticated-api';
+import { withObservability } from '@/lib/with-observability';
+import { prisma } from '@/lib/db';
+import { mintUploadToken } from '@/lib/auth/upload-token';
+
+/**
+ * Personal upload token management. These routes are session-authenticated
+ * (Clerk cookie/bearer, or the qa-local harness) via the default auth policy —
+ * they do NOT set allowUploadToken, so an upload token cannot mint or list
+ * tokens. See lib/auth/upload-token.ts.
+ */
+
+// Generous enough for a few named tokens (phone, laptop, CLI); bounds growth.
+const MAX_ACTIVE_TOKENS = 10;
+const MAX_NAME_LENGTH = 64;
+
+const getHandler = withAuthenticatedApi(async (_req: NextRequest, _context, { principal }) => {
+  if (!prisma) {
+    return NextResponse.json({ error: 'Database unavailable' }, { status: 503 });
+  }
+
+  const tokens = await prisma.uploadToken.findMany({
+    where: { userId: principal.userId, revokedAt: null },
+    select: { id: true, name: true, prefix: true, lastUsedAt: true, createdAt: true },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return NextResponse.json({ tokens });
+});
+
+const postHandler = withAuthenticatedApi(async (req: NextRequest, _context, { principal }) => {
+  if (!prisma) {
+    return NextResponse.json({ error: 'Database unavailable' }, { status: 503 });
+  }
+
+  let rawName: unknown;
+  try {
+    const body = await req.json();
+    rawName = body?.name;
+  } catch {
+    rawName = undefined;
+  }
+
+  const name = typeof rawName === 'string' ? rawName.trim() : '';
+  if (!name) {
+    return NextResponse.json({ error: 'give your token a name' }, { status: 400 });
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    return NextResponse.json(
+      { error: `name must be ${MAX_NAME_LENGTH} characters or fewer` },
+      { status: 400 }
+    );
+  }
+
+  const activeCount = await prisma.uploadToken.count({
+    where: { userId: principal.userId, revokedAt: null },
+  });
+  if (activeCount >= MAX_ACTIVE_TOKENS) {
+    return NextResponse.json(
+      { error: `you can have at most ${MAX_ACTIVE_TOKENS} active tokens — revoke one first` },
+      { status: 422 }
+    );
+  }
+
+  const minted = await mintUploadToken();
+  const created = await prisma.uploadToken.create({
+    data: {
+      userId: principal.userId,
+      name,
+      tokenHash: minted.tokenHash,
+      prefix: minted.prefix,
+    },
+    select: { id: true, name: true, prefix: true, createdAt: true },
+  });
+
+  // The plaintext token is returned exactly once here and never stored or
+  // returned again. Only its sha256 (minted.tokenHash) is persisted.
+  return NextResponse.json({ ...created, token: minted.token }, { status: 201 });
+});
+
+export const GET = withObservability(getHandler, {
+  operation: 'upload-tokens:list',
+  skipTiming: true,
+});
+export const POST = withObservability(postHandler, { operation: 'upload-tokens:mint' });

--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -36,8 +36,10 @@ async function postHandler(req: NextRequest) {
     const url = new URL(req.url);
     const syncEmbeddings = url.searchParams.get('sync_embeddings') === 'true';
 
-    // Authenticate user (Clerk bearer/cookies, or the qa-local harness)
-    const auth = await authenticateRequest(req);
+    // Authenticate user: Clerk bearer/cookies, the qa-local harness, or a
+    // personal upload token (Apple Shortcut / CLI). allowUploadToken is what
+    // makes this an upload-only credential — no other route opts in.
+    const auth = await authenticateRequest(req, { allowUploadToken: true });
     if (auth.status !== 'authenticated') {
       return unauthorizedResponse();
     }

--- a/apps/web/app/api/upload/url/route.ts
+++ b/apps/web/app/api/upload/url/route.ts
@@ -95,6 +95,6 @@ const postHandler = withAuthenticatedApi(async (req: NextRequest, _context, { pr
 
     return NextResponse.json({ success: false, error: 'Upload failed' }, { status: 500 });
   }
-});
+}, { allowUploadToken: true });
 
 export const POST = withObservability(postHandler, { operation: 'upload:url' });

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useAuthUser, useAuthActions } from '@/lib/auth/client';
 import { usePwaInstallPrompt } from '@/hooks/use-pwa-install';
+import { UploadTokensCard } from '@/components/settings/upload-tokens-card';
 import { cn } from '@/lib/utils';
 // Fallback while /api/version (latest landfall release tag) loads.
 const APP_VERSION_FALLBACK = process.env.NEXT_PUBLIC_APP_VERSION || 'v0';
@@ -135,6 +136,8 @@ export default function SettingsPage() {
         </div>
       </section>
 
+      <UploadTokensCard />
+
       <section className="bg-card border border-border p-5 space-y-3">
         <div>
           <h2 className="text-lg font-semibold text-foreground">Install as app</h2>
@@ -180,9 +183,9 @@ export default function SettingsPage() {
 
         <p className="text-xs text-muted-foreground">
           Heads up: sharing images into Sploot from other apps&apos; share
-          sheets works on Android. iPhones don&apos;t let web apps into the
-          share sheet — copy an image and paste it into the upload zone
-          instead.
+          sheets works on Android. iPhones can&apos;t put web apps in the share
+          sheet — mint an upload token above and wire up the &ldquo;Save to
+          Sploot&rdquo; shortcut to share images from any iOS app.
         </p>
       </section>
 

--- a/apps/web/components/settings/upload-tokens-card.tsx
+++ b/apps/web/components/settings/upload-tokens-card.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface UploadToken {
+  id: string;
+  name: string;
+  prefix: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+interface MintedToken extends UploadToken {
+  token: string;
+}
+
+const UPLOAD_ENDPOINT = '/api/upload';
+
+function formatWhen(value: string | null): string {
+  if (!value) return 'never used';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+export function UploadTokensCard() {
+  const [tokens, setTokens] = useState<UploadToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+  const [name, setName] = useState('');
+  const [minting, setMinting] = useState(false);
+  const [justMinted, setJustMinted] = useState<MintedToken | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/upload-tokens');
+        if (!res.ok) {
+          if (!cancelled) setUnavailable(true);
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) setTokens(Array.isArray(data.tokens) ? data.tokens : []);
+      } catch {
+        if (!cancelled) setUnavailable(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const mint = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || minting) return;
+
+    setMinting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/upload-tokens', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data.error === 'string' ? data.error : 'could not mint a token');
+        return;
+      }
+
+      setJustMinted(data as MintedToken);
+      setCopied(false);
+      setTokens((prev) => [
+        { id: data.id, name: data.name, prefix: data.prefix, lastUsedAt: null, createdAt: data.createdAt },
+        ...prev,
+      ]);
+      setName('');
+    } catch {
+      setError('could not mint a token');
+    } finally {
+      setMinting(false);
+    }
+  };
+
+  const revoke = async (id: string) => {
+    const previous = tokens;
+    // Optimistic: drop it immediately, roll back if the request fails.
+    setTokens((current) => current.filter((token) => token.id !== id));
+    if (justMinted?.id === id) setJustMinted(null);
+
+    try {
+      const res = await fetch(`/api/upload-tokens/${id}`, { method: 'DELETE' });
+      if (!res.ok) setTokens(previous);
+    } catch {
+      setTokens(previous);
+    }
+  };
+
+  const copyToken = async () => {
+    if (!justMinted) return;
+    try {
+      await navigator.clipboard.writeText(justMinted.token);
+      setCopied(true);
+    } catch {
+      // Clipboard blocked — the value is visible for manual selection.
+    }
+  };
+
+  return (
+    <section className="bg-card border border-border p-5 space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Upload tokens</h2>
+        <p className="text-muted-foreground text-sm mt-1">
+          Mint a key for the &ldquo;Save to Sploot&rdquo; iPhone shortcut (or any
+          uploader). It can <span className="text-foreground">only upload</span> —
+          never read or delete your library — and you see the secret exactly once.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') mint();
+          }}
+          maxLength={64}
+          placeholder="name it (e.g. iphone)"
+          className="flex-1 min-w-[12rem] bg-background border border-border px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary"
+        />
+        <button
+          onClick={mint}
+          disabled={minting || name.trim().length === 0}
+          className={cn(
+            'inline-flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors',
+            'bg-primary text-primary-foreground hover:bg-primary/90',
+            (minting || name.trim().length === 0) && 'opacity-60 cursor-not-allowed'
+          )}
+        >
+          {minting ? 'minting…' : 'mint token'}
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {justMinted && (
+        <div className="bg-background border border-primary/40 p-3 space-y-2">
+          <p className="text-xs text-muted-foreground">
+            copy it now — this is the only time it&apos;s shown. paste it into your shortcut.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 break-all font-mono text-sm text-foreground">{justMinted.token}</code>
+            <button
+              onClick={copyToken}
+              className="shrink-0 inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              {copied ? 'copied' : 'copy'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">loading your tokens…</p>
+      ) : unavailable ? (
+        <p className="text-sm text-muted-foreground">tokens aren&apos;t available right now.</p>
+      ) : tokens.length === 0 ? (
+        <p className="text-sm text-muted-foreground">no tokens yet. mint one to wire up the iPhone shortcut below.</p>
+      ) : (
+        <ul className="divide-y divide-border border border-border">
+          {tokens.map((token) => (
+            <li key={token.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
+              <div className="min-w-0">
+                <p className="text-sm text-foreground truncate">{token.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-mono">{token.prefix}…</span> · {formatWhen(token.lastUsedAt)}
+                </p>
+              </div>
+              <button
+                onClick={() => revoke(token.id)}
+                className="shrink-0 inline-flex items-center px-3 py-1.5 text-xs font-medium bg-destructive/20 text-destructive hover:bg-destructive/30 transition-colors"
+              >
+                revoke
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <details className="text-sm">
+        <summary className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
+          how to set up the &ldquo;Save to Sploot&rdquo; iPhone shortcut
+        </summary>
+        <ol className="mt-3 space-y-1.5 text-muted-foreground list-decimal list-inside">
+          <li>open the Shortcuts app → <span className="text-foreground">+</span> → add an action.</li>
+          <li>
+            add <span className="text-foreground">Get Contents of URL</span>, set it to{' '}
+            <code className="font-mono text-foreground break-all">{UPLOAD_ENDPOINT}</code> on this site,
+            method <span className="text-foreground">POST</span>.
+          </li>
+          <li>
+            add a header <code className="font-mono text-foreground">Authorization</code> ={' '}
+            <code className="font-mono text-foreground">Bearer &lt;your token&gt;</code>.
+          </li>
+          <li>
+            request body <span className="text-foreground">Form</span>, add a field{' '}
+            <code className="font-mono text-foreground">file</code> set to the Shortcut Input (the shared image).
+          </li>
+          <li>
+            in the shortcut settings, turn on <span className="text-foreground">Show in Share Sheet</span> and
+            accept Images. now <span className="text-foreground">Share → Save to Sploot</span> from any app.
+          </li>
+        </ol>
+        <p className="mt-2 text-xs text-muted-foreground">
+          full recipe: <span className="font-mono">apps/web/docs/shortcuts/save-to-sploot.md</span>
+        </p>
+      </details>
+    </section>
+  );
+}

--- a/apps/web/docs/API.md
+++ b/apps/web/docs/API.md
@@ -19,7 +19,10 @@ User-facing product APIs require authentication through Sploot's auth boundary.
 Production requests are still Clerk-backed. Local and CI authenticated smoke
 tests may use the signed `qa-local` mode documented in `apps/web/docs/AUTH.md`.
 Operational routes such as health and cron endpoints define their own auth
-contracts.
+contracts. The upload routes (`/api/upload`, `/api/upload/url`) additionally
+accept a personal **upload token** (`Authorization: Bearer splt_…`) for
+non-session clients like the iPhone shortcut — see [Personal Upload
+Tokens](#personal-upload-tokens) below.
 
 ### Auth Boundary
 
@@ -49,7 +52,8 @@ with status `401`.
 
 Protected product API route inventory:
 
-- `/api/upload`, `/api/upload/check`
+- `/api/upload`, `/api/upload/url`, `/api/upload/check`
+- `/api/upload-tokens`, `/api/upload-tokens/{id}` (session-only; manage upload tokens)
 - `/api/assets`, `/api/assets/{id}`, `/api/assets/{id}/tags`, `/api/assets/audit`, `/api/assets/{id}/share`, `/api/assets/{id}/similar`
 - `/api/assets/{id}/embedding-status`, `/api/assets/batch/embedding-status`, `/api/assets/{id}/generate-embedding`
 - `/api/taste/profile`
@@ -272,6 +276,65 @@ If the user has too few ready embedded assets:
 - 503: Embeddings are paused or the text-anchor embedding service is
   unavailable and anchors are not cached
 - 500: Server error
+
+---
+
+### Personal Upload Tokens
+
+Hashed, revocable, **upload-only** credentials for non-session clients (the
+iPhone "Save to Sploot" shortcut, CLIs, automation). See
+`apps/web/docs/shortcuts/save-to-sploot.md` for the end-user recipe and
+`apps/web/docs/AUTH.md` for the auth model.
+
+These management endpoints are **session-authenticated** (Clerk/qa-local). An
+upload token cannot mint, list, or revoke tokens.
+
+#### POST /api/upload-tokens
+
+Mint a token. The plaintext `token` is returned **once** and never again; only
+its hash is stored.
+
+**Request:** `{ "name": "iphone" }` (1–64 chars)
+
+**Response `201`:**
+
+```json
+{
+  "id": "ckxyz…",
+  "name": "iphone",
+  "prefix": "splt_ab12cd",
+  "createdAt": "2026-06-18T00:00:00Z",
+  "token": "splt_…"
+}
+```
+
+`400` if the name is missing/blank; `422` if you already have the maximum (10)
+active tokens.
+
+#### GET /api/upload-tokens
+
+List your active tokens — metadata only, never the secret or its hash.
+
+```json
+{ "tokens": [ { "id": "…", "name": "iphone", "prefix": "splt_ab12cd", "lastUsedAt": null, "createdAt": "…" } ] }
+```
+
+#### DELETE /api/upload-tokens/{id}
+
+Revoke a token (soft delete). Ownership-checked and idempotent: revoking a
+missing or already-revoked token still returns `{ "success": true }`.
+
+#### Using a token
+
+```bash
+curl -X POST https://www.sploot.app/api/upload \
+  -H "Authorization: Bearer splt_…" \
+  -F "file=@meme.png"
+```
+
+`/api/upload` and `/api/upload/url` accept upload tokens; every other route
+returns `401` for one. Dedupe, quota, and the `201`/`409` contracts are
+identical to a session upload.
 
 ---
 

--- a/apps/web/docs/AUTH.md
+++ b/apps/web/docs/AUTH.md
@@ -10,6 +10,7 @@ request APIs directly.
 |---|---|---|---|
 | `clerk` | default | Clerk cookies or Clerk session bearer token | local, preview, production |
 | `qa-local` | `SPLOOT_QA_AUTH_MODE=enabled` plus `SPLOOT_QA_AUTH_SECRET` | signed Sploot QA token | local and CI only |
+| `upload-token` | always available | hashed personal upload token (`Authorization: Bearer splt_…`) | **upload routes only** (`/api/upload`, `/api/upload/url`) |
 
 `qa-local` is rejected when `NODE_ENV=production` or `VERCEL_ENV=production`,
 even if the mode and secret are present.
@@ -29,6 +30,33 @@ pnpm --filter web e2e:auth
 The smoke starts a local Next server with `qa-local` enabled and opens `/app`
 with a signed deterministic principal. Passing the smoke proves the app auth
 boundary can be crossed without manual Clerk login.
+
+## Upload Tokens
+
+Personal upload tokens let a non-session client (the iPhone "Save to Sploot"
+shortcut, a CLI, automation) authenticate **upload-only** API calls. They exist
+because Apple Shortcuts cannot carry a Clerk session.
+
+- Format: `splt_` + 32 random bytes (base64url). Only `sha256(token)` is stored
+  (`upload_tokens` table); the plaintext is returned once at mint and never
+  again.
+- Scope is enforced by policy, not by a scope field: `authenticateRequest`
+  checks an upload token only when a route passes `allowUploadToken: true`.
+  Just the two upload routes opt in, so a token presented anywhere else returns
+  the stable `401`. The `lib/auth/server.ts` auth path (`getAuth*`, used by
+  read/delete routes) never calls the verifier at all.
+- Verification is throw-safe: a DB error (including a not-yet-migrated table)
+  resolves to `401`, never `500`. Revoked and unknown tokens are
+  indistinguishable.
+- Managed at `/api/upload-tokens` (mint/list) and `/api/upload-tokens/{id}`
+  (revoke), which are **session-authenticated** — an upload token cannot manage
+  tokens. UI: **Settings → Upload tokens**.
+- Implementation: `lib/auth/upload-token.ts`. User recipe:
+  `docs/shortcuts/save-to-sploot.md`.
+
+Because the token is verified against the `upload_tokens` table, the migration
+must be applied to an environment (`prisma migrate deploy`) before the mint
+route works there.
 
 ## QA Data Seeding
 

--- a/apps/web/docs/adr/006-personal-upload-tokens.md
+++ b/apps/web/docs/adr/006-personal-upload-tokens.md
@@ -1,0 +1,66 @@
+# ADR-006: Personal Upload Tokens (upload-only, scope-by-policy)
+
+**Status:** Accepted
+**Date:** 2026-06-18
+**Deciders:** Sploot maintainer
+**Technical Story:** Backlog 033 — get Sploot into the iPhone share sheet. iOS
+(WebKit) has no Web Share Target API, so the Android `share_target` can't reach
+it. Apple Shortcuts are the sanctioned escape hatch, but they cannot carry a
+Clerk session — they need a credential.
+
+## Context
+
+We need a credential a non-session client (an Apple Shortcut, later a CLI) can
+present to the upload API. Requirements from the ticket: mintable/revocable from
+settings, stored hashed, and **upload-only** (it must not be able to read or
+delete the library). Sploot had no token/API-key concept; auth ran through two
+paths — `authenticateRequest` (policy-based, `lib/auth/request-auth.ts`) and
+`getAuth*` (`lib/auth/server.ts`).
+
+## Decision
+
+**1. Opaque hashed PAT, not a stateless signed token.** A token is
+`splt_` + 32 random bytes (base64url). Only `sha256(token)` is stored in a new
+`upload_tokens` table; the plaintext is shown once at mint. A fast hash is
+correct: at 256 bits of entropy there is no low-entropy secret to stretch and
+online guessing is infeasible (the GitHub-PAT rationale), so no bcrypt/argon and
+no constant-time compare — the lookup is an indexed equality on the hash. This
+is required over a stateless HMAC token (qa-local style) because the ticket
+demands *revocable* and *stored hashed*; a stateless token is neither.
+
+**2. Scope is enforced by policy, not a scope field.** `AuthPolicy` gains
+`allowUploadToken` (default `false`). `authenticateRequest` checks an upload
+token only when a route opts in. Exactly two routes opt in (`/api/upload`,
+`/api/upload/url`); every other policy-based route denies by default, and the
+`getAuth*` path never calls the verifier at all. Deny-by-default plus a
+single-function verifier *is* the upload-only guarantee. We rejected a generic
+`scopes` column / API-key platform as speculative — there is one scope today.
+
+**3. Verification is throw-safe and revoked ≡ unknown.** A DB error (including a
+not-yet-migrated table) resolves to `401`, never `500`; revoked and unknown
+tokens are indistinguishable (matched by `revokedAt IS NULL`, so a revoked row
+is simply "not found"). The stable `{ "error": "Unauthorized" }` / `401`
+contract is preserved.
+
+**4. Management endpoints are session-only.** `/api/upload-tokens` (mint/list)
+and `/api/upload-tokens/{id}` (revoke) use the default policy, so an upload
+token cannot manage tokens.
+
+## Consequences
+
+- **Positive:** the iPhone share-sheet path ships; the token also unlocks
+  CLI/automation ingestion. No new ingestion pipeline — `ingestImage()` is
+  reused, so dedupe/quota/embeddings are unchanged. The blast radius of the new
+  credential is one grep (`allowUploadToken`) plus one verifier function.
+- **Invariant to protect:** `lib/auth/server.ts` must stay token-blind. A guard
+  test asserts it contains no upload-token reference. If the two auth paths are
+  ever unified, the upload-only guarantee must be re-derived.
+- **Operational:** the `upload_tokens` migration must be applied
+  (`prisma migrate deploy`) before the mint route works in an environment; on
+  Vercel, migrations do not auto-run. Verification is throw-safe, so a token
+  before the table exists returns `401`, not `500` — but the settings card
+  should not be exposed until the migration lands.
+- **Accepted residual:** no per-request rate limiter; storage quota is the
+  volume bound on a leaked token and revoke is the kill switch.
+- **Negative:** Sploot now owns a credential lifecycle (mint, hash, revoke,
+  leak response) it did not before.

--- a/apps/web/docs/shortcuts/save-to-sploot.md
+++ b/apps/web/docs/shortcuts/save-to-sploot.md
@@ -1,0 +1,76 @@
+# Save to Sploot — iPhone Share-Sheet Shortcut
+
+iOS (WebKit) does not implement the Web Share Target API, so an installed Sploot
+PWA can never appear in the iPhone share sheet the way it does on Android. The
+sanctioned workaround is an **Apple Shortcut**: it can sit in the share sheet,
+accept an image, and make an authenticated HTTP request.
+
+Shortcuts can't carry your Clerk login, so they authenticate with a **personal
+upload token** instead — a credential that can *only* upload to your library
+(never read or delete it).
+
+## 1. Mint an upload token
+
+1. Open Sploot → **Settings** → **Upload tokens**.
+2. Name it (e.g. `iphone`) and tap **mint token**.
+3. Copy the `splt_…` value. **It is shown only once.** If you lose it, revoke it
+   and mint a new one.
+
+## 2. Build the Shortcut
+
+In the **Shortcuts** app, create a new shortcut with these actions:
+
+1. **Get Contents of URL**
+   - **URL:** `https://www.sploot.app/api/upload`
+   - **Method:** `POST`
+   - **Headers:** add one — `Authorization` = `Bearer splt_…` (your token, with
+     the word `Bearer` and a space before it).
+   - **Request Body:** `Form`
+   - Add a form field:
+     - **Key:** `file`
+     - **Type:** `File`
+     - **Value:** `Shortcut Input` (the shared image)
+2. (Optional) **Show Result** / **Show Notification** of the response so you get
+   a "saved" confirmation.
+
+Then open the shortcut's settings (the ⓘ / share icon):
+
+- Turn on **Show in Share Sheet**.
+- Under **Share Sheet Types**, accept **Images** (and **Media** if you want to
+  share from Photos).
+- Name it **Save to Sploot**.
+
+## 3. Use it
+
+From any app, tap **Share → Save to Sploot**. The image lands in your library.
+
+Sploot deduplicates by content hash, so re-sharing the same image is harmless —
+it returns the existing asset rather than creating a duplicate.
+
+## Responses the Shortcut may see
+
+| Status | Meaning |
+|---|---|
+| `201` | Saved. Response includes the new `asset`. |
+| `409` | Already in your library (duplicate). The existing `asset` is returned. |
+| `401` | `{"error":"Unauthorized"}` — token missing, mistyped, or revoked. |
+| `403` | `code: "quota_exceeded"` — you're out of storage. |
+| `413` | The image is larger than the upload limit. |
+| `503` | `code: "uploads_disabled"` — uploads are temporarily paused. |
+
+## Security
+
+- The token is **upload-only**: presenting it to any read or delete endpoint
+  returns `401`. It cannot list, view, or remove your memes.
+- Only a hash of the token is stored server-side; the plaintext is shown once.
+- If a token leaks (lost phone, shared screenshot), open **Settings → Upload
+  tokens** and **revoke** it. Revocation is immediate.
+- "Last used" is shown per token so you can spot one that's being used
+  unexpectedly.
+
+## Sharing your shortcut (optional)
+
+Apple shortcuts are device-signed, so a ready-made `.shortcut` file can only be
+produced and shared from an Apple device. If you want to share your build with
+someone else, open the shortcut → **Share → Copy iCloud Link** and send that.
+Each person still mints and pastes their **own** token; never share a token.

--- a/apps/web/lib/auth/request-auth.ts
+++ b/apps/web/lib/auth/request-auth.ts
@@ -6,11 +6,15 @@ import type {
   AuthenticatedPrincipal,
   RequestAuthResult,
 } from './types';
+import { extractUploadToken, verifyUploadToken } from './upload-token';
 import { verifyBearerOrThrow } from './verify-bearer';
 
-const DEFAULT_AUTH_POLICY: Required<Pick<AuthPolicy, 'allowClerk' | 'allowQaLocal' | 'requireUserSync'>> = {
+const DEFAULT_AUTH_POLICY: Required<
+  Pick<AuthPolicy, 'allowClerk' | 'allowQaLocal' | 'allowUploadToken' | 'requireUserSync'>
+> = {
   allowClerk: true,
   allowQaLocal: true,
+  allowUploadToken: false,
   requireUserSync: false,
 };
 
@@ -28,6 +32,19 @@ export async function authenticateRequest(
     const qaResult = await verifyQaLocalAuthHeaders(req.headers, env);
     if (qaResult.status !== 'unauthenticated' && qaResult.status !== 'forbidden') {
       return qaResult;
+    }
+  }
+
+  if (resolvedPolicy.allowUploadToken) {
+    const uploadToken = extractUploadToken(req.headers);
+    if (uploadToken) {
+      const principal = await verifyUploadToken(uploadToken);
+      if (principal) {
+        return { status: 'authenticated', principal, syncStatus: 'skipped' };
+      }
+      // A splt_ bearer was presented but is invalid or revoked. It is
+      // unambiguously an upload-token attempt, so do not fall through to Clerk.
+      return { status: 'unauthenticated', reason: 'upload-token-invalid' };
     }
   }
 

--- a/apps/web/lib/auth/types.ts
+++ b/apps/web/lib/auth/types.ts
@@ -1,6 +1,6 @@
-export type AuthProvider = 'clerk' | 'qa-local';
-export type AuthSource = 'clerk-request' | 'qa-local';
-export type AuthCredentialKind = 'cookie-or-bearer' | 'qa-local';
+export type AuthProvider = 'clerk' | 'qa-local' | 'upload-token';
+export type AuthSource = 'clerk-request' | 'qa-local' | 'upload-token';
+export type AuthCredentialKind = 'cookie-or-bearer' | 'qa-local' | 'upload-token';
 export type AuthSyncStatus = 'success' | 'failed' | 'skipped';
 
 export interface AuthenticatedPrincipal {
@@ -38,6 +38,12 @@ export type RequestAuthResult =
 export interface AuthPolicy {
   allowClerk?: boolean;
   allowQaLocal?: boolean;
+  /**
+   * Accept a personal upload token (`Authorization: Bearer splt_…`).
+   * Defaults false — only the upload routes opt in, which is what makes the
+   * token upload-only. See lib/auth/upload-token.ts.
+   */
+  allowUploadToken?: boolean;
   requireUserSync?: boolean;
   env?: Record<string, string | undefined>;
 }

--- a/apps/web/lib/auth/upload-token.ts
+++ b/apps/web/lib/auth/upload-token.ts
@@ -1,0 +1,141 @@
+import { prisma } from '@/lib/db';
+import { logger } from '@/lib/observability-logger';
+import type { AuthenticatedPrincipal } from './types';
+
+/**
+ * Personal upload tokens — hashed, revocable, upload-only credentials.
+ *
+ * A non-session client (Apple Shortcut, CLI) presents one as
+ * `Authorization: Bearer splt_…`. Only `sha256(token)` is ever stored; the
+ * plaintext is returned once at mint time and never again. Verification is
+ * gated by the `allowUploadToken` policy flag, so a token authenticates ONLY on
+ * routes that explicitly opt in (the upload routes) — every other route rejects
+ * it. See lib/auth/request-auth.ts for the branch and
+ * backlog.d/033-ios-share-sheet-ingestion.ctx.md for the design.
+ */
+
+export const UPLOAD_TOKEN_PREFIX = 'splt_';
+
+// 32 random bytes → 256 bits of entropy. Online guessing is infeasible, so a
+// fast hash (sha256) is correct here — there is no low-entropy secret to stretch.
+const TOKEN_RANDOM_BYTES = 32;
+// Characters of the random part kept as a non-secret display prefix.
+const DISPLAY_PREFIX_CHARS = 6;
+
+export interface MintedUploadToken {
+  /** Plaintext token. Returned to the user exactly once; never persisted. */
+  token: string;
+  /** Non-secret display prefix, e.g. "splt_ab12cd", safe to store and show. */
+  prefix: string;
+  /** sha256(token), hex — the only representation stored at rest. */
+  tokenHash: string;
+}
+
+/** Generate a fresh token + its hash. The caller persists hash + prefix only. */
+export async function mintUploadToken(): Promise<MintedUploadToken> {
+  const randomPart = base64UrlEncodeBytes(randomBytes(TOKEN_RANDOM_BYTES));
+  const token = `${UPLOAD_TOKEN_PREFIX}${randomPart}`;
+  const tokenHash = await hashUploadToken(token);
+  const prefix = `${UPLOAD_TOKEN_PREFIX}${randomPart.slice(0, DISPLAY_PREFIX_CHARS)}`;
+  return { token, prefix, tokenHash };
+}
+
+/**
+ * Pull an upload token out of the Authorization header.
+ *
+ * Returns the value only when it is a `splt_`-prefixed Bearer token, so a Clerk
+ * session JWT (`eyJ…`) is never mistaken for one. Returns null otherwise.
+ */
+export function extractUploadToken(headers: Headers): string | null {
+  const header = headers.get('authorization');
+  if (!header) {
+    return null;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const value = match?.[1]?.trim();
+  if (!value || !value.startsWith(UPLOAD_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  return value;
+}
+
+/** Hex sha256 of a token. Mirrors lib/checksum.ts's Web Crypto usage. */
+export async function hashUploadToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Resolve a plaintext upload token to its owning principal, or null.
+ *
+ * Throw-safe by contract: an auth decision must never throw. Any DB error
+ * (including a not-yet-migrated `upload_tokens` table) resolves to null → 401,
+ * never a 500. Revoked and unknown tokens are indistinguishable: both miss the
+ * `revokedAt IS NULL` lookup and return null with no reason/latency tell.
+ */
+export async function verifyUploadToken(token: string): Promise<AuthenticatedPrincipal | null> {
+  try {
+    if (!prisma) {
+      return null;
+    }
+
+    const tokenHash = await hashUploadToken(token);
+    const row = await prisma.uploadToken.findFirst({
+      where: { tokenHash, revokedAt: null },
+      select: { id: true, userId: true },
+    });
+
+    if (!row) {
+      return null;
+    }
+
+    // Best-effort, never blocks the request and never resurrects a revoked row
+    // (updateMany guarded on revokedAt: null matches zero if revoked meanwhile).
+    void touchLastUsed(row.id);
+
+    return {
+      userId: row.userId,
+      provider: 'upload-token',
+      providerSubject: row.userId,
+      source: 'upload-token',
+      credentialKind: 'upload-token',
+    };
+  } catch (error) {
+    logger.logError('auth:upload-token-verify-failed', error as Error);
+    return null;
+  }
+}
+
+async function touchLastUsed(id: string): Promise<void> {
+  try {
+    if (!prisma) {
+      return;
+    }
+    await prisma.uploadToken.updateMany({
+      where: { id, revokedAt: null },
+      data: { lastUsedAt: new Date() },
+    });
+  } catch {
+    // last-used tracking is non-essential; swallow.
+  }
+}
+
+function randomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length));
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}

--- a/apps/web/prisma/migrations/20260618000000_add_upload_tokens/migration.sql
+++ b/apps/web/prisma/migrations/20260618000000_add_upload_tokens/migration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "upload_tokens" (
+  "id" TEXT NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "token_hash" TEXT NOT NULL,
+  "prefix" TEXT NOT NULL,
+  "last_used_at" TIMESTAMP(3),
+  "revoked_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "upload_tokens_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "upload_tokens_token_hash_key" ON "upload_tokens"("token_hash");
+CREATE INDEX "upload_tokens_user_id_idx" ON "upload_tokens"("user_id");
+
+ALTER TABLE "upload_tokens"
+  ADD CONSTRAINT "upload_tokens_user_id_fkey"
+  FOREIGN KEY ("user_id")
+  REFERENCES "users"("id")
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -30,8 +30,29 @@ model User {
   identities               UserIdentity[]
   storageQuota             UserStorageQuota?
   storageQuotaReservations StorageQuotaReservation[]
+  uploadTokens             UploadToken[]
 
   @@map("users")
+}
+
+// UploadToken model - hashed, revocable, upload-only personal access tokens.
+// Lets a non-session client (Apple Shortcut, CLI) authenticate upload-only API
+// calls. Only the sha256 of the token is stored; the plaintext is shown once at
+// mint time. See lib/auth/upload-token.ts.
+model UploadToken {
+  id         String    @id @default(cuid())
+  userId     String    @map("user_id")
+  name       String
+  tokenHash  String    @unique @map("token_hash")
+  prefix     String // Non-secret display prefix, e.g. "splt_ab12cd"
+  lastUsedAt DateTime? @map("last_used_at")
+  revokedAt  DateTime? @map("revoked_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("upload_tokens")
 }
 
 model UserIdentity {

--- a/backlog.d/033-ios-share-sheet-ingestion.ctx.md
+++ b/backlog.d/033-ios-share-sheet-ingestion.ctx.md
@@ -1,0 +1,412 @@
+# Context Packet: iPhone Share-Sheet Ingestion via Personal Upload Tokens
+
+## PRD Summary
+
+- User: an iPhone owner with images scattered across Photos, Reddit, Safari,
+  etc., who wants them in Sploot without switching to a desktop.
+- Problem: WebKit does not implement the Web Share Target API, so the Android
+  `share_target` (PR #216, epic 026) can never surface Sploot in the iOS share
+  sheet. The only sanctioned escape hatch is an Apple Shortcut — but Shortcuts
+  cannot carry a Clerk session, so there is no credential they can present to
+  the upload API.
+- Why now: 026's iOS path is currently "copy → paste into the upload zone,"
+  which fails for the common case (an app offers *Share* but not *Copy*, or the
+  user is many taps from the Sploot tab). The missing primitive is a
+  non-session credential.
+- UX enabled: tap *Share → Save to Sploot* on any image; it lands in the
+  library (deduped) in one or two taps. The same credential unlocks future
+  CLI/automation ingestion.
+- Deliverable type: code (new auth credential + DB model + management UI +
+  API) plus a user-facing Shortcut recipe doc plus an evidence packet.
+- Success signal: with a minted token, `curl -F file=@meme.png -H
+  "Authorization: Bearer splt_…" https://sploot.app/api/upload` returns `201`,
+  a repeat returns `409` (dedupe), revoking the token makes the same call
+  return the stable `401 {"error":"Unauthorized"}`, and that token cannot read
+  or delete anything.
+
+## Goal
+
+Give Sploot a hashed, revocable, **upload-only** personal token that an Apple
+Shortcut (or any HTTP client) can present to the existing upload pipeline, so
+an iPhone user can save images from the native share sheet.
+
+## Non-Goals
+
+- No native iOS app, App Clip, or App Store submission.
+- No generic scoped-token / OAuth-app / API-key platform. Exactly one scope
+  exists today (upload); do not build a scopes column or permission system.
+- No change to how the web app or Chrome extension authenticate (both keep
+  Clerk session/bearer). This adds a credential; it replaces nothing.
+- No new ingestion *pipeline*. Reuse `ingestImage()` unchanged — dedupe, quota,
+  embedding, blob upload, and response contracts come for free.
+- Do not ship a signed binary `.shortcut` file from this lane (see Design →
+  Shortcut artifact). The step-by-step recipe satisfies the oracle.
+- Do not loosen or fork the `401 {"error":"Unauthorized"}` contract.
+
+## Constraints / Invariants
+
+- Sploot is a pnpm Turborepo; use pnpm. `DATABASE_URL` is the Prisma var.
+- Product JSON APIs preserve `401 {"error":"Unauthorized"}`
+  (`apps/web/lib/auth/api.ts:26`; oracle:
+  `apps/web/__tests__/api/auth-unauthorized-contracts.test.ts`).
+- **Two auth front doors exist** (verified): (1) policy-based
+  `authenticateRequest(req, policy)` / `withAuthenticatedApi` — used by only 5
+  routes (`/api/upload`, `/api/upload/url`, `/api/piles`, `/api/taste/profile`,
+  `/api/cache/stats`); (2) `lib/auth/server.ts`
+  `getAuth`/`getAuthWithUser`/`requireUserId*` (qa-local short-circuit, then
+  Clerk `auth()` directly) — used by ~16 routes incl. `/api/assets`,
+  `/api/assets/[id]` DELETE, `/api/search`, `/api/tags`, `/api/stats`. Door (2)
+  has **no policy parameter and never calls the token verifier**, so it cannot
+  accept a `splt_` token at all. Upload-token verification therefore lives in
+  **exactly one** function (`authenticateRequest`, via
+  `lib/auth/upload-token.ts`); `server.ts` must **never** learn the `splt_`
+  token. The auth-import lint guard (`pnpm lint`, see AUTH.md) bans direct
+  Clerk/`verifyBearerOrThrow` imports in product routes — the new branch lives
+  inside `lib/auth`, not in routes.
+- The token plaintext is shown exactly once (at mint) and is **never** stored,
+  logged, or returned again. Only `sha256(token)` is persisted. Observability
+  already redacts token/cookie/secret/session/api-key-shaped keys
+  (apps/web/CLAUDE.md → Error Tracking); log token **id/prefix** only, never the
+  secret.
+- Schema change is **additive** (one new table). No existing table is altered;
+  no `users.id` rewrite.
+- Migrations do not auto-run on Vercel deploy and prod `DATABASE_URL` is
+  build-withheld — see memory `sploot-vercel-migrations`. The new table must be
+  applied to prod before the feature is usable (Risk + Rollout).
+- Upload-only is enforced **two ways, not one**: door-(1) routes are
+  deny-by-default (`allowUploadToken` defaults false; only the 2 upload routes
+  opt in), and door-(2) routes physically cannot reach the verifier. A `splt_`
+  token presented anywhere except the opted-in upload routes returns the stable
+  401.
+- `verifyUploadToken` is **throw-safe**: any DB/Prisma error (including a
+  not-yet-migrated `upload_tokens` table) returns `null` → 401, never a 500. An
+  auth decision must never throw.
+- Revoked and unknown tokens are **indistinguishable**: both resolve to `null`
+  with the same response body, the same log line, and no reason-string or
+  latency tell (achieved by matching `revokedAt IS NULL` in the lookup, so a
+  revoked row is simply "not found").
+
+## Authority Order
+
+tests > type system > code > docs > lore
+
+## Repo Anchors
+
+- `apps/web/lib/auth/request-auth.ts` — central resolver; the new branch goes
+  here, after qa-local and before Clerk.
+- `apps/web/lib/auth/types.ts` — `AuthProvider` / `AuthSource` /
+  `AuthCredentialKind` / `AuthPolicy`; extend each (`'upload-token'`,
+  `allowUploadToken?`).
+- `apps/web/lib/auth/qa-local.ts` — **exemplar** for a custom credential:
+  Web Crypto `sha256`/hex, base64url, `RequestAuthResult` union. Reuse the hash
+  + token-extraction idioms; this token differs in being DB-backed + per-user.
+  Do **not** copy `constantTimeEqual` — it guards an HMAC signature compare;
+  here the lookup is an indexed equality on a 256-bit-entropy hash, so a
+  timing-safe compare buys nothing (no low-entropy secret; an attacker cannot
+  iterate 2^256).
+- `apps/web/lib/auth/server.ts` — the **second auth door**
+  (`getAuth`/`getAuthWithUser`/`requireUserId*`), the path `/api/assets`,
+  `/api/search`, `/api/tags`, `/api/stats`, etc. use. It must stay
+  token-blind (guard test asserts no `splt_`/upload-token reference).
+- `apps/web/lib/auth/api.ts` — `unauthorizedResponse()`; the stable 401.
+- `apps/web/app/api/upload/route.ts:40` — change `authenticateRequest(req)` →
+  `authenticateRequest(req, { allowUploadToken: true })`.
+- `apps/web/app/api/upload/url/route.ts:21` — pass `{ allowUploadToken: true }`
+  to `withAuthenticatedApi` (recommended include).
+- `apps/web/lib/upload/ingest-image.ts` — the shared pipeline; **do not touch**,
+  just call it (dedupe via `Asset @@unique([ownerUserId, checksumSha256])`).
+- `apps/web/prisma/schema.prisma:37-51` — `UserIdentity` is the precedent for an
+  auxiliary credential row hanging off `User` (cuid id, FK cascade, `@@map`,
+  snake_case `@map`). Model the new `UploadToken` the same way.
+- `apps/web/app/app/settings/page.tsx:113-141` — the storage-meter card is the
+  UI exemplar (client component, `fetch` + state, `bg-card`/`border-border`
+  shadcn aliases, lowercase meme voice). Add the tokens card here.
+- `apps/web/__tests__/api/upload-url.test.ts` — exemplar route test: `vi.hoisted`
+  mocks for `authenticateRequest`, crafted `NextRequest`, status+body asserts.
+  Pure (no DB).
+- `apps/web/__tests__/lib/auth/verify-bearer.test.ts` — exemplar for unit-testing
+  a verifier in isolation (mock `@clerk/backend`, `resetModules`).
+- `apps/extension/shared/api-client.ts` — prior art for the HTTP recipe:
+  `POST /api/upload`, `Authorization: Bearer …`, multipart `file` (+ optional
+  `metadata` JSON `{source}`); do **not** set Content-Type manually.
+- `apps/web/docs/AUTH.md` (Modes table) and `apps/web/docs/API.md` (auth +
+  upload recipe) — docs to extend with the third credential + Shortcut recipe.
+
+## Alternatives Considered
+
+| Option | Shape | Strength | Failure mode | Verdict |
+|---|---|---|---|---|
+| **Upload token + Apple Shortcut** | Opaque hashed PAT, upload-only; documented Shortcut posts to `/api/upload` | Hits the real outcome; no new pipeline; token reusable for CLI/automation | We own a credential lifecycle (mint/revoke/leak) | **Choose** |
+| Copy → paste into upload zone (status quo) | No build; document the manual path | Zero cost; already works for *copyable* images | Many apps offer Share but not Copy; multi-tap; not "from where they live" | Keep as documented fallback; insufficient alone |
+| Stateless HMAC token (qa-local style) | Sign `{userId}` with an env secret, no DB row | Smallest code; no migration | **Cannot revoke** and **cannot store hashed** — both are explicit oracle requirements | Reject |
+| Scoped-token / API-key platform | `scopes` column + generic scope middleware | Future-proof for read/delete tokens | Speculative generality; one scope exists; larger surface, more to secure | Reject (YAGNI); revisit if a second scope appears |
+| Clerk OAuth device flow into the Shortcut | Shortcut drives a Clerk auth handshake | Reuses Clerk; no new credential | Shortcuts can't hold a session; heavy, Clerk-coupled, fragile | Reject |
+| Email-to-Sploot (share → Mail → inbound parse) | Unique address ingests attachments | Uses a share-sheet target that exists on iOS | New inbound-email infra + dependency; latency; spam surface | Reject now; note as a separate ingestion idea |
+
+Scope enforcement sub-decision — **scope by policy** (only ingestion routes set
+`allowUploadToken: true`) vs **scope on token** (a `scopes` column checked by
+middleware): choose scope-by-policy. It matches the existing
+`allowClerk`/`allowQaLocal` grain exactly, adds no token field, and makes the
+blast radius a grep (`allowUploadToken` appears on exactly the upload routes).
+Deny-by-default everywhere else *is* the upload-only guarantee.
+
+## Technical Design
+
+Chosen architecture: an opaque, per-user, DB-backed personal access token,
+verified by a new branch inside the existing auth resolver and accepted only by
+routes that explicitly opt in.
+
+**Token primitive**
+- Format: `splt_` + `base64url(32 random bytes)` (high entropy → fast hash is
+  safe; no bcrypt/argon needed, as there is no low-entropy secret to stretch —
+  same reasoning GitHub uses for PATs).
+- At rest: store only `sha256(token)` (hex) in `tokenHash` (unique). Plaintext
+  is returned once from the mint call and never again.
+- Display: store a non-secret `prefix` (e.g. `splt_` + first 6 of the random
+  part) + a user-supplied `name` so the settings list is identifiable.
+- Revocation: soft — `revokedAt DateTime?`. Verification matches
+  `revokedAt IS NULL`. (Hard-delete is the alternative; soft-revoke keeps an
+  audit/last-used trail and a clean "revoked" state in the list.)
+- `lastUsedAt DateTime?`: best-effort update on successful auth (never blocks or
+  throws; matches the observability "never throw" ethos). Throttle to ≥60s
+  staleness if write volume is a concern.
+
+**New Prisma model** (additive; mirror `UserIdentity`):
+```prisma
+model UploadToken {
+  id         String    @id @default(cuid())
+  userId     String    @map("user_id")
+  name       String
+  tokenHash  String    @unique @map("token_hash")
+  prefix     String
+  lastUsedAt DateTime? @map("last_used_at")
+  revokedAt  DateTime? @map("revoked_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@index([userId])
+  @@map("upload_tokens")
+}
+```
+(Add the back-relation `uploadTokens UploadToken[]` to `User`.)
+
+**Verification path** (`apps/web/lib/auth/upload-token.ts`, new)
+- `extractUploadToken(req): string | null` — read `Authorization: Bearer …`,
+  return the value iff it starts with the `splt_` prefix.
+- `verifyUploadToken(token): Promise<AuthenticatedPrincipal | null>` —
+  `sha256(token)` (hex), then a single
+  `prisma.uploadToken.findFirst({ where: { tokenHash, revokedAt: null } })`
+  (revoked ≡ not-found). On a hit, best-effort bump `lastUsedAt`
+  (`update({ where: { id, revokedAt: null }, … })`, errors swallowed, never
+  blocks). Return a principal `{ userId, provider: 'upload-token', source:
+  'upload-token', credentialKind: 'upload-token' }` or `null`. **The whole body
+  is wrapped so any DB error returns `null`** (→ 401), never throws (→ 500).
+- `lib/auth/types.ts`: add `'upload-token'` to the three unions; add
+  `allowUploadToken?: boolean` to `AuthPolicy` (default false).
+- `lib/auth/request-auth.ts`: after qa-local, before Clerk — if
+  `resolvedPolicy.allowUploadToken` and a `splt_` bearer is present, verify it;
+  on success return authenticated; on failure return
+  `{ status: 'unauthenticated', reason: 'upload-token-invalid' }` **without**
+  falling through to Clerk (a `splt_` bearer is unambiguously a token attempt).
+  If no `splt_` bearer, fall through to Clerk unchanged. Default policy keeps
+  `allowUploadToken: false`, so no existing route is affected.
+
+**Scope enforcement (opt-in)**
+- `app/api/upload/route.ts` POST → `authenticateRequest(req, { allowUploadToken: true })`.
+- `app/api/upload/url/route.ts` → `withAuthenticatedApi(handler, { allowUploadToken: true })`.
+- Leave `app/api/upload/check` Clerk-only (uses `verifyBearerOrThrow` directly;
+  the Shortcut posts to `/api/upload` which dedupes server-side anyway — out of
+  scope).
+- All other routes untouched. Door-(1) routes (`/api/piles`,
+  `/api/taste/profile`, `/api/cache/stats`) keep `allowUploadToken:false` → the
+  token branch is not entered → 401. Door-(2) routes (`server.ts`) never reach
+  the verifier → 401. The scope guarantee is proven at the `authenticateRequest`
+  unit level (see Verification), **not** by hitting routes that cannot reach the
+  branch.
+
+**Token management API** (Clerk-session authed via `withAuthenticatedApi`
+default policy → upload tokens **cannot** manage tokens):
+- `POST /api/upload-tokens` — body `{ name }`; mint; return
+  `{ id, name, token, prefix, createdAt }` (plaintext `token` once). Enforce a
+  cap (max 10 active tokens/user → 422 with a lowercase message).
+- `GET /api/upload-tokens` — list `{ id, name, prefix, lastUsedAt, createdAt }`
+  (never plaintext).
+- `DELETE /api/upload-tokens/[id]` — ownership-checked soft revoke; idempotent.
+
+**Settings UI** (`app/app/settings/page.tsx`, new card after storage)
+- Follows the storage-meter card grammar (`<section className="bg-card border
+  border-border p-5 space-y-4">`, shadcn aliases, lowercase meme voice — e.g.
+  "shortcut keys", "mint one, paste it into the Save-to-Sploot shortcut, never
+  see it again").
+- States: list (name, prefix, last used, revoke button); "mint token" →
+  reveals plaintext once with a copy button + a link to the Shortcut recipe;
+  empty state nudges iOS users to the recipe.
+
+**Apple Shortcut recipe** (`apps/web/docs/shortcuts/save-to-sploot.md`, new)
+- Step-by-step build in the iOS Shortcuts app: *Accept images from share sheet*
+  → *Get Contents of URL* `POST https://sploot.app/api/upload`, header
+  `Authorization: Bearer <token>`, request body `Form`, field `file` = Shortcut
+  Input, optional field `metadata` = `{"source":"apple-shortcut"}` → branch on
+  status (201 toast "saved", 409 "already in sploot").
+- Shortcut **artifact decision**: ship the recipe doc (satisfies the oracle's
+  "step-by-step recipe"). A shareable signed `.shortcut`/iCloud link can only be
+  generated from an Apple device by the user; note it as an optional
+  user-generated follow-up, do not block on producing a binary.
+- Cross-link from settings, `docs/API.md` (new "Personal upload tokens"
+  section), and `docs/AUTH.md` (third Modes row: `upload-token`).
+
+ADR decision: lightweight ADR in `apps/web/docs/adr/` — this adds a new
+credential class and security surface. Record the scope-by-policy and
+hashed-PAT decisions.
+
+## Verification System
+
+- **Claim:** a valid upload token can POST an image to `/api/upload` (lands,
+  deduped); a revoked/garbage token gets the stable 401; an upload token cannot
+  read or delete anything.
+- **Falsifier:** a revoked token still uploads; a `splt_` token authenticates
+  against `/api/assets` (read) or a DELETE route; a bad token returns non-401;
+  plaintext appears in any log/DB column other than the one-time mint response.
+- **Driver (automated):**
+  - `pnpm --filter web vitest run` over new tests:
+    - `__tests__/lib/auth/upload-token.test.ts` — verify valid / revoked /
+      unknown-hash / non-`splt_` bearer; `lastUsedAt` best-effort.
+    - `__tests__/api/upload-tokens.test.ts` — mint returns plaintext once + cap;
+      list never returns plaintext; revoke is ownership-checked + idempotent
+      (pure, mocked prisma + auth, per `upload-url.test.ts`).
+    - `__tests__/lib/auth/upload-token-scope.test.ts` (**the real scope
+      falsifier**) — a *valid* `splt_` token through
+      `authenticateRequest(req, {})` and `{ allowUploadToken: false }` returns
+      `unauthenticated` and `verifyUploadToken` is **not called** (spy); only
+      `{ allowUploadToken: true }` enters the branch. Plus a guard: grep
+      `lib/auth/server.ts` for `splt_`/upload-token → none.
+    - extend `__tests__/api/auth-unauthorized-contracts.test.ts` — **smoke**: a
+      `splt_` token to a door-(1) non-opted route (`/api/piles`) and a door-(2)
+      route (`/api/assets` DELETE) returns `401 {"error":"Unauthorized"}`
+      (redundant end-to-end confirmation, not the guarantee itself).
+  - A live credential cycle (the oracle's mint → POST → revoke → 401), runnable
+    against the `qa-local`/`qa:seed` local stack:
+    `mint → curl -F file=@fixture.png -H "Authorization: Bearer splt_…"
+    /api/upload (201) → repeat (409) → DELETE the token → same curl (401)`.
+- **Driver (manual / stop condition):** the real-device share-sheet tap (oracle
+  item 3, "verified on a real device") is **human-in-the-loop**, exactly like
+  026's open item. The agent cannot tap an iPhone share sheet headlessly. The
+  curl cycle is the automatable proxy; the device test is a documented user
+  checklist in the evidence packet. **Stop and hand off** rather than claim the
+  device path.
+- **Grader:** route/unit tests green; the curl-cycle transcript; `pnpm
+  lint && pnpm type-check && pnpm --filter web test` green.
+- **Evidence packet:** `pnpm --filter web qa:evidence` →
+  `docs/qa/evidence/2026-06-18-upload-tokens/packet.md` (mint UI screenshot,
+  curl transcript, the four-step cycle, manual device checklist).
+- **Cadence:** report after the token primitive + branch lands (milestone 1
+  critic gate), and again after the UI/recipe land.
+- **Gaps / waiver:** the route/unit tests are mocked (no DB), so they do **not**
+  prove DB-backed verification — the live curl cycle on the qa-local stack is the
+  only real proof that `verifyUploadToken` resolves a real row, and it is part of
+  the evidence packet. Real-device share-sheet verification is deferred to the
+  user (human-in-the-loop).
+
+## Oracle
+
+- [ ] `POST /api/upload-tokens` mints a token, returns plaintext exactly once,
+      persists only `sha256`; `GET` lists metadata without plaintext; `DELETE`
+      revokes (ownership-checked, idempotent). Cap enforced.
+- [ ] A valid `splt_` token POSTs an image to `/api/upload` → `201`; a repeat →
+      `409` (dedupe via `ingestImage`); after revoke → `401 {"error":
+      "Unauthorized"}`. (Live curl transcript in the evidence packet.)
+- [ ] Scope proven at the unit level: a valid `splt_` token through
+      `authenticateRequest` with default / `allowUploadToken:false` policy stays
+      `unauthenticated` and never calls the verifier; only explicit opt-in enters
+      the branch. `lib/auth/server.ts` carries no token reference (guard).
+      End-to-end smoke: `splt_` → `/api/piles` and `/api/assets` DELETE → `401`.
+- [ ] `verifyUploadToken` is throw-safe (prisma error → `null` → 401, not 500)
+      and revoked ≡ unknown (indistinguishable). (Unit tests.)
+- [ ] Settings shows a tokens card (mint reveals once + copy + recipe link;
+      list; revoke); `pnpm lint:design` green.
+- [ ] `apps/web/docs/shortcuts/save-to-sploot.md` documents the share-sheet
+      Shortcut; settings + `docs/API.md` + `docs/AUTH.md` link/row updated.
+- [ ] `pnpm lint && pnpm type-check && pnpm --filter web test` green.
+- [ ] Evidence packet at `docs/qa/evidence/2026-06-18-upload-tokens/` with the
+      mint→POST→revoke→401 cycle and a manual real-device checklist.
+
+## Premise Source
+
+Premise Source: `sha256:58994f5d7c2ff54518a7f356c5efd1d311fd7ba3bf577514fd190209d8951166 backlog.d/033-ios-share-sheet-ingestion.md`
+
+The platform reality (WebKit lacks Web Share Target; Apple Shortcuts are the
+sanctioned escape hatch) was confirmed on the user's iPhone on 2026-06-11 and
+is recorded in the ticket Notes.
+
+## HTML Plan
+
+`/tmp/upload-tokens-plan.html` — authored from `skills/shape/templates/html-plan.html`,
+opened for rendered review before execution.
+
+## Critique
+
+A fresh-context adversarial security critic (separate lane, artifact-only)
+reviewed this packet against the live auth code. It found the original scope
+oracle **non-falsifiable**: it named routes (`/api/assets`, `/api/search`) that
+use the *second* auth door (`lib/auth/server.ts`) and can never reach the new
+branch, so the test would pass with zero implementation. Folded in: the two-door
+reality + the token-blind invariant on `server.ts` (Constraints, Anchors), the
+re-anchored unit-level scope falsifier (Verification, Oracle), throw-safe
+verification + revoked-≡-unknown (Constraints, Design), and the explicit
+no-rate-limit residual (Risk). Confirmed solid by the critic and left as-is: the
+sha256/entropy choice (no constant-time compare needed), Clerk/extension
+non-regression, storage quota as the real volume bound, and the honest
+human-in-the-loop scoping of the device test.
+
+## Risk + Rollout
+
+- **Leaked token → silent uploads to a user's library.** Mitigate: upload-only
+  scope (can't read/delete/exfiltrate), one-tap revoke, `lastUsedAt` surfaced in
+  settings, cap on active tokens, never log the secret. **Accepted residual:**
+  the repo has no per-request rate limiter and this lane adds none — storage
+  quota (`ingestImage` reserves bytes) is the only volume bound on a leaked
+  token, and revoke is the only kill switch. The token's 256-bit entropy makes
+  online guessing infeasible, so no brute-force limiter on verification is
+  needed; a mint-attempt cap bounds abuse of the management route.
+- **Plaintext accidentally logged.** Mitigate: log id/prefix only; rely on the
+  existing redaction of token-shaped keys; a test asserts the mint response is
+  the sole place plaintext appears.
+- **Scope leak via a future route forgetting deny-by-default.** Mitigate: it is
+  deny-by-default — a new route would have to *opt in*; the scope test enumerates
+  protected routes; ADR records the rule.
+- **Clerk-bearer regression.** Mitigate: the branch only triggers on a `splt_`
+  prefix; Clerk JWTs (`eyJ…`) and the extension path are untouched; the 401
+  contract test guards the boundary.
+- **Migration not applied in prod** (memory `sploot-vercel-migrations`: no
+  auto-run, prod `DATABASE_URL` build-withheld). Mitigate: rollout step —
+  apply `upload_tokens` to the prod Neon branch via `prisma migrate deploy`
+  with the prod URL before/at release. Because `verifyUploadToken` is
+  throw-safe, a `splt_` token before the table exists returns the stable 401
+  (not a 500); only the *mint* route (which must write) errors, so ship the
+  migration before exposing the settings card.
+- **Real-device path unverified by the agent.** Mitigate: documented user
+  checklist + the curl cycle as proxy; explicit stop/hand-off, not a false
+  "verified" claim.
+- **Rollback:** additive and self-contained — revert the routes/UI/branch; the
+  `upload_tokens` table is inert if unused and can be dropped in a follow-up
+  migration. No existing flow depends on it.
+
+## Implementation Sequence
+
+1. Add the `UploadToken` model + `User.uploadTokens` back-relation;
+   `db:migrate:dev` to create `upload_tokens`.
+2. `lib/auth/upload-token.ts` (extract + throw-safe verify + sha256 + scoped
+   best-effort lastUsed; revoked ≡ unknown) + unit tests
+   (valid / revoked / unknown / non-`splt_` / prisma-throws). Extend
+   `lib/auth/types.ts` unions + `allowUploadToken`.
+3. Wire the branch into `authenticateRequest` (after qa-local, before Clerk);
+   default policy unchanged. **Milestone-1 critic gate** (auth/security diff).
+4. Opt the upload routes in (`/api/upload`, `/api/upload/url`). Add the
+   unit-level scope falsifier (default policy doesn't enter the branch; verifier
+   not called), the `server.ts` token-blind guard test, and the end-to-end
+   smoke in `auth-unauthorized-contracts`.
+5. Token management routes (`/api/upload-tokens` mint/list, `[id]` revoke) +
+   route tests (cap, plaintext-once, ownership).
+6. Settings tokens card (mint-once reveal + copy + revoke + recipe link).
+7. `docs/shortcuts/save-to-sploot.md` + AUTH.md row + API.md section + ADR.
+8. Live curl cycle + `qa:evidence` packet; document the real-device checklist.
+9. Gates green; report; hand off the device test.

--- a/backlog.d/033-ios-share-sheet-ingestion.md
+++ b/backlog.d/033-ios-share-sheet-ingestion.md
@@ -1,6 +1,6 @@
 # Get Sploot into the iPhone share sheet via a Shortcut
 
-Priority: P2 · Status: pending · Estimate: M
+Priority: P2 · Status: in-progress · Estimate: M
 
 ## Goal
 

--- a/backlog.d/035-unify-auth-doors-on-policy-boundary.md
+++ b/backlog.d/035-unify-auth-doors-on-policy-boundary.md
@@ -1,0 +1,51 @@
+# Unify the two auth doors on the policy boundary
+
+Priority: P3 · Status: pending · Estimate: M
+
+## Goal
+
+Sploot has one auth front door, not two. Every protected route resolves auth
+through `authenticateRequest(req, policy)` / `withAuthenticatedApi`, so scope
+decisions (like upload-only tokens) are governed in exactly one place.
+
+## Context
+
+Shaping/delivering 033 (upload tokens) surfaced that auth runs through **two**
+independent paths:
+
+- `lib/auth/request-auth.ts` (`authenticateRequest` + `withAuthenticatedApi`) —
+  policy-based, used by ~5 routes (the upload routes opt into `allowUploadToken`
+  here).
+- `lib/auth/server.ts` (`getAuth` / `getAuthWithUser` / `requireUserId*`) —
+  qa-local short-circuit then Clerk `auth()` directly, **no policy parameter**,
+  used by ~16 routes (`/api/assets`, `/api/assets/[id]` DELETE, `/api/search`,
+  `/api/tags`, `/api/stats`, …). `/api/upload/check` also uses
+  `verifyBearerOrThrow` directly.
+
+The upload-token scope guarantee currently holds *because* door 2 never calls
+the token verifier — a guard test (`__tests__/lib/auth/upload-token-scope.test.ts`)
+asserts `server.ts` stays token-blind. That works, but the invariant is implicit
+and would invert silently if the doors were ever merged carelessly (see
+ADR-006).
+
+## Oracle
+
+- [ ] `/api/assets`, `/api/assets/[id]`, `/api/search`, `/api/tags`,
+      `/api/stats`, `/api/upload/check` (and peers) resolve auth via
+      `withAuthenticatedApi` / `authenticateRequest`, not `getAuth*` /
+      `verifyBearerOrThrow` directly.
+- [ ] The `401 {"error":"Unauthorized"}` contract and user-sync behavior are
+      preserved (existing contract tests stay green).
+- [ ] `pnpm --filter web auth:guard` is extended to ban `getAuth*` in product
+      routes once migrated; `lib/auth/server.ts` can shrink or be folded into
+      the boundary.
+- [ ] Upload-only scope still holds and is provable by one mechanism (the
+      `allowUploadToken` policy), so the `server.ts` token-blind guard test
+      becomes redundant rather than load-bearing.
+
+## Notes
+
+Additive, mechanical, route-by-route — preserve `requireUserIdWithSync`'s
+user-sync semantics behind the boundary (the policy already has
+`requireUserSync`). Low product risk, real architectural payoff: one place to
+reason about who can hit what. Discovered via the 033 milestone critic.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -14,10 +14,10 @@ Status conventions:
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
 | [026](026-ingest-memes-where-they-live.md) | Ingest Memes Where They Live (epic) | P1 | XL |
-| [029](029-build-the-taste-engine.md) | Build The Taste Engine (epic, raw) | P3 | XL |
 | [031](031-storage-based-pricing.md) | Charge For Storage With A Generous Free Tier (epic, raw) | P2 | XL |
 | [032](032-adopt-design-system-and-landing-pass.md) | Adopt Design System And Re-Cut Landing (epic, blocked) | P2 | XL |
-| [033](033-ios-share-sheet-ingestion.md) | Get Sploot Into The iPhone Share Sheet Via A Shortcut | P2 | M |
+| [033](033-ios-share-sheet-ingestion.md) | Get Sploot Into The iPhone Share Sheet Via A Shortcut (in progress) | P2 | M |
+| [035](035-unify-auth-doors-on-policy-boundary.md) | Unify The Two Auth Doors On The Policy Boundary | P3 | M |
 
 ## Done
 

--- a/docs/qa/evidence/2026-06-18-upload-tokens/packet.md
+++ b/docs/qa/evidence/2026-06-18-upload-tokens/packet.md
@@ -1,0 +1,123 @@
+# Evidence Packet: upload-tokens
+
+- Date: 2026-06-18
+- Branch: `deliver-033-ios-share-sheet-tokens`
+- Ticket: `backlog.d/033-ios-share-sheet-ingestion.md` (+ `.ctx.md`)
+
+> Hand-authored. `pnpm --filter web qa:evidence` (the browser+seed harness) was
+> not runnable in the delivery environment — no local Postgres, Vercel Blob
+> token, or Clerk keys. Automated checks below were run; the live cycle, browser
+> walk, and real-device test are operator steps with exact commands.
+
+## Intent
+
+An iPhone user can mint a hashed, revocable, **upload-only** personal token and
+use a "Save to Sploot" Apple Shortcut to share images from the iOS share sheet
+into their library (deduped). A token presented to any non-upload route, or
+after revocation, returns the stable `401`.
+
+## Checks — automated (run)
+
+### PASS — type-check
+
+```
+pnpm --filter web type-check        # tsc --noEmit, exit 0
+```
+
+### PASS — lint + auth boundary guard
+
+```
+pnpm --filter web lint              # next lint: no warnings/errors; auth:guard exit 0
+```
+
+### PASS — auth core unit + scope falsifier (17 tests)
+
+```
+CI=1 pnpm --filter web vitest run \
+  __tests__/lib/auth/upload-token.test.ts \
+  __tests__/lib/auth/upload-token-scope.test.ts
+```
+
+Covers: mint format + hash match + uniqueness; `splt_` extraction (rejects Clerk
+`eyJ…` JWTs, non-Bearer); verify valid/revoked/unknown; **throw-safety** (DB
+error → null → 401, not 500); **revoked ≡ unknown**; the **deny-by-default scope
+falsifier** (verifier is not even called under default/`allowUploadToken:false`
+policy; entered only on explicit opt-in); and the `server.ts` token-blind guard.
+
+### PASS — token management routes (9 tests)
+
+```
+CI=1 pnpm --filter web vitest run __tests__/api/upload-tokens.test.ts
+```
+
+Covers: mint returns plaintext once + persists only the hash; name validation;
+active-token cap (422); list excludes the hash; ownership-scoped + idempotent
+revoke; 401 when unauthenticated.
+
+### PASS — /api/upload opt-in wiring (2 tests)
+
+```
+CI=1 pnpm --filter web vitest run __tests__/api/upload-token-opt-in.test.ts
+```
+
+Proves `/api/upload` calls `authenticateRequest` with `{ allowUploadToken: true }`
+and returns the stable 401 when the token is rejected.
+
+### PASS — regression sweep (196 tests, 22 files)
+
+```
+CI=1 pnpm --filter web vitest run __tests__/lib/auth __tests__/api \
+  --exclude '**/*.integration.test.ts'
+```
+
+All auth + API route tests pass; no regression in the existing 401 contract,
+Clerk bearer path, or upload routes.
+
+## Checks — live (operator steps, pending)
+
+These need a running server with a migrated DB, a Vercel Blob token, and an
+authenticated session (Clerk or `qa-local`). Apply the migration first:
+`pnpm --filter web db:migrate` (or `db:migrate:dev` locally).
+
+### PENDING — mint → upload → dedupe → revoke → 401 cycle
+
+```
+# 1. Mint in the UI (Settings → Upload tokens) or via the session API, copy splt_…
+# 2. Upload:
+curl -i -X POST "$BASE/api/upload" -H "Authorization: Bearer splt_…" -F "file=@meme.png"   # expect 201
+# 3. Repeat the same file:
+curl -i -X POST "$BASE/api/upload" -H "Authorization: Bearer splt_…" -F "file=@meme.png"   # expect 409 (dedupe)
+# 4. Scope: same token at a read/delete route:
+curl -i "$BASE/api/assets" -H "Authorization: Bearer splt_…"                                # expect 401
+# 5. Revoke in the UI, then re-run step 2:
+curl -i -X POST "$BASE/api/upload" -H "Authorization: Bearer splt_…" -F "file=@meme.png"   # expect 401
+```
+
+### PENDING — browser walk of the settings card
+
+`/app/settings` → Upload tokens card: mint reveals the token once with copy;
+list shows name/prefix/last-used; revoke removes it; recipe `<details>` renders.
+
+### PENDING — real-device share-sheet test (human-in-the-loop)
+
+Build the shortcut from `apps/web/docs/shortcuts/save-to-sploot.md`, share a
+photo from the iOS share sheet, confirm it lands in the library. (Cannot be
+automated; same class as epic 026's open device-verification item.)
+
+## Verdict
+
+Auth core, management API, UI, and docs implemented and proven by 196 automated
+tests + type-check + lint. The milestone-1 fresh-context security critic cleared
+the auth core (no blocker). Live end-to-end cycle, browser walk, and real-device
+test are documented operator steps, pending an environment with DB/blob/session.
+
+## Residual Risk
+
+- Live upload success (201) is unproven by automation (needs a Blob token); the
+  auth/scope/revoke/401 paths are proven by tests and reject before any blob
+  write.
+- The `upload_tokens` migration must be applied to an environment before its
+  mint route works there (verify is throw-safe, so a token pre-migration returns
+  401, not 500). On Vercel, migrations do not auto-run.
+- `pnpm lint:design` is red on `docs/design/component-library.md` — pre-existing
+  and unrelated to this change (verified by stashing); tracked separately.


### PR DESCRIPTION
Closes-backlog: 033-ios-share-sheet-ingestion

## What & why

iOS Safari ships no Web Share Target API, so the Android `share_target` can never surface Sploot in the iPhone share sheet. Apple Shortcuts are the sanctioned escape hatch, but they can't carry a Clerk session — they need a non-session credential to present to the upload API.

This adds a hashed, revocable, **upload-only** personal access token. Mint one in settings, paste it into a "Save to Sploot" Shortcut, and share images from any iOS app into the library (deduped).

## How it works

- **`UploadToken` model** (additive migration, mirrors `UserIdentity`). Only `sha256(token)` is stored; the plaintext is shown once at mint and never again.
- **`verifyUploadToken` branch** in `authenticateRequest`, gated by a new `allowUploadToken` policy flag. Only `/api/upload` and `/api/upload/url` opt in, so the token is upload-only *by construction*: every other route — and the second auth door (`lib/auth/server.ts`), which never reaches the verifier — rejects a `splt_` token with the stable `401 {"error":"Unauthorized"}`. Verification is **throw-safe** (DB error → null → 401, never 500) and **revoked ≡ unknown** (no reason/latency tell).
- **`/api/upload-tokens`** mint/list + **`/api/upload-tokens/[id]`** revoke, session-authed (a token cannot manage tokens), capped at 10 active/user, ownership-scoped idempotent soft-revoke.
- **Settings card** to mint (reveal-once + copy), list, and revoke, with the inline Shortcut recipe.
- **Docs**: ADR-006, AUTH.md mode row, API.md section, the Shortcut recipe.

## Verification

- `type-check` ✅ · `lint` + auth-boundary guard ✅ · full suite **1032/1032** ✅ (30 new tests)
- Scope falsifier (`upload-token-scope.test.ts`) asserts the verifier is never called off the opt-in path; `server.ts` stays token-blind. Plus a route-level smoke that a `splt_` bearer on a door-2 route and on Clerk-only `/api/upload/check` returns 401.
- Fresh-context adversarial security review: **SHIP**, no blockers — attacked upload-only scope, throw-safety, plaintext secrecy, revoked≡unknown, cross-user leaks, and the 401 contract; all hold.

## Operator steps before this is user-usable

1. **Apply the migration to prod** — migrations don't auto-run on Vercel deploy; run `prisma migrate deploy` against the prod Neon URL before exposing the settings card. (`verifyUploadToken` is throw-safe, so a token before the table exists returns 401, not 500.)
2. **Live DB-backed cycle** — the route/unit tests are mocked; the real proof is the `mint → POST(201) → repeat(409) → revoke → 401` curl cycle on the qa-local stack (needs local Postgres/Blob/Clerk, which the delivery env lacked). Checklist in `docs/qa/evidence/2026-06-18-upload-tokens/packet.md`.
3. **Real-device share-sheet tap** — human-in-the-loop (oracle item 3); documented checklist in the evidence packet.

Follow-up #035 (filed here) proposes unifying the two auth doors so the upload-only invariant stops being implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced personal upload tokens for non-session clients, enabling upload-only access via bearer credentials.
  * Added token management interface in Settings to create, list, and revoke tokens.
  * Enabled iOS image sharing via Apple Shortcut with token-based authentication.

* **Documentation**
  * Updated API and authentication documentation for upload token usage.
  * Added setup guide for iPhone image sharing workflow via Shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->