### PR TITLE
ci(web): apply prod migrations on merge via GitHub Actions (036 child 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,31 @@ jobs:
             fi
           done
           echo "All jobs passed"
+
+  # Apply pending Prisma migrations to production on merge to master, after the
+  # merge gate passes. The prod URL is held as a repo secret, so a schema change
+  # reaches prod with no human running a DDL command and no one handling the
+  # connection string per-deploy. Inert-but-loud until the secret is set.
+  # See apps/web/docs/adr/007-prod-migrations-via-github-actions.md.
+  migrate-prod:
+    name: Migrate Prod
+    needs: [merge-gate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Apply pending migrations to production
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          if [[ -z "$DATABASE_URL" ]]; then
+            echo "::warning title=Prod auto-migrate not activated::PRODUCTION_DATABASE_URL secret is unset; skipping prod migrations. Run 'gh secret set PRODUCTION_DATABASE_URL' once (same value as Vercel's prod DATABASE_URL) to activate hands-off schema deploys."
+            exit 0
+          fi
+          pnpm --filter web exec node scripts/migrate-deploy.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,12 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs to save CI, but never cancel an in-flight master
+  # run — the migrate-prod job below must not be killed mid-DDL by a newer push
+  # (a non-transactional migration could be left half-applied). Concurrent
+  # migrate-prod runs are still safe: prisma migrate deploy serializes on a
+  # Postgres advisory lock.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   secrets:

--- a/apps/web/__tests__/scripts/migrate-deploy.test.ts
+++ b/apps/web/__tests__/scripts/migrate-deploy.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs script without type declarations; we test its pure helper.
+import { deriveDirectUrl } from '../../scripts/migrate-deploy.mjs';
+
+// migrate-deploy.mjs derives a direct (non-pooler) connection for `prisma
+// migrate deploy`, because Prisma's advisory lock does not work through Neon's
+// PgBouncer pooler. The risky bit is the URL transform; prove it in isolation.
+// Fixtures use synthetic hosts only — never a real connection string.
+describe('deriveDirectUrl', () => {
+  it('strips the -pooler host suffix (pooled → direct)', () => {
+    const out = deriveDirectUrl('postgresql://user:pass@db-pooler.example.com/app?sslmode=require');
+    expect(out).toContain('@db.example.com/');
+    expect(out).not.toContain('-pooler.');
+  });
+
+  it('removes the pgbouncer query param but keeps the rest', () => {
+    const out = deriveDirectUrl(
+      'postgresql://user:pass@db-pooler.example.com/app?sslmode=require&pgbouncer=true'
+    );
+    expect(out).not.toContain('pgbouncer');
+    expect(out).toContain('sslmode=require');
+  });
+
+  it('leaves an already-direct url untouched', () => {
+    const raw = 'postgresql://user:pass@db.example.com/app?sslmode=require';
+    expect(deriveDirectUrl(raw)).toBe(raw);
+  });
+});

--- a/apps/web/docs/adr/007-prod-migrations-via-github-actions.md
+++ b/apps/web/docs/adr/007-prod-migrations-via-github-actions.md
@@ -1,0 +1,46 @@
+# ADR-007: Apply production migrations via GitHub Actions, not the Vercel build
+
+Status: Accepted (2026-06-21)
+
+## Context
+
+Schema and code must not ship apart (incident 2026-06-09: a migration never ran;
+2026-06-20: the `upload_tokens` table for #033 could not be applied to prod from
+a developer/agent machine). The web `build` script already runs
+`scripts/migrate-deploy.mjs` before `next build`, but on Vercel the production
+`DATABASE_URL` is a **Sensitive** environment variable: injected at runtime,
+withheld at build time and from `vercel env pull`. So the build-time migrate step
+always skips on prod, and applying a migration requires a human holding the
+sequestered connection string — there is no hands-off path. The prod Neon project
+also lives on an account a developer's `neonctl`/`op` may not be logged into.
+
+## Decision
+
+Apply pending production migrations from a dedicated **GitHub Actions job**
+(`migrate-prod` in `.github/workflows/ci.yml`) that runs on push to `master`
+after the merge gate passes. The job reads the prod connection string from the
+`PRODUCTION_DATABASE_URL` **repository secret** and runs `prisma migrate deploy`
+through the existing `migrate-deploy.mjs` (which derives a direct, non-pooler
+URL). The secret lives in GitHub; no human or agent handles it per-deploy.
+
+Until the secret is set the job emits a visible `::warning::` and no-ops, so it
+is inert-but-loud rather than silently green.
+
+Activation (one-time): `gh secret set PRODUCTION_DATABASE_URL` with the same
+value as Vercel's prod `DATABASE_URL` (the script derives the direct URL itself).
+
+## Consequences
+
+- A merged migration is applied to prod with **no human credential step**. Closes
+  the #033 prod-migration gap and epic 036 child 1.
+- Deploy (Vercel) and migrate (Actions) race by a couple of minutes, so
+  migrations must stay **backward-compatible (expand/contract)**: add
+  columns/tables before the code that requires them; never drop in the same
+  release as the code that stops using them.
+- `migrate deploy` is idempotent, so running on every `master` push is a cheap
+  no-op when nothing is pending. A `paths: prisma/migrations/**` filter is a
+  possible later optimization.
+- The Vercel build's migrate step stays as a harmless skip; the runtime app is
+  unaffected.
+- **Rejected:** un-marking `DATABASE_URL` as Sensitive so the build could migrate
+  — a security downgrade that would also run migrations on every preview build.

--- a/apps/web/docs/adr/007-prod-migrations-via-github-actions.md
+++ b/apps/web/docs/adr/007-prod-migrations-via-github-actions.md
@@ -40,6 +40,11 @@ value as Vercel's prod `DATABASE_URL` (the script derives the direct URL itself)
 - `migrate deploy` is idempotent, so running on every `master` push is a cheap
   no-op when nothing is pending. A `paths: prisma/migrations/**` filter is a
   possible later optimization.
+- The workflow's `concurrency.cancel-in-progress` is disabled for `push` events,
+  so a newer master push never cancels an in-flight `migrate-prod` mid-DDL (a
+  non-transactional `CREATE INDEX CONCURRENTLY` could otherwise be left
+  half-applied). Two `migrate-prod` runs that overlap are still safe — Prisma's
+  advisory lock serializes them.
 - The Vercel build's migrate step stays as a harmless skip; the runtime app is
   unaffected.
 - **Rejected:** un-marking `DATABASE_URL` as Sensitive so the build could migrate

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -1,31 +1,47 @@
 #!/usr/bin/env node
-// Run `prisma migrate deploy` before the production build so schema and code
-// cannot ship apart (incident 2026-06-09: user_identities migration never ran).
+// Run `prisma migrate deploy` so schema and code cannot ship apart
+// (incident 2026-06-09: a user_identities migration never ran).
+//
+// Invoked from two places:
+//   - the production `build` script, which SKIPS here because Vercel marks the
+//     prod DATABASE_URL as Sensitive (injected at runtime, withheld at build);
+//   - the `migrate-prod` GitHub Actions job, which runs on merge to master with
+//     the prod URL held as a repo secret — the path that actually applies prod
+//     migrations. See docs/adr/007-prod-migrations-via-github-actions.md.
 //
 // Prisma migrations need a direct (non-pooler) connection. Prefer
 // DATABASE_URL_DIRECT when set; otherwise derive it from DATABASE_URL by
 // stripping the Neon `-pooler` host suffix and the `pgbouncer` query param.
 import { execSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
-const pooled = process.env.DATABASE_URL;
-
-if (!pooled) {
-  console.log('[migrate-deploy] DATABASE_URL not set; skipping migrations (local/CI build without database).');
-  process.exit(0);
-}
-
-function deriveDirectUrl(raw) {
+export function deriveDirectUrl(raw) {
   const url = new URL(raw);
   url.hostname = url.hostname.replace('-pooler.', '.');
   url.searchParams.delete('pgbouncer');
   return url.toString();
 }
 
-const directUrl = process.env.DATABASE_URL_DIRECT || deriveDirectUrl(pooled);
+export function runMigrateDeploy(env = process.env) {
+  const pooled = env.DATABASE_URL;
 
-console.log('[migrate-deploy] running prisma migrate deploy...');
-execSync('prisma migrate deploy', {
-  stdio: 'inherit',
-  env: { ...process.env, DATABASE_URL: directUrl },
-});
-console.log('[migrate-deploy] migrations applied.');
+  if (!pooled) {
+    console.log('[migrate-deploy] DATABASE_URL not set; skipping migrations (local/CI build without database).');
+    return;
+  }
+
+  const directUrl = env.DATABASE_URL_DIRECT || deriveDirectUrl(pooled);
+
+  console.log('[migrate-deploy] running prisma migrate deploy...');
+  execSync('prisma migrate deploy', {
+    stdio: 'inherit',
+    env: { ...env, DATABASE_URL: directUrl },
+  });
+  console.log('[migrate-deploy] migrations applied.');
+}
+
+// Run only when invoked directly (`node scripts/migrate-deploy.mjs`), so that
+// importing this module from a test does not trigger a migration.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runMigrateDeploy();
+}

--- a/backlog.d/036-make-schema-to-prod-fully-agent-deployable.md
+++ b/backlog.d/036-make-schema-to-prod-fully-agent-deployable.md
@@ -57,11 +57,15 @@ structurally agent-native.
 
 ## Children
 
-1. **Migrate-on-deploy (the immediate fix; do first).** Add a release/CI step
-   that runs `prisma migrate deploy` against prod on merge to `master`, with the
-   prod `DATABASE_URL` held as a GitHub Actions secret (or Vercel deploy hook)
-   the agent never reads. One-time human secret placement; permanent agent
-   autonomy after. Directly unblocks 033's pending prod migration.
+1. **Migrate-on-deploy (the immediate fix; do first).** ✅ **Delivered** (PR for
+   `deliver-036-migrate-on-deploy`): `migrate-prod` job in
+   `.github/workflows/ci.yml` runs `prisma migrate deploy` on push to `master`
+   after the merge gate, with the prod URL held as the `PRODUCTION_DATABASE_URL`
+   repo secret — the agent never reads it. ADR-007 records the decision; the job
+   is inert-but-loud until activated. **Activation (one-time, operator):**
+   `gh secret set PRODUCTION_DATABASE_URL` with the same value as Vercel's prod
+   `DATABASE_URL`. After that the next merge applies pending migrations and
+   unblocks 033 automatically.
 2. **Agent-readable secret store.** Put the boundary secrets (DB, Blob, Clerk,
    Canary) behind a token-on-disk store (1Password **service-account** token, or
    Doppler) so the agent can run the live QA loop and reach every boundary


### PR DESCRIPTION
Epic **036** child 1 — make schema-to-prod fully agent-deployable. Unblocks #033.

## Problem
The web `build` already runs `scripts/migrate-deploy.mjs`, but it **always skips on Vercel**: the prod `DATABASE_URL` is a *Sensitive* var — injected at runtime, withheld at build (and from `vercel env pull`). So applying a migration required a human holding the sequestered connection string. That's the wall that stranded #033's `upload_tokens` table.

## Change
A `migrate-prod` GitHub Actions job (`.github/workflows/ci.yml`) that:
- runs **only** on `push` to `master`, **after** the merge gate (`if: github.event_name == 'push' && github.ref == 'refs/heads/master'`, `needs: [merge-gate]`) — never on PRs/previews/forks;
- runs `prisma migrate deploy` via the existing script, reading the prod URL from the **`PRODUCTION_DATABASE_URL` repo secret** — the runner holds it; no human/agent touches it per-deploy;
- is **inert-but-loud**: emits a visible `::warning::` and no-ops until the secret is set, so master stays green pre-activation.

`migrate-deploy.mjs` now exports `deriveDirectUrl`/`runMigrateDeploy` with a guarded CLI main (importing it in a test won't migrate); the direct-URL derivation is unit-tested. **ADR-007** records the decision + the expand/contract constraint (deploy and migrate race by ~2 min).

## Verification
- `deriveDirectUrl` unit test (3 cases) ✅ · type-check ✅ · lint + auth guard ✅ · full suite **1035/1035** ✅ · `actionlint .github/workflows/ci.yml` clean ✅ · secrets gate green ✅
- The `migrate deploy` command itself is already exercised against real Postgres by the existing `test` job.

## Activation (one-time, operator)
```
gh secret set PRODUCTION_DATABASE_URL   # same value as Vercel's prod DATABASE_URL
```
After that, the next merge applies pending migrations automatically — including #033's `upload_tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated production database migrations now run via a dedicated GitHub Actions job after merges to the master branch.
  * The workflow reads the production connection string from a GitHub secret and safely no-ops (with a visible warning) if it’s unset.
* **Bug Fixes**
  * Adjusted CI concurrency so in-progress production migrations aren’t canceled mid-flight for push events.
* **Documentation**
  * Added an ADR detailing the production migration workflow and migration safety expectations.
* **Tests**
  * Added tests to validate direct-URL derivation behavior for the migration helper.
* **Chores**
  * Refined the migration script to support callable execution paths and direct-URL preference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->