### PR TITLE
chore(factory): add Canary integration receipt

### DIFF
--- a/.canary/integration.json
+++ b/.canary/integration.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "service": "sploot-web",
+  "environment": "production",
+  "canary_endpoint": "https://canary-obs.fly.dev",
+  "health_url": "https://www.sploot.app/api/health",
+  "target_id": "TGT-4y0pa5ph1rws",
+  "monitor_ids": [
+    "MON-arka6z0fp920"
+  ],
+  "webhook_ids": [],
+  "api_key_id": null,
+  "verification_status": "verified",
+  "env_names": [
+    "CANARY_ENDPOINT",
+    "CANARY_API_KEY",
+    "NEXT_PUBLIC_CANARY_ENDPOINT",
+    "NEXT_PUBLIC_CANARY_API_KEY"
+  ],
+  "verification_commands": [
+    "bin/canary integrate status /Users/phaedrus/Development/sploot --service sploot-web --production-url https://www.sploot.app/api/health --json",
+    "bin/canary errors sploot-web --window 1h --json"
+  ],
+  "last_verified_at": "2026-07-03T22:43:37Z"
+}


### PR DESCRIPTION
## Summary
- Adds Factory stack integration metadata for Canary, Powder, or Landmark.
- Keeps the change manifest/receipt-only; no runtime behavior changes.

## Verification
- See local fleet audit: meta/briefs/2026-07-03-misty-step-factory-integration.html
- Harness/commit hooks ran where configured during commit/push.