### PR TITLE
perf(web): serve the grid 256px thumbnails, not full originals (048)

### DIFF
--- a/apps/web/__tests__/api/assets.integration.test.ts
+++ b/apps/web/__tests__/api/assets.integration.test.ts
@@ -118,6 +118,25 @@ describe("GET /api/assets seeded shuffle integration", () => {
     });
   });
 
+  // 048: the grid must source the stored thumbnail, not the full original. This
+  // exercises the real shuffle SQL against pgvector so a missing/mistyped
+  // `thumbnail_url` alias is caught (unit mocks + tsc cannot see raw-SQL columns).
+  it("returns the stored thumbnailUrl on each shuffle tile", async () => {
+    const res = await GET(
+      request({ sortBy: "shuffle", shuffleSeed: "7", limit: "4", offset: "0" }),
+      { params: Promise.resolve({}) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.assets.length).toBeGreaterThan(0);
+    for (const tile of body.assets) {
+      expect(tile.thumbnailUrl).toBe(
+        `https://sploot-test.public.blob.vercel-storage.com/thumb-${tile.pathname}`,
+      );
+    }
+  });
+
   it("uses seeded ring order over stable shuffle keys", async () => {
     const fullPage = await GET(
       request({
@@ -236,6 +255,7 @@ function asset(
     id,
     ownerUserId,
     blobUrl: `https://sploot-test.public.blob.vercel-storage.com/${filename}`,
+    thumbnailUrl: `https://sploot-test.public.blob.vercel-storage.com/thumb-${filename}`,
     pathname: filename,
     mime: "image/png",
     size,

--- a/apps/web/__tests__/api/assets.test.ts
+++ b/apps/web/__tests__/api/assets.test.ts
@@ -81,6 +81,7 @@ describe("GET /api/assets", () => {
         {
           id: "asset-b",
           blobUrl: "https://blob.test/b.png",
+          thumbnailUrl: "https://blob.test/thumb-b.png",
           pathname: "memes/b.png",
           mime: "image/png",
           width: 640,
@@ -132,6 +133,8 @@ describe("GET /api/assets", () => {
       "asset-b",
       "asset-a",
     ]);
+    // 048: the shuffle mapping must carry the stored thumbnail through to the grid.
+    expect(body.assets[0].thumbnailUrl).toBe("https://blob.test/thumb-b.png");
     expect(body.pagination).toEqual({
       total: 2,
       limit: 2,
@@ -185,6 +188,9 @@ describe("GET /api/assets", () => {
     expect(mocks.prisma.asset.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         orderBy: { size: "asc" },
+        // 048: the regular-list path must SELECT the thumbnail so the grid can
+        // serve it directly instead of optimizing the full original.
+        select: expect.objectContaining({ thumbnailUrl: true }),
       }),
     );
   });

--- a/apps/web/app/api/assets/[id]/similar/route.ts
+++ b/apps/web/app/api/assets/[id]/similar/route.ts
@@ -56,10 +56,10 @@ async function getHandler(
       .filter((r: { id: string }) => r.id !== id)
       .slice(0, limit);
 
-    const formattedResults = filtered.map((result: { id: string; blob_url: string; pathname: string; mime: string; width: number | null; height: number | null; favorite: boolean; size: number; created_at: Date; distance: number }) => ({
+    const formattedResults = filtered.map((result: { id: string; blob_url: string; thumbnail_url: string | null; pathname: string; mime: string; width: number | null; height: number | null; favorite: boolean; size: number; created_at: Date; distance: number }) => ({
       id: result.id,
       blobUrl: result.blob_url,
-      thumbnailUrl: null,
+      thumbnailUrl: result.thumbnail_url,
       pathname: result.pathname,
       filename: result.pathname.split('/').pop() || result.pathname,
       mime: result.mime,

--- a/apps/web/app/api/assets/[id]/similar/route.ts
+++ b/apps/web/app/api/assets/[id]/similar/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { unstable_rethrow } from 'next/navigation';
-import { prisma, vectorSearch } from '@/lib/db';
+import { prisma, vectorSearch, type VectorSearchRow } from '@/lib/db';
 import { getAuth } from '@/lib/auth/server';
 import { withObservability } from '@/lib/with-observability';
 import type { RouteContext } from '@/lib/with-observability';
@@ -56,7 +56,7 @@ async function getHandler(
       .filter((r: { id: string }) => r.id !== id)
       .slice(0, limit);
 
-    const formattedResults = filtered.map((result: { id: string; blob_url: string; thumbnail_url: string | null; pathname: string; mime: string; width: number | null; height: number | null; favorite: boolean; size: number; created_at: Date; distance: number }) => ({
+    const formattedResults = filtered.map((result: VectorSearchRow) => ({
       id: result.id,
       blobUrl: result.blob_url,
       thumbnailUrl: result.thumbnail_url,

--- a/apps/web/app/api/assets/route.ts
+++ b/apps/web/app/api/assets/route.ts
@@ -66,6 +66,7 @@ function shuffleSeedToPivot(seed: number): bigint {
 type AssetListRow = {
   id: string;
   blobUrl: string;
+  thumbnailUrl: string | null;
   pathname: string;
   mime: string;
   width: number | null;
@@ -136,6 +137,7 @@ async function fetchShuffleSegment(
       SELECT
         a.id,
         a.blob_url,
+        a.thumbnail_url,
         a.pathname,
         a.mime,
         a.width,
@@ -160,6 +162,7 @@ async function fetchShuffleSegment(
     SELECT
       a.id,
       a.blob_url as "blobUrl",
+      a.thumbnail_url as "thumbnailUrl",
       a.pathname,
       a.mime,
       a.width,
@@ -596,6 +599,7 @@ async function getHandler(req: NextRequest) {
                 select: {
                   id: true,
                   blobUrl: true,
+                  thumbnailUrl: true,
                   pathname: true,
                   mime: true,
                   width: true,
@@ -642,6 +646,7 @@ async function getHandler(req: NextRequest) {
     const formattedAssets = assets.map((asset: any) => ({
       id: asset.id,
       blobUrl: asset.blobUrl,
+      thumbnailUrl: asset.thumbnailUrl ?? null,
       pathname: asset.pathname,
       filename: asset.pathname,
       mime: asset.mime,

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -159,6 +159,7 @@ async function postHandler(req: NextRequest) {
         return {
           id: result.id,
           blobUrl: result.blob_url,
+          thumbnailUrl: result.thumbnail_url ?? null,
           pathname: result.pathname,
           filename: result.pathname.split('/').pop() || result.pathname,
           mime: result.mime,

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { unstable_rethrow } from 'next/navigation';
-import { prisma, vectorSearch, logSearch } from '@/lib/db';
+import { prisma, vectorSearch, logSearch, type VectorSearchRow } from '@/lib/db';
 import { createEmbeddingService, EmbeddingError } from '@/lib/embeddings';
 import { getCacheService } from '@/lib/cache';
 import { getAuthWithUser } from '@/lib/auth/server';
@@ -149,7 +149,7 @@ async function postHandler(req: NextRequest) {
 
     // Format results with additional metadata
     const formattedResults = await Promise.all(
-      searchResults.map(async (result: any) => {
+      searchResults.map(async (result: VectorSearchRow) => {
         // Get tags for each asset
         const assetTags = await prisma!.assetTag.findMany({
           where: { assetId: result.id },

--- a/apps/web/components/library/image-tile.tsx
+++ b/apps/web/components/library/image-tile.tsx
@@ -437,12 +437,12 @@ function ImageTileComponent({
                       preserveAspectRatio ? 'object-contain' : 'object-cover'
                     )}
                     loading="lazy"
-                    // NOTE: the grid currently sources the full original, not the
-                    // 256px thumbnail (the list/search/similar read paths don't
-                    // SELECT thumbnailUrl) — so it must stay optimized for now, or
-                    // it would ship full-res originals. Wiring the thumbnail into
-                    // those reads + serving unoptimized is ticket 048. See ADR-008.
-                    unoptimized={isAnimatedImage}
+                    // Grid tiles source the pre-built ~256px thumbnail (the
+                    // list/shuffle/search/similar reads return thumbnailUrl as of
+                    // 048), so the optimizer would add transform + cache-write cost
+                    // for no benefit — serve it directly. The detail/share pages
+                    // stay optimized. See ADR-008.
+                    unoptimized
                     onLoad={() => {
                       setImageLoaded(true);
                       recordBlobSuccess();

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -716,6 +716,7 @@ export async function vectorSearch(
       Array<{
         id: string;
         blob_url: string;
+        thumbnail_url: string | null;
         pathname: string;
         mime: string;
         width: number | null;
@@ -729,6 +730,7 @@ export async function vectorSearch(
       SELECT
         a.id,
         a.blob_url,
+        a.thumbnail_url,
         a.pathname,
         a.mime,
         a.width,

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -684,6 +684,20 @@ export async function upsertAssetEmbedding(
  * Helper function to execute vector similarity search
  * Note: This uses raw SQL since Prisma doesn't natively support pgvector operations
  */
+export interface VectorSearchRow {
+  id: string;
+  blob_url: string;
+  thumbnail_url: string | null;
+  pathname: string;
+  mime: string;
+  width: number | null;
+  height: number | null;
+  favorite: boolean;
+  size: number;
+  created_at: Date;
+  distance: number;
+}
+
 export async function vectorSearch(
   userId: string,
   queryEmbedding: number[],
@@ -712,21 +726,7 @@ export async function vectorSearch(
   try {
     // ALWAYS order by similarity (preserve semantic ranking)
     // Shuffle happens in application code after fetching top results
-    const results = await prisma.$queryRaw<
-      Array<{
-        id: string;
-        blob_url: string;
-        thumbnail_url: string | null;
-        pathname: string;
-        mime: string;
-        width: number | null;
-        height: number | null;
-        favorite: boolean;
-        size: number;
-        created_at: Date;
-        distance: number;
-      }>
-    >(Prisma.sql`
+    const results = await prisma.$queryRaw<VectorSearchRow[]>(Prisma.sql`
       SELECT
         a.id,
         a.blob_url,

--- a/apps/web/lib/taste/taste-engine.ts
+++ b/apps/web/lib/taste/taste-engine.ts
@@ -8,6 +8,7 @@ export type TasteProfileStatus = 'ready' | 'insufficient_bangers';
 export interface TasteAssetRow {
   id: string;
   blobUrl: string;
+  thumbnailUrl: string | null;
   pathname: string;
   mime: string;
   width: number | null;
@@ -212,6 +213,7 @@ async function fetchTasteAssets(options: TasteAssetQueryOptions): Promise<TasteA
     SELECT
       a.id,
       a.blob_url AS "blobUrl",
+      a.thumbnail_url AS "thumbnailUrl",
       a.pathname,
       a.mime,
       a.width,

--- a/backlog.d/049-unify-asset-dto-mappers.md
+++ b/backlog.d/049-unify-asset-dto-mappers.md
@@ -1,0 +1,44 @@
+# Unify the hand-rolled asset→DTO mappers behind one canonical mapper
+
+Priority: P3 · Status: ready · Estimate: M
+
+## Goal
+
+There is one canonical function that turns an asset row into the grid/client
+asset DTO, used by every read path — so a field can't be silently dropped from
+one surface again.
+
+## Context
+
+Delivering 048 (and 046's review) found the grid asset shape is hand-rolled in
+**five** places, each with a slightly different source shape and field set:
+
+- `app/api/assets/route.ts` `formattedAssets` (camelCase Prisma/shuffle rows)
+- `app/api/assets/route.ts` shuffle raw SQL (`AssetListRow`)
+- `lib/taste/taste-engine.ts` `getTasteWeightedAssets` (`TasteAssetRow`)
+- `app/api/search/route.ts` (snake_case `vectorSearch` rows + tags)
+- `app/api/assets/[id]/similar/route.ts` (snake_case `vectorSearch` rows)
+
+`thumbnailUrl` was missing from all of them (048); `similar` even hardcoded it to
+`null`. The divergence is the root cause: there is no single place that owns "what
+shape does the grid get." Each new field (next: a perceptual-hash flag from 040,
+or pile membership) risks the same per-path omission.
+
+## Oracle
+
+- [ ] A single `toGridAsset(row)` (or similar) mapper owns the grid/client asset
+      DTO; the snake_case (`vectorSearch`) and camelCase (Prisma/shuffle/taste)
+      sources are normalized into it.
+- [ ] All five read paths build their response assets through it; no path
+      hand-rolls the shape.
+- [ ] A type (not `any`) defines the DTO so a missing field is a compile error,
+      not a silent drop — removing the `any`-typed `.map((asset: any) => …)` casts
+      that hid the 048 bug.
+
+## Notes
+
+From 048 / the 046 review (2026-06-22). The `any`-typed mappers are why `tsc`
+didn't catch the dropped `thumbnailUrl`; an explicit DTO type is the real fix.
+Watch the genuine per-path differences (search adds `similarity`/`relevance`/tags;
+taste adds `tasteScore`; embedding shapes differ) — model them as explicit
+extensions of the base DTO, not as a reason to keep five mappers.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -30,6 +30,7 @@ Status conventions:
 | [045](045-extension-ux-auth-screenshot-feedback.md) | Extension UX: Reachable Auth, Screenshot Capture, Unmissable Feedback (epic) | P2 | M |
 | [047](047-fix-vector-dimension-drift.md) | Fix Vector-Dimension Drift And Version The Embedding Migration | P2 | S |
 | [048](048-serve-grid-thumbnails-not-full-originals.md) | Serve The Grid 256px Thumbnails, Not Full Originals | P2 | S |
+| [049](049-unify-asset-dto-mappers.md) | Unify The Hand-Rolled Asset→DTO Mappers Behind One Canonical Mapper | P3 | M |
 | [043](043-fix-standing-red-lint-design-gate.md) | Fix The Standing-Red lint:design Gate (→ folded into 032 child 3) | P3 | S |
 
 ## Done

--- a/docs/qa/evidence/2026-06-22-grid-thumbnails/packet.md
+++ b/docs/qa/evidence/2026-06-22-grid-thumbnails/packet.md
@@ -1,0 +1,61 @@
+# Evidence Packet: serve the grid 256px thumbnails, not full originals (048)
+
+- Date: 2026-06-22
+- Branch: `deliver-048-grid-thumbnails`
+- Ticket: `backlog.d/048-serve-grid-thumbnails-not-full-originals.md`
+- Builds on: ADR-008 (the deferred grid-`unoptimized` part)
+
+## Intent
+
+The grid silently served full ≤2048px originals: thumbnails are stored on upload,
+but the grid read paths omitted `thumbnailUrl`, so `getTileImageSrc` fell through
+to `blobUrl`. Wire the thumbnail into every grid read path, then serve it
+`unoptimized` (no Vercel optimizer) — ~20× fewer grid bytes + zero optimization
+cost on the highest-volume surface.
+
+## What changed (all 5 grid read paths + the tile)
+
+- **Regular list** (`assets/route.ts`): `findMany` select + the `formattedAssets`
+  mapping now include `thumbnailUrl`.
+- **Shuffle** (`assets/route.ts` `fetchShuffleSegment`): `thumbnail_url` added to
+  the CTE + outer `… as "thumbnailUrl"`; `AssetListRow` type updated.
+- **Taste** (`taste-engine.ts` `getTasteWeightedAssets`): SQL `… AS "thumbnailUrl"`
+  + `TasteAssetRow` type.
+- **Search** (`db.ts` `vectorSearch` + `search/route.ts`): `a.thumbnail_url` in
+  the SQL + row type; route maps `result.thumbnail_url`.
+- **Similar** (`similar/route.ts`): was hardcoded `thumbnailUrl: null` → real value.
+- **Tile** (`image-tile.tsx`): grid `<Image unoptimized>` (detail/share stay
+  optimized).
+
+## Checks — automated (run)
+
+- **PASS — real-DB integration** (`assets.integration.test.ts`): a new case
+  asserts the **shuffle SQL returns the seeded `thumbnailUrl`** for every tile,
+  run against pgvector. This catches a missing/mistyped `thumbnail_url` alias that
+  unit mocks and `tsc` cannot see. Ran and passed locally + CI.
+- **PASS — regular-list unit** (`assets.test.ts`): `findMany` select includes
+  `thumbnailUrl: true`; the mapping carries it through to the response.
+- **PASS — type-check**: the typed row shapes (`AssetListRow`, `TasteAssetRow`,
+  `vectorSearch` row, `similar` inline) all carry the column consistently.
+- **PASS — full suite**: 92 files, **1039 tests**. lint + auth-guard green.
+
+## Coverage note
+
+The shuffle path is covered end-to-end against a real DB. Taste, search, and
+similar use the **identical raw-SQL-alias + mapping pattern** the shuffle
+integration test proves, and are type-checked; they are verified by inspection
+rather than a dedicated integration test (each would need embedding seeds — a
+heavier follow-up not warranted for this S change).
+
+## Operator / residual
+
+- **Live grid check**: load `/app` — grid `<img src>` should now be the
+  `…/thumb-…` thumbnail blob URL served directly (not `/_next/image?…`); the
+  detail page stays on `/_next/image`.
+- **Backfill caveat**: assets with `thumbnailUrl = null` (older uploads, or
+  formats without a thumbnail) fall back to the original served `unoptimized` —
+  renders correctly, just larger bytes for those specific assets. If many are
+  null, a thumbnail backfill is worthwhile; can't count from here.
+- The remaining thumbnail egress is zeroed later by R2 (epic 044 child 2).
+- Follow-up **049**: unify the 5 hand-rolled asset→DTO mappers behind one
+  canonical mapper so a field can't be dropped per-path again.


### PR DESCRIPTION
Closes-backlog: 048-serve-grid-thumbnails-not-full-originals

## Problem
The grid silently served full ≤2048px originals. Thumbnails are generated/stored on upload, and `getTileImageSrc` prefers `thumbnailUrl` — but the **five** grid read paths never SELECT it, so it fell through to `blobUrl`. (This is exactly why 046 couldn't flip the grid to `unoptimized`.)

## Change — wire `thumbnailUrl` through every path, then `unoptimized`
- **Regular list** (`assets/route.ts`): `findMany` select + `formattedAssets` mapping.
- **Shuffle** (`assets/route.ts`): raw SQL `… as "thumbnailUrl"` + `AssetListRow`.
- **Taste** (`taste-engine.ts`): SQL alias + `TasteAssetRow`.
- **Search** (`db.ts vectorSearch` + `search/route.ts`): SQL + row type + mapping.
- **Similar** (`similar/route.ts`): was hardcoded `null` → real value.
- **Tile** (`image-tile.tsx`): grid `<Image unoptimized>`; detail/share stay optimized.

Result: the grid serves the ~256px thumbnail directly — ~20× fewer bytes, zero optimizer cost on the highest-volume surface.

## Verification
- **Real-DB integration** (`assets.integration.test.ts`): asserts the shuffle SQL returns the seeded `thumbnailUrl` on every tile (run against pgvector — catches alias typos `tsc`/mocks can't). Ran + passed.
- Unit locks: `findMany` select includes `thumbnailUrl: true`; mapping carries it through.
- type-check (typed row shapes consistent) · full suite **1039** · lint+auth-guard — green.
- Taste/search/similar use the identical raw-SQL pattern the shuffle integration test proves; verified by inspection (own integration tests would need embedding seeds — deferred).

## Residual
- **Backfill caveat**: assets with `thumbnailUrl = null` fall back to the original served `unoptimized` (renders fine, larger bytes for those). A thumbnail backfill is worthwhile if many are null.
- Filed **049**: unify the five hand-rolled, `any`-typed mappers that let the field go missing (the root cause; an explicit DTO type makes a drop a compile error).
- R2 (044 child 2) zeroes the remaining thumbnail egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The grid now serves optimized 256px thumbnails (instead of full-size images), improving load time and reducing bandwidth.
  * Asset-related APIs now include `thumbnailUrl` in responses so thumbnails can be rendered directly across grid read paths.
* **Bug Fixes**
  * Fixed missing/incorrect thumbnail URLs in shuffle, search, and similar results.
* **Tests**
  * Added/updated API and integration tests to verify thumbnail URL behavior against real database-backed data.
* **Documentation**
  * Added QA evidence documenting the thumbnail rollout and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->