### PR TITLE
feat(observability): report canary health check-ins

### DIFF
--- a/apps/web/__tests__/api/health.test.ts
+++ b/apps/web/__tests__/api/health.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/with-observability', () => ({
 
 vi.mock('@/lib/canary-reporter', () => ({
   canaryConfigured: vi.fn(() => false),
+  reportCanaryCheckIn: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('@/package.json', () => ({

--- a/apps/web/__tests__/lib/canary-reporter.test.ts
+++ b/apps/web/__tests__/lib/canary-reporter.test.ts
@@ -99,4 +99,48 @@ describe('canary reporter', () => {
       status: 'not_configured',
     });
   });
+
+  it('posts health check-ins to Canary ingest', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { reportCanaryCheckIn } = await import('@/lib/canary-reporter');
+
+    await reportCanaryCheckIn({
+      status: 'alive',
+      summary: 'sploot-web health route ok',
+      ttlMs: 300_000,
+      context: {
+        route: '/api/health',
+        authorization: 'Bearer secret',
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://canary.example.test/api/v1/check-ins',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-canary-key',
+          'X-API-Key': 'test-canary-key',
+        }),
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+
+    expect(body).toMatchObject({
+      monitor: 'sploot-test',
+      status: 'alive',
+      summary: 'sploot-web health route ok',
+      ttl_ms: 300_000,
+      context: {
+        source: 'sploot-web',
+        environment: 'test',
+        route: '/api/health',
+        authorization: '[redacted]',
+      },
+    });
+  });
 });

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
 import { kv } from '@vercel/kv';
-import { canaryConfigured } from '@/lib/canary-reporter';
+import { canaryConfigured, reportCanaryCheckIn } from '@/lib/canary-reporter';
 import { withObservability } from '@/lib/with-observability';
 import { logger } from '@/lib/observability-logger';
 import pkg from '@/package.json';
@@ -179,6 +179,12 @@ async function getHandler(_req: NextRequest) {
         version: pkg.version,
       };
 
+      await reportHealthCheckIn('alive', 'sploot-web health route ok', {
+        database: 'up',
+        redis: 'up',
+        connection_latency_ms: results.db.latency_ms,
+      });
+
       return NextResponse.json(payload, {
         status: 200,
         headers: {
@@ -203,6 +209,12 @@ async function getHandler(_req: NextRequest) {
           env_vars: envVars,
         },
       };
+
+      await reportHealthCheckIn('error', 'sploot-web health route degraded', {
+        database: results.db.success ? 'up' : 'down',
+        redis: results.redis ? 'up' : 'down',
+        error: errorMsg.join(', '),
+      });
 
       return NextResponse.json(payload, {
         status: 503,
@@ -230,6 +242,10 @@ async function getHandler(_req: NextRequest) {
       },
     };
 
+    await reportHealthCheckIn('error', 'sploot-web health route failed', {
+      error: payload.error,
+    });
+
     return NextResponse.json(payload, {
       status: 503,
       headers: {
@@ -246,6 +262,22 @@ async function headHandler(req: NextRequest) {
     headers: {
       'Cache-Control': res.headers.get('Cache-Control') || 'no-cache, no-store, must-revalidate',
       'Content-Type': res.headers.get('Content-Type') || 'application/json',
+    },
+  });
+}
+
+async function reportHealthCheckIn(
+  status: 'alive' | 'error',
+  summary: string,
+  context: Record<string, any>
+) {
+  await reportCanaryCheckIn({
+    status,
+    summary,
+    ttlMs: 300_000,
+    context: {
+      route: '/api/health',
+      ...context,
     },
   });
 }

--- a/apps/web/lib/canary-reporter.ts
+++ b/apps/web/lib/canary-reporter.ts
@@ -21,6 +21,13 @@ interface CanaryReportInput {
   severity?: Severity;
 }
 
+interface CanaryCheckInInput {
+  status?: 'alive' | 'in_progress' | 'ok' | 'error';
+  summary: string;
+  ttlMs?: number;
+  context?: Record<string, any>;
+}
+
 interface CanaryStatus {
   configured: boolean;
   reachable: boolean | null;
@@ -125,6 +132,45 @@ export async function checkCanaryStatus(): Promise<CanaryStatus> {
       status: 'degraded',
       message: error instanceof Error ? error.message : 'Canary unreachable',
     };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function reportCanaryCheckIn(input: CanaryCheckInInput): Promise<void> {
+  const config = getCanaryConfig();
+  if (!config) {
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    await fetch(`${config.endpoint}/api/v1/check-ins`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'X-API-Key': config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        monitor: config.service,
+        status: input.status ?? 'alive',
+        summary: input.summary,
+        ttl_ms: input.ttlMs ?? 300_000,
+        context: sanitizeValue({
+          source: 'sploot-web',
+          environment: config.environment,
+          vercel_region: process.env.VERCEL_REGION,
+          vercel_url: process.env.VERCEL_URL,
+          ...input.context,
+        }),
+      }),
+      signal: controller.signal,
+    });
+  } catch {
+    // Canary must never affect the user flow or primary health route.
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
## Summary
- report Canary monitor check-ins from /api/health
- keep existing Canary error reporting behavior intact
- use existing Vercel production CANARY_* secrets; no secrets committed

## Verification
- pnpm --dir apps/web exec vitest run __tests__/lib/canary-reporter.test.ts __tests__/api/health.test.ts
- DATABASE_URL='postgresql://test:test@localhost:5432/sploot_test' pnpm lint && DATABASE_URL='postgresql://test:test@localhost:5432/sploot_test' pnpm type-check && DATABASE_URL='postgresql://test:test@localhost:5432/sploot_test' pnpm --filter web test && pnpm --filter extension build
- pre-push: gitleaks, secrets:check, typecheck

Agent: codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: canary-906