### PR TITLE
chore(license): add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Misty Step LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -24,7 +24,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "packageManager": "pnpm@10.22.0",
   "devDependencies": {
     "@types/chrome": "^0.1.42",


### PR DESCRIPTION
## Summary
- Add root MIT LICENSE for Misty Step LLC.
- Align `apps/extension/package.json` license metadata from ISC to MIT.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm type-check`
- `docker run -d --name ms909-sploot-pg ... pgvector/pgvector:pg15`
- `DATABASE_URL=postgresql://test:test@localhost:5432/sploot_test?sslmode=disable pnpm --filter web db:migrate`
- `DATABASE_URL=postgresql://test:test@localhost:5432/sploot_test?sslmode=disable pnpm --filter web test` (93 files, 1038 tests passed)
- `pnpm --filter extension build`
- push pre-push checks passed

Agent: codex
Agent-Surface: Codex CLI
Agent-Model: OpenAI GPT-5
Agent-Task: misty-step-909