### PR TITLE
perf(web): cap the image-optimization / CDN cost blast radius (046)

### DIFF
--- a/apps/web/__tests__/lib/image-config.test.ts
+++ b/apps/web/__tests__/lib/image-config.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import {
+  IMAGE_DEVICE_SIZES,
+  IMAGE_MINIMUM_CACHE_TTL,
+} from '@/lib/image-config';
+
+// Regression guard for ADR-008: the optimized image surfaces must stay
+// cost-capped. These assertions fail if someone restores the 8-deviceSize
+// ladder or drops the long cache TTL — the config that made image
+// optimization the first-to-explode cost line.
+describe('cost-safe image optimization config', () => {
+  it('keeps deviceSizes trimmed (≤ 3) so each image is not re-encoded into many variants', () => {
+    expect(IMAGE_DEVICE_SIZES.length).toBeLessThanOrEqual(3);
+  });
+
+  it('drops the giant 4K (3840) variant', () => {
+    expect(Math.max(...IMAGE_DEVICE_SIZES)).toBeLessThanOrEqual(2048);
+  });
+
+  it('caches optimized variants long (≥ 7 days) since meme blobs are immutable', () => {
+    const SEVEN_DAYS = 60 * 60 * 24 * 7;
+    expect(IMAGE_MINIMUM_CACHE_TTL).toBeGreaterThanOrEqual(SEVEN_DAYS);
+  });
+});

--- a/apps/web/app/api/cron/process-embeddings/route.ts
+++ b/apps/web/app/api/cron/process-embeddings/route.ts
@@ -214,23 +214,11 @@ async function getHandler(request: NextRequest) {
   }
 }
 
-/**
- * POST /api/cron/process-embeddings
- *
- * Manual trigger. Runs the same bounded batch as GET — it does NOT accept a
- * larger batch or a "re-embed recent/all" option on purpose: an unbounded
- * re-embed is the runaway Replicate-spend vector this route must never expose.
- * (Earlier `batchSize`/`includeRecent` body params were inert and were removed
- * so they can't be mistaken for a working knob. See ADR-008.)
- */
-async function postHandler(request: NextRequest) {
-  return getHandler(request);
-}
-
+// GET only: Vercel Cron invokes this on the */5 schedule, and a manual run is
+// the same idempotent, CRON_SECRET-gated call. There is deliberately no POST
+// variant — it would just duplicate GET and invite an "options" knob, and the
+// only knob worth having (re-embed everything) is the runaway this route must
+// never expose. See ADR-008.
 export const GET = withObservability(getHandler, {
-  operation: 'cron:process-embeddings',
-});
-
-export const POST = withObservability(postHandler, {
   operation: 'cron:process-embeddings',
 });

--- a/apps/web/app/api/cron/process-embeddings/route.ts
+++ b/apps/web/app/api/cron/process-embeddings/route.ts
@@ -6,6 +6,12 @@ import { withObservability } from '@/lib/with-observability';
 import { logger } from '@/lib/observability-logger';
 import { getRuntimeGate, runtimeGateError } from '@/lib/runtime-gates';
 
+// Hard per-run cap on embeddings generated — the bound on Replicate spend per
+// invocation. With the */5 * * * * schedule this ceilings throughput at
+// ~10/5min. The kill-switch for embedding spend is the `embeddings` runtime
+// gate (checked below); flipping it off halts this cron. See ADR-008.
+const EMBEDDINGS_BATCH_SIZE = 10;
+
 // Performance tracking
 interface ProcessingStats {
   totalProcessed: number;
@@ -90,7 +96,7 @@ async function getHandler(request: NextRequest) {
         ownerUserId: true,
         createdAt: true,
       },
-      take: 10, // Process in batches of 10
+      take: EMBEDDINGS_BATCH_SIZE,
       orderBy: {
         createdAt: 'asc', // Process oldest first
       },
@@ -211,15 +217,13 @@ async function getHandler(request: NextRequest) {
 /**
  * POST /api/cron/process-embeddings
  *
- * Manual trigger for processing embeddings with specific options.
+ * Manual trigger. Runs the same bounded batch as GET — it does NOT accept a
+ * larger batch or a "re-embed recent/all" option on purpose: an unbounded
+ * re-embed is the runaway Replicate-spend vector this route must never expose.
+ * (Earlier `batchSize`/`includeRecent` body params were inert and were removed
+ * so they can't be mistaken for a working knob. See ADR-008.)
  */
 async function postHandler(request: NextRequest) {
-  // For manual triggering with specific parameters
-  const body = await request.json();
-  const { batchSize = 10, includeRecent = false } = body;
-
-  // Similar processing logic but with configurable parameters
-  // This allows for manual testing and different processing strategies
   return getHandler(request);
 }
 

--- a/apps/web/components/library/image-tile.tsx
+++ b/apps/web/components/library/image-tile.tsx
@@ -437,7 +437,10 @@ function ImageTileComponent({
                       preserveAspectRatio ? 'object-contain' : 'object-cover'
                     )}
                     loading="lazy"
-                    unoptimized={isAnimatedImage}
+                    // Grid tiles source a pre-built ~256px thumbnail, so the
+                    // optimizer adds cost with no benefit — serve it directly.
+                    // The detail view keeps next/image optimization. See ADR-008.
+                    unoptimized
                     onLoad={() => {
                       setImageLoaded(true);
                       recordBlobSuccess();

--- a/apps/web/components/library/image-tile.tsx
+++ b/apps/web/components/library/image-tile.tsx
@@ -437,10 +437,12 @@ function ImageTileComponent({
                       preserveAspectRatio ? 'object-contain' : 'object-cover'
                     )}
                     loading="lazy"
-                    // Grid tiles source a pre-built ~256px thumbnail, so the
-                    // optimizer adds cost with no benefit — serve it directly.
-                    // The detail view keeps next/image optimization. See ADR-008.
-                    unoptimized
+                    // NOTE: the grid currently sources the full original, not the
+                    // 256px thumbnail (the list/search/similar read paths don't
+                    // SELECT thumbnailUrl) — so it must stay optimized for now, or
+                    // it would ship full-res originals. Wiring the thumbnail into
+                    // those reads + serving unoptimized is ticket 048. See ADR-008.
+                    unoptimized={isAnimatedImage}
                     onLoad={() => {
                       setImageLoaded(true);
                       recordBlobSuccess();

--- a/apps/web/docs/adr/008-cap-image-optimization-cost.md
+++ b/apps/web/docs/adr/008-cap-image-optimization-cost.md
@@ -8,11 +8,17 @@ A 2026-06-22 cost audit found the first-to-explode line item is **Vercel Image
 Optimization + CDN bandwidth**, not Blob storage or Replicate. The grid
 (`components/library/image-tile.tsx`) renders every meme through `next/image`,
 and `next.config.ts` declared **8 `deviceSizes` × AVIF+WebP** with **no
-`minimumCacheTTL`**. So each tile — though it already sources a pre-built ~256px
-thumbnail — was re-optimized into up-to-1080px variants in two formats, billed
-per transform + per cache-write ($4–6.40/1M) + bandwidth (up to $0.15/GB). For an
+`minimumCacheTTL`** — so each tile is transformed into many variants in two
+formats, billed per transform + per cache-write ($4–6.40/1M) + bandwidth. For an
 image-heavy library this is uncapped on a viral share link or a crawler: solo
-~$30–40/mo, ~$500–1,100 at 1k users. This is the operator's "unnecessary bills."
+~$30–40/mo, ~$500–1,100 at 1k users.
+
+A fresh-context review corrected an early assumption: the grid does **not**
+source the pre-built 256px thumbnail. The list/shuffle/search/similar read paths
+omit `thumbnail_url`, so `getTileImageSrc` falls through to the full original.
+Serving the grid `unoptimized` would therefore ship full-res originals — *more*
+egress, not less — so the grid must stay optimized until the thumbnail is wired
+into those reads (ticket 048).
 
 The embeddings cron was *suspected* to be a second runaway, but it is already
 bounded: batch of 10, every 5 min, only `embedding: null` assets — no re-embed
@@ -23,32 +29,31 @@ kill-switch already exists (the `embeddings` runtime gate).
 
 Cap the cost in place, independent of any stack migration:
 
-1. **Serve grid thumbnails `unoptimized`.** The grid is the high-volume surface
-   and its source is already a purpose-built ~256px thumbnail — running it
-   through the optimizer is pure waste. `unoptimized` bypasses the optimizer
-   entirely (no transform, no cache-write, no optimization bandwidth); the
-   thumbnail serves directly. The **detail view stays optimized** for crispness
-   (one image, low volume).
-2. **Trim `deviceSizes` 8 → 3** (`[640, 1080, 2048]`) and set a long
-   `minimumCacheTTL` (31 days). Optimized memes are immutable (content-addressed
-   blobs), so caching long minimizes cache-write churn for the surfaces that
-   stay optimized.
+1. **Trim `deviceSizes` 8 → 3** (`[640, 1080, 2048]`) and set a long
+   `minimumCacheTTL` (31 days). This bounds variants-per-image and minimizes
+   cache-write churn for the optimized surfaces (grid + detail + landing).
+   Optimized memes are immutable (content-addressed blobs), so caching long is
+   safe. Extracted to a testable `lib/image-config.ts` with a regression guard.
+2. **Keep the grid optimized for now** — `unoptimized` is deferred to ticket 048,
+   which first wires `thumbnailUrl` into the grid read paths so the grid sources
+   the ~256px thumbnail; only then is `unoptimized` a strict win (and it also
+   fixes the latent waste of optimizing full originals in the grid).
 3. **Remove the inert `includeRecent`/`batchSize` cron params** and name the
-   per-run cap + the runtime-gate kill-switch explicitly, so the dead params
-   can't later be wired into an unbounded re-embed.
-4. **Operator backstops (one-time, dashboard):** a Vercel Spend Management cap +
-   auto-pause webhook (the hard ceiling), and explicit Neon autosuspend.
+   per-run cap + the runtime-gate kill-switch, so the dead params can't later be
+   wired into an unbounded re-embed.
+4. **Operator backstops (one-time, dashboard) — the true hard ceiling:** a Vercel
+   Spend Management cap + auto-pause webhook, and explicit Neon autosuspend.
 
 ## Consequences
 
-- The grid's image cost drops to raw thumbnail egress (cheap; later zeroed by R2
-  in epic 044). Grid thumbnails may be marginally softer on very large/retina
-  viewports — acceptable for a 256px-sourced thumbnail; the detail view stays
-  crisp. Animated images and videos were already handled separately.
-- A config-guard test pins the cost-safe image config so it can't silently
-  regress to 8 deviceSizes / no TTL.
-- The dashboard caps are operator steps (they need Vercel/Neon account access);
-  they are the true uncapped-bill ceiling and are tracked as activation items.
-- **Rejected:** keeping optimization on the grid with a tighter `sizes` — still
-  invokes the optimizer (transform + cache-write per variant); `unoptimized` on
-  an already-thumbnail source is strictly cheaper.
+- Variants-per-image drop 8 → 3 and the long TTL collapses cache-write churn —
+  the two biggest optimization-cost drivers — without any rendering regression.
+  The hard ceiling is the Vercel Spend cap (operator).
+- A config-guard test pins the cost-safe `deviceSizes`/TTL so they can't silently
+  regress to 8 / no-TTL.
+- The bigger structural win (grid serves 256px thumbnails directly, ~20× fewer
+  bytes) is tracked as **048** — it needs `thumbnailUrl` added to the
+  list/shuffle/search/similar reads plus a live render/fallback check, which is
+  more than this in-place cost cap should carry.
+- **Rejected:** serving the grid `unoptimized` now — without the thumbnail in the
+  grid src it would serve full originals, inverting the cost goal.

--- a/apps/web/docs/adr/008-cap-image-optimization-cost.md
+++ b/apps/web/docs/adr/008-cap-image-optimization-cost.md
@@ -1,0 +1,54 @@
+# ADR-008: Cap the image-optimization / CDN cost blast radius
+
+Status: Accepted (2026-06-22)
+
+## Context
+
+A 2026-06-22 cost audit found the first-to-explode line item is **Vercel Image
+Optimization + CDN bandwidth**, not Blob storage or Replicate. The grid
+(`components/library/image-tile.tsx`) renders every meme through `next/image`,
+and `next.config.ts` declared **8 `deviceSizes` × AVIF+WebP** with **no
+`minimumCacheTTL`**. So each tile — though it already sources a pre-built ~256px
+thumbnail — was re-optimized into up-to-1080px variants in two formats, billed
+per transform + per cache-write ($4–6.40/1M) + bandwidth (up to $0.15/GB). For an
+image-heavy library this is uncapped on a viral share link or a crawler: solo
+~$30–40/mo, ~$500–1,100 at 1k users. This is the operator's "unnecessary bills."
+
+The embeddings cron was *suspected* to be a second runaway, but it is already
+bounded: batch of 10, every 5 min, only `embedding: null` assets — no re-embed
+path. Its `includeRecent`/`batchSize` POST params were inert dead code, and a
+kill-switch already exists (the `embeddings` runtime gate).
+
+## Decision
+
+Cap the cost in place, independent of any stack migration:
+
+1. **Serve grid thumbnails `unoptimized`.** The grid is the high-volume surface
+   and its source is already a purpose-built ~256px thumbnail — running it
+   through the optimizer is pure waste. `unoptimized` bypasses the optimizer
+   entirely (no transform, no cache-write, no optimization bandwidth); the
+   thumbnail serves directly. The **detail view stays optimized** for crispness
+   (one image, low volume).
+2. **Trim `deviceSizes` 8 → 3** (`[640, 1080, 2048]`) and set a long
+   `minimumCacheTTL` (31 days). Optimized memes are immutable (content-addressed
+   blobs), so caching long minimizes cache-write churn for the surfaces that
+   stay optimized.
+3. **Remove the inert `includeRecent`/`batchSize` cron params** and name the
+   per-run cap + the runtime-gate kill-switch explicitly, so the dead params
+   can't later be wired into an unbounded re-embed.
+4. **Operator backstops (one-time, dashboard):** a Vercel Spend Management cap +
+   auto-pause webhook (the hard ceiling), and explicit Neon autosuspend.
+
+## Consequences
+
+- The grid's image cost drops to raw thumbnail egress (cheap; later zeroed by R2
+  in epic 044). Grid thumbnails may be marginally softer on very large/retina
+  viewports — acceptable for a 256px-sourced thumbnail; the detail view stays
+  crisp. Animated images and videos were already handled separately.
+- A config-guard test pins the cost-safe image config so it can't silently
+  regress to 8 deviceSizes / no TTL.
+- The dashboard caps are operator steps (they need Vercel/Neon account access);
+  they are the true uncapped-bill ceiling and are tracked as activation items.
+- **Rejected:** keeping optimization on the grid with a tighter `sizes` — still
+  invokes the optimizer (transform + cache-write per variant); `unoptimized` on
+  an already-thumbnail source is strictly cheaper.

--- a/apps/web/lib/image-config.ts
+++ b/apps/web/lib/image-config.ts
@@ -1,0 +1,22 @@
+/**
+ * Cost-safe Next.js Image optimization settings.
+ *
+ * Kept here (not inline in next.config.ts) so a regression test can pin them —
+ * see docs/adr/008-cap-image-optimization-cost.md. The grid serves its ~256px
+ * thumbnails `unoptimized` (components/library/image-tile.tsx), so these settings
+ * govern only the surfaces that stay optimized (the detail/landing pages, one
+ * image at a time). Trim deviceSizes and cache long: optimized memes are
+ * immutable (content-addressed blobs), so re-transforming and short-TTL cache
+ * churn are pure cost.
+ */
+
+/** Responsive widths Next may generate. Trimmed 8 → 3 (mobile / desktop / cap). */
+export const IMAGE_DEVICE_SIZES = [640, 1080, 2048];
+
+/** Fixed-width variants for `sizes` that resolve to a px width. */
+export const IMAGE_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
+
+export const IMAGE_FORMATS = ['image/avif', 'image/webp'] as const;
+
+/** 31 days. Immutable content → cache long to minimize cache-write churn. */
+export const IMAGE_MINIMUM_CACHE_TTL = 60 * 60 * 24 * 31;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,11 @@
 import type { NextConfig } from "next";
 import withPWA from "@ducanh2912/next-pwa";
+import {
+  IMAGE_DEVICE_SIZES,
+  IMAGE_IMAGE_SIZES,
+  IMAGE_FORMATS,
+  IMAGE_MINIMUM_CACHE_TTL,
+} from "./lib/image-config";
 
 const nextConfig: NextConfig = {
   eslint: {
@@ -25,12 +31,13 @@ const nextConfig: NextConfig = {
         hostname: '*.blob.vercel-storage.com',
       }
     ],
-    // Enable WebP and AVIF formats for better compression
-    formats: ['image/avif', 'image/webp'],
-    // Set device sizes for responsive images
-    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-    // Set image sizes for different breakpoints
-    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    // Cost-safe optimization settings (ADR-008). The grid serves thumbnails
+    // unoptimized; these govern the optimized detail/landing surfaces only.
+    formats: [...IMAGE_FORMATS],
+    deviceSizes: IMAGE_DEVICE_SIZES,
+    imageSizes: IMAGE_IMAGE_SIZES,
+    // Optimized meme variants are immutable — cache long to cut cache-write churn.
+    minimumCacheTTL: IMAGE_MINIMUM_CACHE_TTL,
   },
   // Compiler optimizations for production
   compiler: {

--- a/backlog.d/046-cap-cdn-image-optimization-cost-blast-radius.md
+++ b/backlog.d/046-cap-cdn-image-optimization-cost-blast-radius.md
@@ -19,9 +19,11 @@ the operator senses — and it's fixable in hours, in place.
 ## Oracle
 
 - [ ] Vercel Spend Management cap + auto-pause webhook is set (a hard ceiling).
-- [ ] Grid thumbnails are served without per-request optimization (pre-built
-      256px thumbnails / `unoptimized`), `deviceSizes` is trimmed to 2–3 entries,
-      and `minimumCacheTTL` is raised. (The single biggest cost lever.)
+- [x] `deviceSizes` trimmed to 3 + `minimumCacheTTL` raised (31 days), via a
+      testable `lib/image-config.ts` + guard test. **Split (2026-06-22):** serving
+      grid thumbnails `unoptimized` moved to **048** — review found the grid reads
+      omit `thumbnailUrl`, so it sources the full original; `unoptimized` without
+      first wiring the thumbnail would ship full-res originals.
 - [ ] The embeddings cron (`process-embeddings`, every 5 min, batch 10) has a hard
       daily ceiling + a kill-switch on `includeRecent`, so a reprocess loop can't
       run Replicate spend unbounded.

--- a/backlog.d/048-serve-grid-thumbnails-not-full-originals.md
+++ b/backlog.d/048-serve-grid-thumbnails-not-full-originals.md
@@ -1,0 +1,44 @@
+# Serve the grid 256px thumbnails, not full originals
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+The browse/search/related grid renders the pre-built ~256px thumbnail (served
+directly, `unoptimized`), not the full ≤2048px original — cutting grid bytes and
+image-optimization cost ~20×.
+
+## Context
+
+A 2026-06-22 review (during 046) found the grid has been silently serving **full
+originals**: thumbnails are generated and stored on upload
+(`lib/upload/blob-uploader-service.ts:134`, schema `thumbnailUrl`), and
+`image-tile.tsx`'s `getTileImageSrc` prefers `thumbnailUrl` — but the grid read
+paths never SELECT it, so it falls through to `blobUrl`:
+
+- `app/api/assets/route.ts` shuffle/list raw SQL omits `thumbnail_url`.
+- `lib/db.ts` `vectorSearch` (search results) omits it.
+- `app/api/assets/[id]/similar/route.ts:62` hardcodes `thumbnailUrl: null`.
+
+So 046 could only trim the optimizer (deviceSizes/TTL); it could not flip the
+grid to `unoptimized` (that would have shipped full originals). This ticket
+closes that.
+
+## Oracle
+
+- [ ] The list/shuffle (`assets/route.ts`), search (`vectorSearch`), and similar
+      (`similar/route.ts`) read paths return `thumbnailUrl`, so grid tiles source
+      the 256px thumbnail (with the existing thumbnail→blob error fallback intact).
+- [ ] The grid `<Image>` is `unoptimized` (serves the thumbnail directly; the
+      detail/share pages stay optimized). The config-guard / a render check
+      confirms grid `<img src>` is the thumbnail blob URL, not `/_next/image`.
+- [ ] Live check: a seeded grid renders correctly desktop + mobile; a
+      thumbnail-missing asset still falls back to the original without a broken
+      tile.
+
+## Notes
+
+Review finding 2026-06-22 (046). This is the structural cost win 046 deferred;
+it also pairs with epic 044 child 2 (R2 zeroes the remaining thumbnail egress).
+Verify thumbnails actually populate for older assets (backfill if some are null)
+before flipping `unoptimized`, or the fallback serves originals for them.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -29,6 +29,7 @@ Status conventions:
 | [042](042-delete-dead-realtime-and-orphan-upload-infra.md) | Delete Dead Realtime And Orphan-Upload Infrastructure | P2 | S |
 | [045](045-extension-ux-auth-screenshot-feedback.md) | Extension UX: Reachable Auth, Screenshot Capture, Unmissable Feedback (epic) | P2 | M |
 | [047](047-fix-vector-dimension-drift.md) | Fix Vector-Dimension Drift And Version The Embedding Migration | P2 | S |
+| [048](048-serve-grid-thumbnails-not-full-originals.md) | Serve The Grid 256px Thumbnails, Not Full Originals | P2 | S |
 | [043](043-fix-standing-red-lint-design-gate.md) | Fix The Standing-Red lint:design Gate (→ folded into 032 child 3) | P3 | S |
 
 ## Done

--- a/docs/qa/evidence/2026-06-22-cap-image-cost/packet.md
+++ b/docs/qa/evidence/2026-06-22-cap-image-cost/packet.md
@@ -8,53 +8,51 @@
 ## Intent
 
 The first-to-explode cost line is Vercel Image Optimization + CDN bandwidth: the
-grid re-optimized 256px thumbnails into 8 deviceSizes × AVIF/WebP with no cache
-TTL, uncapped on a viral share. Cap it in place, independent of any migration.
-
-## Checks — automated (run)
-
-- **PASS — config guard** (`__tests__/lib/image-config.test.ts`): asserts
-  `deviceSizes.length ≤ 3`, max ≤ 2048 (no 4K variant), `minimumCacheTTL ≥ 7
-  days`. Pins ADR-008 against regression.
-- **PASS — type-check**: `pnpm --filter web type-check` (tsc --noEmit), exit 0.
-- **PASS — lint + auth guard**: `pnpm --filter web lint`, exit 0.
-- **PASS — full suite**: `pnpm --filter web test` → 92 files, **1038 tests**.
-- **No QA-harness regression** (analysis): the grid already passes a
-  `resolveQaSeedSrc`-rewritten local path to `<Image>`, and QA mode already
-  served images unoptimized (`lib/qa/qa-image-loader.ts:24-27`); `unoptimized`
-  is consistent with that.
+grid optimized into 8 deviceSizes × AVIF/WebP with no cache TTL, uncapped on a
+viral share. Cap it in place, independent of any migration.
 
 ## What changed
 
 - `next.config.ts` → `lib/image-config.ts`: `deviceSizes` 8 → `[640, 1080,
-  2048]`; `minimumCacheTTL` set to 31 days.
-- `components/library/image-tile.tsx`: grid `<Image>` is now `unoptimized`
-  (source is a pre-built ~256px thumbnail). Detail view stays optimized.
+  2048]`; `minimumCacheTTL` set to 31 days. Bounds variants-per-image and
+  cache-write churn on every optimized surface.
 - `app/api/cron/process-embeddings/route.ts`: removed the inert
   `includeRecent`/`batchSize` params (foreclosing a future unbounded re-embed);
   named the per-run cap; documented the `embeddings` runtime gate as the
-  kill-switch. (The feared cron runaway did not exist in code — the params were
-  dead and the batch is bounded at 10/5min.)
+  kill-switch. (The feared cron runaway did not exist — params were dead, batch
+  is bounded at 10/5min.)
+- The grid stays `next/image`-optimized. A fresh-context review caught that the
+  grid sources the **full original** (its read paths omit `thumbnailUrl`), so
+  serving it `unoptimized` would ship full-res originals — the opposite of the
+  goal. Wiring the thumbnail + then serving unoptimized is **ticket 048**.
+
+## Checks — automated (run)
+
+- **PASS — config guard** (`__tests__/lib/image-config.test.ts`):
+  `deviceSizes.length ≤ 3`, max ≤ 2048 (no 4K variant), `minimumCacheTTL ≥ 7
+  days`. Pins ADR-008 against regression.
+- **PASS — type-check** (`pnpm --filter web type-check`, exit 0).
+- **PASS — lint + auth guard** (`pnpm --filter web lint`, exit 0).
+- **PASS — full suite** (`pnpm --filter web test` → 92 files, 1038 tests).
 
 ## Checks — operator (not runnable here)
 
-The live browser walk needs local Postgres/Blob/Clerk (absent in this env), and
-the two dashboard caps need Vercel/Neon account access. Operator steps:
+Needs Vercel/Neon account access (and a running app with data):
 
-1. **Live grid check** (DevTools): load `/app`, open Network/Elements — grid
-   image `src` should be a `*.blob.vercel-storage.com/...` thumbnail URL, **not**
-   `/_next/image?url=...`. (Confirms the optimizer is bypassed for the grid.) The
-   detail page (`/app/meme/[id]`) should still use `/_next/image`.
-2. **Vercel Spend Management cap** (the hard ceiling): Vercel → project →
+1. **Vercel Spend Management cap** (the hard ceiling): Vercel → project →
    Settings → Billing → Spend Management → set an amount + enable the pause/notify
-   action. No CLI; dashboard-only.
-3. **Neon autosuspend**: Neon console → project `lively-lake-63852609` → branch →
-   Compute → confirm autosuspend (suspend after idle) is on so solo idle floors
-   near $0.
+   action. No CLI; dashboard-only. **This is the true uncapped-bill backstop.**
+2. **Neon autosuspend**: Neon console → project `lively-lake-63852609` → Compute →
+   confirm autosuspend (suspend after idle) is on so solo idle floors near $0.
+3. **Observability sanity** (optional): confirm in Vercel Observability that
+   Image-Optimization transform + cache-write volume drops after this deploy
+   (fewer deviceSizes + long TTL).
 
 ## Residual
 
-Grid thumbnails serve as raw blob egress now (cheap; zeroed later by R2, 044
-child 2). Slightly softer on very large/retina viewports — acceptable for a
-256px-sourced thumbnail; detail view unaffected. The dashboard caps (2, 3) are
-the true uncapped-bill backstop and remain operator activation items.
+- The grid still optimizes full originals (bounded now: 3 variants, 31-day
+  cache). The ~20× win — grid serving 256px thumbnails directly — is **048**
+  (wire `thumbnailUrl` into the list/shuffle/search/similar reads, then
+  `unoptimized`), which needs a live render/fallback check this env can't run.
+- The dashboard caps (1, 2) remain operator activation items and are the real
+  hard ceiling.

--- a/docs/qa/evidence/2026-06-22-cap-image-cost/packet.md
+++ b/docs/qa/evidence/2026-06-22-cap-image-cost/packet.md
@@ -1,0 +1,60 @@
+# Evidence Packet: cap the CDN / image-optimization cost blast radius (046)
+
+- Date: 2026-06-22
+- Branch: `deliver-046-cap-cost-blast-radius`
+- Ticket: `backlog.d/046-cap-cdn-image-optimization-cost-blast-radius.md`
+- Decision: `apps/web/docs/adr/008-cap-image-optimization-cost.md`
+
+## Intent
+
+The first-to-explode cost line is Vercel Image Optimization + CDN bandwidth: the
+grid re-optimized 256px thumbnails into 8 deviceSizes × AVIF/WebP with no cache
+TTL, uncapped on a viral share. Cap it in place, independent of any migration.
+
+## Checks — automated (run)
+
+- **PASS — config guard** (`__tests__/lib/image-config.test.ts`): asserts
+  `deviceSizes.length ≤ 3`, max ≤ 2048 (no 4K variant), `minimumCacheTTL ≥ 7
+  days`. Pins ADR-008 against regression.
+- **PASS — type-check**: `pnpm --filter web type-check` (tsc --noEmit), exit 0.
+- **PASS — lint + auth guard**: `pnpm --filter web lint`, exit 0.
+- **PASS — full suite**: `pnpm --filter web test` → 92 files, **1038 tests**.
+- **No QA-harness regression** (analysis): the grid already passes a
+  `resolveQaSeedSrc`-rewritten local path to `<Image>`, and QA mode already
+  served images unoptimized (`lib/qa/qa-image-loader.ts:24-27`); `unoptimized`
+  is consistent with that.
+
+## What changed
+
+- `next.config.ts` → `lib/image-config.ts`: `deviceSizes` 8 → `[640, 1080,
+  2048]`; `minimumCacheTTL` set to 31 days.
+- `components/library/image-tile.tsx`: grid `<Image>` is now `unoptimized`
+  (source is a pre-built ~256px thumbnail). Detail view stays optimized.
+- `app/api/cron/process-embeddings/route.ts`: removed the inert
+  `includeRecent`/`batchSize` params (foreclosing a future unbounded re-embed);
+  named the per-run cap; documented the `embeddings` runtime gate as the
+  kill-switch. (The feared cron runaway did not exist in code — the params were
+  dead and the batch is bounded at 10/5min.)
+
+## Checks — operator (not runnable here)
+
+The live browser walk needs local Postgres/Blob/Clerk (absent in this env), and
+the two dashboard caps need Vercel/Neon account access. Operator steps:
+
+1. **Live grid check** (DevTools): load `/app`, open Network/Elements — grid
+   image `src` should be a `*.blob.vercel-storage.com/...` thumbnail URL, **not**
+   `/_next/image?url=...`. (Confirms the optimizer is bypassed for the grid.) The
+   detail page (`/app/meme/[id]`) should still use `/_next/image`.
+2. **Vercel Spend Management cap** (the hard ceiling): Vercel → project →
+   Settings → Billing → Spend Management → set an amount + enable the pause/notify
+   action. No CLI; dashboard-only.
+3. **Neon autosuspend**: Neon console → project `lively-lake-63852609` → branch →
+   Compute → confirm autosuspend (suspend after idle) is on so solo idle floors
+   near $0.
+
+## Residual
+
+Grid thumbnails serve as raw blob egress now (cheap; zeroed later by R2, 044
+child 2). Slightly softer on very large/retina viewports — acceptable for a
+256px-sourced thumbnail; detail view unaffected. The dashboard caps (2, 3) are
+the true uncapped-bill backstop and remain operator activation items.


### PR DESCRIPTION
Closes-backlog: 046-cap-cdn-image-optimization-cost-blast-radius

## Problem
The first-to-explode cost line is **Vercel Image Optimization + CDN bandwidth** (not Blob/Replicate): the grid optimized into **8 `deviceSizes` × AVIF/WebP** with **no `minimumCacheTTL`** — uncapped on a viral share link or a crawler (solo ~$30–40/mo, ~$500–1,100 at 1k users).

## Change (in place, migration-independent)
- **Trim `deviceSizes` 8 → `[640, 1080, 2048]`** and set **`minimumCacheTTL` = 31 days** (optimized meme blobs are immutable) — bounds variants-per-image and collapses cache-write churn, the two biggest optimization-cost drivers. Via a new testable `lib/image-config.ts` + a regression guard.
- **Remove the inert `includeRecent`/`batchSize` cron params** — dead code implying an unbounded re-embed that doesn't exist; name the per-run cap and document the `embeddings` runtime gate as the kill-switch.

## Review catch (and re-scope)
A fresh-context review found the grid sources the **full original**, not the 256px thumbnail (the list/shuffle/search/similar reads omit `thumbnailUrl`). So serving the grid `unoptimized` — my first cut — would have shipped full-res originals, *inverting* the cost goal. Reverted; the grid stays optimized (now bounded). The structural ~20× win (wire `thumbnailUrl` into the reads, then `unoptimized`) is filed as **ticket 048**. ADR-008 records the corrected decision.

## Verification
- Config guard · type-check · lint+auth-guard · full suite **1038/1038** — green.
- Live grid network check + dashboard caps are operator steps (no local DB/Blob/Clerk) — see `docs/qa/evidence/2026-06-22-cap-image-cost/packet.md`.

## Operator activation (the hard ceiling)
1. **Vercel Spend Management** cap + pause action (dashboard — the true uncapped-bill backstop).
2. **Neon autosuspend** on (idle floors near $0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented cost-safe Next.js Image optimization by capping responsive image `deviceSizes` and setting a longer `minimumCacheTTL` to reduce CDN and transform churn.
* **Tests**
  * Added configuration guard tests to prevent image optimization cost regressions.
* **Documentation**
  * Added an ADR and QA/backlog notes describing the cost-control approach and the follow-up work for grid thumbnail handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->