### PR TITLE
docs(backlog): strategic groom 2026-06-21 — taste gap, share-out, dead-code, agent-ops

### DIFF
--- a/backlog.d/031-storage-based-pricing.md
+++ b/backlog.d/031-storage-based-pricing.md
@@ -2,6 +2,15 @@
 
 Priority: P2 · Status: pending · Estimate: XL
 
+> **Groom reframe (2026-06-21):** the *enforcement* half is already built —
+> per-user byte metering and cap (`lib/quota/storage-quota-policy.ts`, 1GB
+> default), the settings meter, `StorageQuotaExceededError`, and an upgrade-prompt
+> hook. What's missing is the strategic half: the measured cost model, price
+> points, and a thin Stripe layer wired to the existing hooks. Re-estimate **XL →
+> L**, and **sequence after** the shareability/onboarding gaps (038, first-10
+> on-ramp) that serve today's lone user — don't monetize a tool nobody else can
+> yet delightfully share out of. Premise verdict: **keep, but shrink and defer.**
+
 ## Goal
 
 Sploot has a real pricing model aligned with its real cost structure:

--- a/backlog.d/037-make-taste-and-piles-actually-know-your-taste.md
+++ b/backlog.d/037-make-taste-and-piles-actually-know-your-taste.md
@@ -1,0 +1,81 @@
+# Make the taste and piles intelligence actually know your taste
+
+Priority: P1 · Status: ready · Estimate: XL
+
+## Goal
+
+sploot's piles and taste ranking reflect each user's actual humor — discovered
+from their own embeddings — not a fixed 12-category taxonomy or a single average
+vector.
+
+## Context
+
+The north star is "the meme app that **knows your taste**." A groom sweep
+(2026-06-21) found the headline intelligence is geometry-thin:
+
+- **Piles are fixed-anchor classification, not clustering.**
+  `lib/piles/semantic-piles.ts:14-27` hardcodes 12 English anchor labels; every
+  asset is assigned to its nearest anchor (`:163-219`), and the centroid relabel
+  maps back to the *same 12* (`:373-383`). No k-means/HDBSCAN/community detection
+  exists (grep clean). The shipped ticket 025 sketched real clustering ("k by
+  silhouette") but shipped a classifier. Memes that don't fit the 12 anchors get
+  generic or empty piles.
+- **Taste is a single mean centroid** of favorited embeddings
+  (`lib/taste/taste-engine.ts:174-184`); ranking is cosine to that one point
+  (`:223`). One average collapses multi-modal taste (cursed + wholesome) into a
+  meaningless midpoint.
+- **"Banger" = the `favorite` boolean** (`taste-engine.ts:107-110`); no implicit
+  signal. Taste learns only from manual stars (min 2).
+- **Piles cover only the newest 240 assets** (`semantic-piles.ts:10`); a large
+  library's piles silently ignore most of it.
+
+The substrate is real and generation-ready: genuine CLIP-768 image embeddings in
+pgvector, anchors are real cached CLIP text embeddings with a hard gate (no
+keyword fallback). The gap is purely the analysis layer above the embeddings.
+
+## Oracle
+
+- [ ] Piles are formed by clustering the user's own embeddings (k chosen by a
+      quality metric such as silhouette), labeled by nearest-anchor as a
+      *dictionary* — not bucketed into a fixed taxonomy. A library of unusual
+      memes still produces coherent, non-empty piles.
+- [ ] Taste is represented as multiple exemplars/centroids (or kNN-over-bangers),
+      so a user with diverse humor is ranked sensibly; verified by a ranking test
+      over a synthetic two-cluster favorite set.
+- [ ] Piles cover the whole library (assignment persisted per asset, computed on
+      ingest/cron), not a 240-row request-time scan.
+- [ ] At least one implicit taste signal beyond `favorite` feeds the model.
+
+## Verification System
+
+- **Claim:** piles and taste reflect the user's real, possibly multi-modal taste.
+- **Falsifier:** a two-cluster favorite set ranks the off-taste cluster as highly
+  as the on-taste one (mean-centroid failure); a library that avoids all 12
+  anchors yields empty/garbage piles; piles ignore assets beyond the newest 240.
+- **Driver:** unit/integration over a synthetic embedding set with known clusters;
+  live walk of piles on a seeded library > 240 assets.
+- **Grader:** ranking separates the clusters; piles are coherent and cover the
+  library.
+- **Evidence packet:** `docs/qa/evidence` — pile screenshots + ranking test output.
+- **Cadence:** after the clustering core, and after the taste-model change.
+
+## Children
+
+1. **Real pile clustering.** Replace fixed-anchor assignment with embedding
+   clustering (k-means/HDBSCAN, k by silhouette); keep anchors only as a label
+   dictionary, not bucket definers. Delete `PILE_ANCHORS` as definers + the
+   `nearestAnchor` self-relabel.
+2. **Real taste model.** Represent taste as exemplars/multi-centroid (or
+   kNN-over-bangers); add ≥1 implicit signal (shuffle-keep, dwell, re-share).
+3. **Whole-library pile coverage.** Persist `pile_id` per asset on ingest/cron;
+   remove the 240-asset request-time ceiling.
+
+## Notes
+
+- The #1 gap between the live repo and the north star, and the de-risking step for
+  the "generate memes matching your taste" future — generation needs a real taste
+  distribution, not one averaged point.
+- Apply the "match implementation to product premise" doctrine: the product brain
+  is the embedding geometry; stop approximating taste with a counter.
+- Evidence lane: groom 2026-06-21 "taste-native quality". Pairs with 040
+  (perceptual dedup) — cleaner embeddings make clusters sharper.

--- a/backlog.d/038-share-the-actual-meme-file.md
+++ b/backlog.d/038-share-the-actual-meme-file.md
@@ -1,0 +1,25 @@
+# Share the actual meme file, not a sploot link
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+Sharing a meme from sploot drops the image itself into the target app (group
+chat, etc.), not a sploot.app link with a marketing CTA.
+
+## Oracle
+
+- [ ] Where `navigator.canShare({ files })` is true, the share button shares the
+      image via `navigator.share({ files })`; the URL share is fallback only.
+- [ ] Sharing into a messaging app shows the meme inline — no tap-through to a
+      landing page.
+
+## Notes
+
+The vision's "share optimization → export to messaging apps" is unbuilt:
+`components/library/share-button.tsx:38-47` shares only `{title, url}`, and
+`hooks/use-web-share.ts:88` computes `canShareFiles` but never uses it. `/s/[slug]`
+→ `/m/[id]` is an HTML landing page with recruiting OG copy, not the raw image.
+Outbound share is the neglected half of the loop (inbound is ~solved by 026/033);
+the capability check is already written and dead, so this is mostly wiring.
+Evidence lane: groom 2026-06-21 "onboarding/delight/share".

--- a/backlog.d/039-debounce-search-and-honest-zero-results.md
+++ b/backlog.d/039-debounce-search-and-honest-zero-results.md
@@ -1,0 +1,29 @@
+# Debounce search and make zero-results honest
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+Search fires one embedding call per settled query (not per keystroke), and a query
+with no real matches shows an honest empty state instead of padding with random
+memes.
+
+## Oracle
+
+- [ ] Typing a query issues at most one `/api/search` after input settles (~300ms),
+      matching the documented contract; verified by counting calls in a test or
+      network trace.
+- [ ] When no result clears the similarity threshold, the UI shows an empty /
+      "no matches yet" state (or a clearly separated "loose matches" section), not
+      threshold-0 padding presented as matches.
+
+## Notes
+
+`apps/web/CLAUDE.md` specifies "Debounced search input (300ms)" but no debounce
+exists: `components/search/search-bar.tsx:156-166` + `app/app/page.tsx:306-310`
+feed `useSearchAssets` on every change; the stale comment `hooks/use-assets.ts:597`
+("SearchBar handles it") is false. Each keystroke can trigger a Replicate text
+embedding (`lib/embeddings.ts:55-104`, 20s timeout). `app/api/search/route.ts:116-145`
+pads any <10-result query with threshold-0 matches, surfaced only by a faint
+sub-line. Both hurt the "fast, knows-your-taste" feel of the core loop.
+Evidence lane: groom 2026-06-21 "core loop".

--- a/backlog.d/040-detect-near-duplicate-memes-perceptual-hash.md
+++ b/backlog.d/040-detect-near-duplicate-memes-perceptual-hash.md
@@ -1,0 +1,23 @@
+# Detect near-duplicate memes with a perceptual hash
+
+Priority: P2 · Status: ready · Estimate: M
+
+## Goal
+
+Re-encoded/re-shared copies of the same meme are recognized as near-duplicates,
+not stored and surfaced as distinct assets.
+
+## Oracle
+
+- [ ] A perceptual hash (dHash/pHash) is computed at ingest alongside the SHA-256.
+- [ ] Visually-identical uploads that differ in bytes (Twitter `name=orig` vs
+      screenshot vs Discord re-encode) are flagged as near-dups — flagged, not
+      silently rejected; the user decides.
+- [ ] "More like this" and piles no longer fill with near-identical copies.
+
+## Notes
+
+Dedupe today is exact-checksum only (`lib/upload/deduplication-service.ts:91-96`);
+no perceptual hash anywhere (grep clean). As the library grows (the stated goal),
+near-dup pollution erodes search and pile quality — and compounds the taste/piles
+work (037). Evidence lanes: groom 2026-06-21 "ingestion breadth" + "core loop".

--- a/backlog.d/041-make-sploot-agent-operable-verify-read-recover.md
+++ b/backlog.d/041-make-sploot-agent-operable-verify-read-recover.md
@@ -1,0 +1,38 @@
+# Make sploot agent-operable end to end: verify, read, recover
+
+Priority: P2 · Status: ready · Estimate: M
+
+## Goal
+
+Beyond deploying (036), an agent can verify a deploy succeeded, read prod
+errors/SLOs, and recover from a bad deploy — all from on-disk tokens and CLIs.
+
+## Context
+
+036 owns *applying* migrations and *reaching* secrets. A groom sweep (2026-06-21)
+found the verify / read / recover side is missing or doc-only.
+
+## Oracle
+
+- [ ] CI verifies migrations post-apply: a step after `migrate-prod` runs
+      `prisma migrate status` (clean = pass), failing the run on drift — closes
+      036's own status-verification oracle, which `migrate-prod` does not check.
+- [ ] An agent can query prod errors/SLOs with one command: a `canary:query` script
+      wrapping `GET /api/v1/query`, with the read key provisioned into the secret
+      store (it currently exists only in `OBSERVABILITY.md`, no key anywhere on
+      disk or in code).
+- [ ] Rollback runbooks exist for a bad deploy and a failed migration, using the
+      already-authed `vercel rollback`.
+- [ ] Ops docs reconciled and de-staled: one observability doc (not two), and
+      `docs/DEPLOYMENT.md` no longer references the banned `POSTGRES_URL`,
+      `vercel postgres *` (Neon is the DB), or Replicate-as-required.
+
+## Notes
+
+Evidence lane: groom 2026-06-21 "agent-operability + ops". Distinct from 036
+(deploy/migrate/secret-reach) — this is verify/read/recover. Canary is currently
+write-only for the agent (`lib/canary-reporter.ts` POSTs ingest only). Stale docs
+actively misdirect: `docs/DEPLOYMENT.md`'s rollback section uses non-existent
+`vercel postgres restore`. `scripts/db-drift-check.sh` also uses the banned
+`POSTGRES_URL` alias — fold into the post-migrate CI gate and delete the standalone
+script.

--- a/backlog.d/042-delete-dead-realtime-and-orphan-upload-infra.md
+++ b/backlog.d/042-delete-dead-realtime-and-orphan-upload-infra.md
@@ -1,0 +1,28 @@
+# Delete dead realtime and orphan-upload infrastructure
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+Remove ~2,150 LOC of zero-importer infrastructure so the maintenance surface
+matches what the app actually runs.
+
+## Oracle
+
+- [ ] After a `tsc`/knip confirmation of zero live importers, these modules and
+      their dead chains are removed:
+      - `lib/websocket-manager.ts` + `hooks/use-websocket.ts`
+      - `lib/pg-notify-listener.ts` + its test + `scripts/test-pg-notify.ts`
+      - `lib/connection-pool.ts` + `hooks/use-embedding-status-manager.ts`
+      - `lib/upload/upload-queue-service.ts` + its test (orphan parallel to the
+        live `lib/upload-queue.ts`)
+- [ ] `pnpm build && pnpm test` green after removal; no behavior change.
+
+## Notes
+
+All confirmed zero-importer via recursive grep (groom 2026-06-21 "architecture").
+LISTEN/NOTIFY is incompatible with the PgBouncer setup and was never wired; the
+WebSocket / connection-pool chains have no renderers. **Confirm with the user that
+streaming embedding-status was abandoned (not deferred) before deleting.** Verify
+with `tsc`/knip, not just grep. Pure subtraction — sibling in spirit to the shipped
+027 (delete dead enterprise infra).

--- a/backlog.d/043-fix-standing-red-lint-design-gate.md
+++ b/backlog.d/043-fix-standing-red-lint-design-gate.md
@@ -1,0 +1,25 @@
+# Fix the standing-red lint:design gate
+
+Priority: P3 · Status: ready · Estimate: S
+
+## Goal
+
+`pnpm lint:design` passes (or is honestly scoped) on master, so gate output is
+trustworthy again.
+
+## Oracle
+
+- [ ] `pnpm lint:design` exits 0 on master.
+- [ ] The gate no longer hard-requires docs that don't exist, OR those docs
+      (`docs/design/component-library.md`, `docs/design/tokens.md`) are written.
+
+## Notes
+
+`pnpm lint:design` exits 1: `scripts/check-design-system.mjs:34,113-114`
+hard-requires `docs/design/component-library.md` (Pile/cluster grammar) and
+`docs/design/tokens.md`, which are **absent** — yet `apps/web/CLAUDE.md` tells devs
+to "read those." Debt from the recent piles work; not introduced by any single
+ticket. A standing-red gate trains everyone to ignore gate output. Since the design
+system is being imported separately (the docs may arrive with it), prefer relaxing
+the checker to match current reality over writing throwaway docs — decide at
+delivery. Evidence lanes: groom 2026-06-21 "architecture" + "onboarding/delight".

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -14,11 +14,18 @@ Status conventions:
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
 | [026](026-ingest-memes-where-they-live.md) | Ingest Memes Where They Live (epic) | P1 | XL |
-| [031](031-storage-based-pricing.md) | Charge For Storage With A Generous Free Tier (epic, raw) | P2 | XL |
+| [037](037-make-taste-and-piles-actually-know-your-taste.md) | Make The Taste And Piles Actually Know Your Taste (epic) | P1 | XL |
+| [031](031-storage-based-pricing.md) | Charge For Storage With A Generous Free Tier (epic; reframe → L, see note) | P2 | XL |
 | [032](032-adopt-design-system-and-landing-pass.md) | Adopt Design System And Re-Cut Landing (epic, blocked) | P2 | XL |
 | [033](033-ios-share-sheet-ingestion.md) | Get Sploot Into The iPhone Share Sheet Via A Shortcut (merged; blocked on prod migration — see 036) | P2 | M |
+| [036](036-make-schema-to-prod-fully-agent-deployable.md) | Make Schema-To-Prod Fully Agent-Deployable (epic; child 1 shipped) | P2 | L |
+| [038](038-share-the-actual-meme-file.md) | Share The Actual Meme File, Not A Sploot Link | P2 | S |
+| [039](039-debounce-search-and-honest-zero-results.md) | Debounce Search And Make Zero-Results Honest | P2 | S |
+| [040](040-detect-near-duplicate-memes-perceptual-hash.md) | Detect Near-Duplicate Memes With A Perceptual Hash | P2 | M |
+| [041](041-make-sploot-agent-operable-verify-read-recover.md) | Make Sploot Agent-Operable: Verify, Read, Recover (epic) | P2 | M |
+| [042](042-delete-dead-realtime-and-orphan-upload-infra.md) | Delete Dead Realtime And Orphan-Upload Infrastructure | P2 | S |
 | [035](035-unify-auth-doors-on-policy-boundary.md) | Unify The Two Auth Doors On The Policy Boundary | P3 | M |
-| [036](036-make-schema-to-prod-fully-agent-deployable.md) | Make Schema-To-Prod Fully Agent-Deployable (epic) | P2 | L |
+| [043](043-fix-standing-red-lint-design-gate.md) | Fix The Standing-Red lint:design Gate | P3 | S |
 
 ## Done
 


### PR DESCRIPTION
Full strategic groom: six fresh-context lanes swept the repo against `VISION.md`, each finding vetted against live code (file:line cited in every ticket).

## Headline
The north-star differentiator — **"the meme app that knows your taste"** — is geometry-thin:
- **Piles are a fixed 12-anchor classifier, not clustering** (`lib/piles/semantic-piles.ts:14-27`); no k-means/HDBSCAN exists.
- **Taste is one mean centroid** of favorites (`lib/taste/taste-engine.ts:174-184`) — collapses multi-modal humor.
- **"Banger" = the `favorite` boolean**; no implicit signal.
- **Piles only see the newest 240 assets** (`:10`).

The CLIP-768 + pgvector substrate is real and generation-ready; the analysis layer above it is the gap. → **037** (P1 epic).

## New tickets
| # | | P | Est |
|---|---|---|---|
| 037 | Make taste/piles actually cluster the user's embeddings (epic) | P1 | XL |
| 038 | Share the actual meme file, not a sploot link (`canShareFiles` detected but dead) | P2 | S |
| 039 | Debounce search (fires per keystroke today) + honest zero-results | P2 | S |
| 040 | Perceptual near-dup detection (exact-checksum only today) | P2 | M |
| 041 | Agent-operable verify/read/recover (complements 036) (epic) | P2 | M |
| 042 | Delete ~2,150 LOC zero-importer realtime/orphan-upload infra | P2 | S |
| 043 | Fix the standing-red `lint:design` gate (references absent docs) | P3 | S |

## Reframe
- **031** storage pricing: enforcement half already built → **XL→L**, sequence after the delight work.

## Proposals (not yet applied — your call)
- **VISION.md is stale** (last touched 2026-01-25): it lists taste/piles as live differentiators, but they're only shallowly built, and animated-meme/GIF support shipped. Recommend a `/vision` refresh.
- **026**: add camera-roll/Google-Photos batch ingest + folder drag-drop as children (biggest scattered source is unserved).
- **035**: confirmed (17 routes on the policy-blind door); consider P3→P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)