### PR TITLE
chore(backlog): epic 036 — make schema-to-prod fully agent-deployable

### DIFF
--- a/backlog.d/033-ios-share-sheet-ingestion.md
+++ b/backlog.d/033-ios-share-sheet-ingestion.md
@@ -1,6 +1,6 @@
 # Get Sploot into the iPhone share sheet via a Shortcut
 
-Priority: P2 · Status: in-progress · Estimate: M
+Priority: P2 · Status: blocked · Estimate: M
 
 ## Goal
 
@@ -33,3 +33,14 @@ cookies aren't available to Shortcuts, hence the upload-token feature
 (which also unlocks future CLI/automation ingestion). Until this ships,
 the iOS path is copy → paste into the upload zone (documented in
 settings).
+
+Status (2026-06-20): the feature code merged to master (PR #231, squash
+`73238ff`, `Closes-backlog: 033`). **Blocked, not done** — the user-facing
+oracle (lands on a real device; live mint→POST→revoke→401 cycle) is not yet
+green because the `upload_tokens` table is not applied to prod. Vercel does
+not run migrations on deploy and the prod `DATABASE_URL` is sequestered, so
+applying it is a manual step → owned by epic 036 (make schema-to-prod fully
+agent-deployable). Until the table exists, the settings card degrades
+gracefully ("tokens aren't available") and any `splt_` token returns the
+throw-safe 401. Archive to `_done/` once the migration is applied and the
+device test passes.

--- a/backlog.d/036-make-schema-to-prod-fully-agent-deployable.md
+++ b/backlog.d/036-make-schema-to-prod-fully-agent-deployable.md
@@ -1,0 +1,94 @@
+# Make Schema-To-Prod Fully Agent-Deployable
+
+Priority: P2 · Status: ready · Estimate: L
+
+## Goal
+
+An agent can take a schema or infra change from merged PR to verified-in-prod
+with zero human credential step — migrations ride the deploy, and every
+boundary's secret is reachable by a token already on disk.
+
+## Context
+
+Delivering 033 exposed the seam: the agent can build, test, review, and merge a
+migration, but cannot apply it to prod. Vercel runs `next build`, not
+`prisma migrate deploy`; the prod `DATABASE_URL` is a Vercel **Sensitive** var
+(withheld from build and from `vercel env pull`); and the prod Neon project
+(`lively-lake-63852609`) lives on a Neon account this machine's `neonctl` / `op`
+are not logged into. Net: a merged schema change strands at the prod boundary
+and needs a human holding the sequestered credential.
+
+The friction is not a missing capability — it is that the deploy loop is
+"dashboard + sequestered secret" where it needs to be "token-on-disk + one
+command." This epic closes that gap for the current stack first (cheap, high
+leverage), then decides whether a runtime move makes the whole loop
+structurally agent-native.
+
+## Oracle
+
+- [ ] A migration merged to `master` is applied to prod with **no human running
+      a DDL command and no agent ever handling the prod connection string**
+      (CI/release-time `prisma migrate deploy`, secret held by the runner).
+- [ ] `prisma migrate status` against prod reports no pending migrations after a
+      deploy completes.
+- [ ] The live QA loop (mint → `POST` 201 → 409 dedupe → revoke → 401) is
+      runnable by the agent against a non-prod environment without a human
+      handing over a secret (agent-readable secret store or seeded preview).
+- [ ] An ADR records the platform decision: "stay on Vercel+Neon and glue the
+      seam" vs "consolidate the runtime onto a token-on-disk platform" (Fly,
+      already authed here; or Supabase), with criteria and, if a move is chosen,
+      a sequenced migration path.
+
+## Verification System
+
+- **Claim:** an agent can ship a schema change to prod end-to-end with no human
+  credential step.
+- **Falsifier:** a merged migration leaves prod's schema stale, OR applying it
+  requires a human to run a command or paste a secret.
+- **Driver:** merge a trivial additive migration (e.g. an inert comment column
+  on a throwaway table), observe it land in prod via the automated path, then
+  revert it the same way.
+- **Grader:** `prisma migrate status` clean against prod post-deploy; the run
+  log shows the migration applied by the runner, not a human.
+- **Evidence packet:** the CI/release run log + `migrate status` output under
+  `docs/qa/evidence/`.
+- **Cadence:** after child 1 lands (the migrate-on-deploy path), and again if a
+  platform move ships.
+
+## Children
+
+1. **Migrate-on-deploy (the immediate fix; do first).** Add a release/CI step
+   that runs `prisma migrate deploy` against prod on merge to `master`, with the
+   prod `DATABASE_URL` held as a GitHub Actions secret (or Vercel deploy hook)
+   the agent never reads. One-time human secret placement; permanent agent
+   autonomy after. Directly unblocks 033's pending prod migration.
+2. **Agent-readable secret store.** Put the boundary secrets (DB, Blob, Clerk,
+   Canary) behind a token-on-disk store (1Password **service-account** token, or
+   Doppler) so the agent can run the live QA loop and reach every boundary
+   without an interactive login. Document the bootstrap in AGENTS/CLAUDE.
+3. **Platform-fit spike + ADR.** Evaluate three futures against the criteria
+   below: (a) **stay + glue** — Vercel+Neon+Clerk with children 1–2; (b) **move
+   to Fly** — `FLY_API_TOKEN` is already on this disk, migrations ride
+   `release_command`, pgvector supported, aligns with the Canary-on-Fly
+   footprint and the Rust-by-default doctrine; (c) **consolidate on Supabase** —
+   DB + pgvector + auth + storage behind one CLI/key, but replaces Clerk and
+   Vercel Blob. Output an ADR with a recommendation and, if a move is chosen, a
+   sequenced migration epic.
+
+## Notes
+
+- **Decision criteria (child 3):** fewest sequestered secrets · migrations
+  included in the deploy · one account/CLI not five partial auths · pgvector and
+  the embedding pipeline preserved · preview/staging the agent can spin and test
+  against.
+- **Evidence (2026-06-20 delivery session):** `vercel env pull --environment
+  production` returns `DATABASE_URL` empty (Sensitive); `neonctl` authed as
+  `phraznikov@gmail.com` / org `phaedrus` (projects `memory-engine-prod`,
+  `moneta-prod`) has no access to `lively-lake-63852609` (direct fetch → "could
+  not be authorized"); `op` installed but signed out. The prod-Neon credential
+  is on a `mistystep`-associated account unreachable from this machine.
+- **Do child 1 first regardless of the child-3 decision** — auto-migrate pays
+  off even if a runtime move happens later.
+- Related: memory `sploot-vercel-migrations` records the no-auto-migrate +
+  build-withheld facts this epic closes. Distinct from 035 (unify auth doors),
+  which is code architecture, not infra.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -16,8 +16,9 @@ Status conventions:
 | [026](026-ingest-memes-where-they-live.md) | Ingest Memes Where They Live (epic) | P1 | XL |
 | [031](031-storage-based-pricing.md) | Charge For Storage With A Generous Free Tier (epic, raw) | P2 | XL |
 | [032](032-adopt-design-system-and-landing-pass.md) | Adopt Design System And Re-Cut Landing (epic, blocked) | P2 | XL |
-| [033](033-ios-share-sheet-ingestion.md) | Get Sploot Into The iPhone Share Sheet Via A Shortcut (in progress) | P2 | M |
+| [033](033-ios-share-sheet-ingestion.md) | Get Sploot Into The iPhone Share Sheet Via A Shortcut (merged; blocked on prod migration — see 036) | P2 | M |
 | [035](035-unify-auth-doors-on-policy-boundary.md) | Unify The Two Auth Doors On The Policy Boundary | P3 | M |
+| [036](036-make-schema-to-prod-fully-agent-deployable.md) | Make Schema-To-Prod Fully Agent-Deployable (epic) | P2 | L |
 
 ## Done
 


### PR DESCRIPTION
Captures the 2026-06-20 agent-manageability brainstorm and tidies 033 post-merge.

## Tidy
- **033** → `Status: blocked` (was `in-progress`). Code merged via #231, but the user-facing oracle (real-device share, live mint→POST→revoke→401 cycle) isn't green until the `upload_tokens` table is applied to prod. Not archived to `_done/` — its oracle isn't green. README no longer claims "in progress."

## Emission
- **036** (epic, `ready`, P2/L): *Make schema-to-prod fully agent-deployable.* An agent should take a schema change from merged PR to verified-in-prod with zero human credential step.
  - **Child 1 — migrate-on-deploy** (do first): CI/release runs `prisma migrate deploy` on merge, prod `DATABASE_URL` held by the runner, agent never touches it. Unblocks 033.
  - **Child 2 — agent-readable secret store** (1Password service-account / Doppler) so the live QA loop runs without an interactive login.
  - **Child 3 — platform-fit ADR**: stay+glue (Vercel+Neon) vs Fly (`FLY_API_TOKEN` already on disk, migrations via `release_command`) vs Supabase (one CLI for DB+auth+storage).

Evidence in the ticket: `vercel env pull` returns prod `DATABASE_URL` empty (Sensitive); `neonctl` here can't reach the sploot Neon project; `op` signed out. The deploy loop is "dashboard + sequestered secret" where it needs to be "token-on-disk + one command."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project backlog tracking and deployment workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->