### PR TITLE
Push-button local boot: pnpm dev:local from clone to a seeded, signed-in, searchable /app (sploot-072)

### DIFF
--- a/.agents/skills/sploot-qa/SKILL.md
+++ b/.agents/skills/sploot-qa/SKILL.md
@@ -35,6 +35,11 @@ text→image search finds it → favorite/tag. Web routes: `/app`, `/app/search`
 
 ```sh
 pnpm install
+pnpm dev:local      # push-button: docker pgvector + migrate + qa:seed + qa-local
+                    # auth + dev server + doctor evidence (.sploot-local/doctor/);
+                    # sign in via http://localhost:3001/api/qa-auth/login;
+                    # teardown: pnpm dev:local:down
+# — or against real services —
 cp apps/web/.env.example apps/web/.env.local   # fill required vars (below)
 pnpm dev            # web: http://localhost:3001  (turbo runs all apps)
 pnpm dev:web        # web only, same port

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ next-env.d.ts
 .spellbook/traces/provider-lanes/
 .pi/state/
 .codex/agents/
+
+# dev:local doctor evidence + local state
+.sploot-local/

--- a/README.md
+++ b/README.md
@@ -29,9 +29,33 @@ This monorepo consolidates the Sploot web application, browser extension, and sh
 pnpm install
 ```
 
-### Development
+### Local loop, no vendor credentials (recommended first run)
 
-Run all apps simultaneously (Web: localhost:3001, Extension: hot-reload):
+One command from clone to a signed-in, seeded, searchable library — no
+Clerk/Neon/Blob/Replicate keys. Requires Docker for the local pgvector
+Postgres:
+
+```bash
+pnpm dev:local
+```
+
+It provisions the database, applies migrations, seeds 24 browsable assets,
+boots the web app with qa-local auth (see `apps/web/docs/AUTH.md`), and runs a
+doctor pass that writes an evidence packet (health, signed-in `/app`, seeded
+grid, search response) to `.sploot-local/doctor/`. When it finishes, open
+`http://localhost:3001/api/qa-auth/login` to land signed-in on `/app`.
+
+Teardown (removes the database container and generated files):
+
+```bash
+pnpm dev:local:down
+```
+
+### Development against real services
+
+Run all apps simultaneously (Web: localhost:3001, Extension: hot-reload) —
+requires `apps/web/.env.local` with real vendor credentials
+(`apps/web/.env.example`):
 
 ```bash
 pnpm dev

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -67,8 +67,9 @@ UPSTASH_REDIS_REST_TOKEN=your_upstash_token_here
 # ============================================
 # DEVELOPMENT OPTIONS
 # ============================================
-# Set to true to use mock mode (no external services needed)
-MOCK_MODE=false
+# Credential-free local loop (local pgvector Postgres + qa-local auth +
+# seeded assets): run `pnpm dev:local` from the repo root instead of setting
+# the vendor variables above. See docs/AUTH.md.
 
 # Port for development server (default: 3000)
 PORT=3000

--- a/apps/web/__tests__/api/embedding-runtime-gates.test.ts
+++ b/apps/web/__tests__/api/embedding-runtime-gates.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   createEmbeddingService: vi.fn(),
   getSearchResults: vi.fn(),
   setSearchResults: vi.fn(),
+  getTextEmbedding: vi.fn(),
   findFirst: vi.fn(),
   findManyAssetTags: vi.fn(),
   vectorSearch: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock('@/lib/auth/server', () => ({
 }));
 
 vi.mock('@/lib/embeddings', () => ({
+  CLIP_MODEL: 'test/clip:model',
   createEmbeddingService: mocks.createEmbeddingService,
   EmbeddingError: class EmbeddingError extends Error {
     constructor(message: string, public statusCode?: number) {
@@ -31,6 +33,7 @@ vi.mock('@/lib/cache', () => ({
   getCacheService: () => ({
     getSearchResults: mocks.getSearchResults,
     setSearchResults: mocks.setSearchResults,
+    getTextEmbedding: mocks.getTextEmbedding,
   }),
 }));
 

--- a/apps/web/__tests__/api/qa-auth-login.test.ts
+++ b/apps/web/__tests__/api/qa-auth-login.test.ts
@@ -1,0 +1,61 @@
+import { GET } from '@/app/api/qa-auth/login/route';
+import { verifyQaLocalAuthHeaders } from '@/lib/auth/qa-local';
+import { NextRequest } from 'next/server';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const QA_SECRET = 'qa-auth-login-test-secret-with-entropy';
+
+function makeRequest(url = 'http://localhost:3001/api/qa-auth/login') {
+  return new NextRequest(url);
+}
+
+describe('/api/qa-auth/login', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.SPLOOT_QA_AUTH_MODE = 'enabled';
+    process.env.SPLOOT_QA_AUTH_SECRET = QA_SECRET;
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('sets a verifiable qa-local session cookie and redirects to /app', async () => {
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost:3001/app');
+
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sploot_qa_auth=');
+    expect(setCookie.toLowerCase()).toContain('httponly');
+
+    const token = decodeURIComponent(
+      setCookie.split(';')[0].replace('sploot_qa_auth=', '')
+    );
+    const headers = new Headers({ cookie: `sploot_qa_auth=${token}` });
+    const auth = await verifyQaLocalAuthHeaders(headers);
+    expect(auth.status).toBe('authenticated');
+    if (auth.status === 'authenticated') {
+      expect(auth.principal.userId).toBe('qa-design-user');
+    }
+  });
+
+  it('returns 404 when qa-local auth mode is not enabled', async () => {
+    delete process.env.SPLOOT_QA_AUTH_MODE;
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('returns 404 in production even when mode is enabled', async () => {
+    process.env.VERCEL_ENV = 'production';
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+});

--- a/apps/web/__tests__/api/search-cached-query.test.ts
+++ b/apps/web/__tests__/api/search-cached-query.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getAuthWithUser: vi.fn(),
+  createEmbeddingService: vi.fn(),
+  getSearchResults: vi.fn(),
+  setSearchResults: vi.fn(),
+  getTextEmbedding: vi.fn(),
+  findManyAssetTags: vi.fn(),
+  vectorSearch: vi.fn(),
+  logSearch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/server', () => ({
+  getAuthWithUser: mocks.getAuthWithUser,
+}));
+
+vi.mock('@/lib/embeddings', () => ({
+  CLIP_MODEL: 'test/clip:model',
+  createEmbeddingService: mocks.createEmbeddingService,
+  EmbeddingError: class EmbeddingError extends Error {
+    constructor(message: string, public statusCode?: number) {
+      super(message);
+    }
+  },
+}));
+
+vi.mock('@/lib/cache', () => ({
+  getCacheService: () => ({
+    getSearchResults: mocks.getSearchResults,
+    setSearchResults: mocks.setSearchResults,
+    getTextEmbedding: mocks.getTextEmbedding,
+  }),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    assetTag: {
+      findMany: mocks.findManyAssetTags,
+    },
+  },
+  vectorSearch: mocks.vectorSearch,
+  logSearch: mocks.logSearch,
+}));
+
+vi.mock('@/lib/with-observability', () => ({
+  withObservability: (handler: any) => handler,
+}));
+
+import { POST as search } from '@/app/api/search/route';
+
+function searchRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/search', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('/api/search with a cached query embedding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAuthWithUser.mockResolvedValue({ userId: 'qa-design-user' });
+    mocks.getSearchResults.mockResolvedValue(null);
+    mocks.setSearchResults.mockResolvedValue(undefined);
+    mocks.findManyAssetTags.mockResolvedValue([]);
+    mocks.logSearch.mockResolvedValue(undefined);
+  });
+
+  it('serves results from the cached embedding without the Replicate service', async () => {
+    const cachedEmbedding = new Array(512).fill(0).map((_, i) => (i === 3 ? 1 : 0));
+    mocks.getTextEmbedding.mockResolvedValue(cachedEmbedding);
+    mocks.createEmbeddingService.mockImplementation(() => {
+      throw new Error('Replicate API token not configured');
+    });
+    mocks.vectorSearch.mockResolvedValue([
+      {
+        id: 'asset-1',
+        blob_url: 'https://sploot-qa-seed.public.blob.vercel-storage.com/a.png',
+        thumbnail_url: null,
+        pathname: 'qa/a.png',
+        mime: 'image/png',
+        width: 800,
+        height: 800,
+        favorite: false,
+        size: 1234,
+        created_at: new Date().toISOString(),
+        distance: 0.91,
+      },
+    ]);
+
+    const res = await search(searchRequest({ query: 'reaction face meme' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].id).toBe('asset-1');
+    expect(mocks.vectorSearch).toHaveBeenCalledWith(
+      'qa-design-user',
+      cachedEmbedding,
+      expect.objectContaining({ limit: 30 })
+    );
+    expect(mocks.createEmbeddingService).not.toHaveBeenCalled();
+  });
+
+  it('still reports 503 for uncached queries when the service is unconfigured', async () => {
+    mocks.getTextEmbedding.mockResolvedValue(null);
+    mocks.createEmbeddingService.mockImplementation(() => {
+      throw new Error('Replicate API token not configured');
+    });
+
+    const res = await search(searchRequest({ query: 'query nobody cached' }));
+    expect(res.status).toBe(503);
+    expect(mocks.vectorSearch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/qa-auth/login/route.ts
+++ b/apps/web/app/api/qa-auth/login/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  createQaLocalAuthToken,
+  getQaLocalAuthCookieName,
+  isQaLocalAuthEnabled,
+} from '@/lib/auth/qa-local';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const QA_USER_ID = 'qa-design-user';
+const SESSION_SECONDS = 8 * 60 * 60;
+
+/**
+ * Dev-only browser sign-in for the qa-local auth harness.
+ *
+ * When SPLOOT_QA_AUTH_MODE=enabled (hard-refused in production by
+ * isQaLocalAuthEnabled), GET mints a signed qa-local token for the seeded
+ * QA user, sets it as the session cookie, and redirects to /app — so
+ * `pnpm dev:local` can end at a signed-in, seeded grid without Clerk
+ * credentials. Anywhere else this route is indistinguishable from a 404.
+ */
+export async function GET(request: NextRequest) {
+  if (!isQaLocalAuthEnabled()) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const secret = process.env.SPLOOT_QA_AUTH_SECRET;
+  if (!secret) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const token = await createQaLocalAuthToken({
+    userId: QA_USER_ID,
+    email: `${QA_USER_ID}@sploot.test`,
+    secret,
+    expiresInSeconds: SESSION_SECONDS,
+  });
+
+  const response = NextResponse.redirect(new URL('/app', request.url), 307);
+  const cookie = [
+    `${getQaLocalAuthCookieName()}=${encodeURIComponent(token)}`,
+    'Path=/',
+    `Max-Age=${SESSION_SECONDS}`,
+    'HttpOnly',
+    'SameSite=Lax',
+  ].join('; ');
+  response.headers.set('set-cookie', cookie);
+  return response;
+}

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { unstable_rethrow } from 'next/navigation';
 import { prisma, vectorSearch, logSearch, type VectorSearchRow } from '@/lib/db';
-import { createEmbeddingService, EmbeddingError } from '@/lib/embeddings';
+import { CLIP_MODEL, createEmbeddingService, EmbeddingError } from '@/lib/embeddings';
 import { getCacheService } from '@/lib/cache';
 import { getAuthWithUser } from '@/lib/auth/server';
 import { withObservability } from '@/lib/with-observability';
@@ -75,37 +75,47 @@ async function postHandler(req: NextRequest) {
       });
     }
 
-    const embeddingGate = getRuntimeGate('embeddings');
-    if (!embeddingGate.enabled) {
-      return runtimeGateResponse(embeddingGate);
-    }
+    // Cache-first query embedding: the Postgres text-embedding store outlives
+    // processes (qa:seed and prior searches populate it), so a hit needs no
+    // Replicate service and no generation gate — nothing is being generated.
+    let queryEmbedding = await cache.getTextEmbedding(query, CLIP_MODEL);
+    let embeddingModel = CLIP_MODEL;
 
-    // Initialize embedding service
-    let embeddingService;
-    try {
-      embeddingService = createEmbeddingService();
-    } catch (error) {
-      // Failed to initialize embedding service. A degraded backend must not
-      // masquerade as an honest empty result set (HTTP 200 + results: []
-      // renders as "no matches" in the client).
-      return NextResponse.json(
-        {
-          error: 'Search is temporarily unavailable: embedding service is not configured.',
-          query,
-          processingTime: Date.now() - startTime,
-        },
-        { status: 503 }
-      );
-    }
+    if (!queryEmbedding) {
+      const embeddingGate = getRuntimeGate('embeddings');
+      if (!embeddingGate.enabled) {
+        return runtimeGateResponse(embeddingGate);
+      }
 
-    // Generate text embedding for the query
-    const embeddingResult = await embeddingService.embedText(query);
+      // Initialize embedding service
+      let embeddingService;
+      try {
+        embeddingService = createEmbeddingService();
+      } catch (error) {
+        // Failed to initialize embedding service. A degraded backend must not
+        // masquerade as an honest empty result set (HTTP 200 + results: []
+        // renders as "no matches" in the client).
+        return NextResponse.json(
+          {
+            error: 'Search is temporarily unavailable: embedding service is not configured.',
+            query,
+            processingTime: Date.now() - startTime,
+          },
+          { status: 503 }
+        );
+      }
+
+      // Generate text embedding for the query
+      const embeddingResult = await embeddingService.embedText(query);
+      queryEmbedding = embeddingResult.embedding;
+      embeddingModel = embeddingResult.model;
+    }
 
     // Perform vector similarity search. Keep zero-results honest: callers asked
     // for a similarity floor, so do not pad misses with threshold-0 results.
     let searchResults = await vectorSearch(
       userId,
-      embeddingResult.embedding,
+      queryEmbedding,
       { limit: effectiveLimit, threshold, shuffleSeed }
     );
 
@@ -173,7 +183,7 @@ async function postHandler(req: NextRequest) {
       threshold,
       requestedThreshold: threshold,
       processingTime: queryTime,
-      embeddingModel: embeddingResult.model,
+      embeddingModel,
       cached: false,
       thresholdFallback: false,
     });

--- a/apps/web/docs/API.md
+++ b/apps/web/docs/API.md
@@ -1192,17 +1192,15 @@ Clear or warm the cache.
 | 500  | Internal Server Error                       |
 | 503  | Service Unavailable - External service down |
 
-## Mock Mode
+## Local Development Without Vendor Credentials
 
-When running in development without external services configured, the API automatically switches to mock mode. Mock mode provides:
-
-- Simulated authentication (any request is authorized)
-- In-memory storage for assets
-- Fake embeddings for testing
-- Cached example search results
-- No external API calls
-
-To enable mock mode, set `MOCK_MODE=true` in your environment or leave external service environment variables unconfigured.
+There is no mock mode. The credential-free path is the real app against local
+services: `pnpm dev:local` (repo root) provisions a local pgvector Postgres,
+applies migrations, seeds a browsable pile (`qa:seed`), enables qa-local auth
+(`docs/AUTH.md`), boots the dev server, and runs a doctor pass that emits
+evidence. Search works offline for seeded queries because qa:seed populates
+the Postgres text-embedding cache; uncached queries still require
+`REPLICATE_API_TOKEN`.
 
 ## WebSocket Events (Future)
 

--- a/apps/web/docs/AUTH.md
+++ b/apps/web/docs/AUTH.md
@@ -79,7 +79,20 @@ loader is inert in production builds.
 
 Mint a token for the seeded user with `createQaLocalAuthToken` from
 `lib/auth/qa-local.ts` (default seed user id: `qa-design-user`), set it as the
-`sploot_qa_auth` cookie, and open `/app`.
+`sploot_qa_auth` cookie, and open `/app`. In a browser, `GET
+/api/qa-auth/login` does this in one hop (mints the token, sets the cookie,
+redirects to `/app`) — the route 404s unless qa-local mode is enabled and is
+hard-refused in production like the rest of the harness.
+
+## One-Command Local Boot
+
+`pnpm dev:local` (repo root) composes all of the above: provisions a local
+pgvector Postgres in Docker, applies migrations, runs `qa:seed`, boots the dev
+server with qa-local auth enabled, and finishes with a doctor pass that writes
+an evidence packet (health, signed-in `/app`, seeded grid readback, search
+response, and a grid screenshot when the `agent-browser` CLI is available) to
+`.sploot-local/doctor/`. `pnpm dev:local:down` removes the database container
+and generated files.
 
 ## Evidence Packets
 

--- a/apps/web/docs/DEPLOYMENT.md
+++ b/apps/web/docs/DEPLOYMENT.md
@@ -95,7 +95,6 @@ UPSTASH_REDIS_REST_TOKEN=...
 
 # Feature Flags
 NEXT_PUBLIC_ENABLE_PWA=true
-MOCK_MODE=false
 ```
 
 ## Vercel Deployment

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,8 @@
     "test:coverage": "vitest run --coverage",
     "e2e:auth": "playwright test --config playwright.config.ts",
     "qa:seed": "tsx scripts/qa-seed.ts",
+    "dev:local": "tsx scripts/dev-local.ts",
+    "dev:local:down": "tsx scripts/dev-local.ts --down",
     "qa:evidence": "tsx scripts/qa-evidence.ts",
     "auth:guard": "node scripts/check-auth-boundary.mjs",
     "db:generate": "prisma generate",

--- a/apps/web/scripts/dev-local.ts
+++ b/apps/web/scripts/dev-local.ts
@@ -1,0 +1,379 @@
+/**
+ * Push-button local boot: one command from clone to a browsable, searchable,
+ * seeded pile — no Clerk/Neon/Blob/Replicate credentials required.
+ *
+ * Composes the existing harness pieces (docker pgvector Postgres, prisma
+ * migrations, qa:seed fixtures, qa-local auth from docs/AUTH.md) and ends
+ * with a doctor pass that emits evidence, not just a green exit code.
+ *
+ * Usage (repo root):
+ *   pnpm dev:local              # provision + migrate + seed + serve + doctor
+ *   pnpm dev:local:down         # remove the local database + generated files
+ *
+ * Flags / env:
+ *   --down                      teardown (same as dev:local:down)
+ *   --port <n>                  dev server port        (default 3001, or PORT)
+ *   --db-port <n>               host Postgres port     (default 5432, or SPLOOT_LOCAL_PG_PORT)
+ *   --no-doctor                 skip the verify pass
+ *
+ * The doctor writes an evidence packet to .sploot-local/doctor/<timestamp>/
+ * (gitignored): health probe, signed-in /app fetch, seeded-assets readback,
+ * cached-query search response, and — when the agent-browser CLI is on PATH —
+ * a rendered-grid screenshot.
+ *
+ * Requires: docker (for the pgvector Postgres). Everything else is pnpm.
+ */
+
+import { execFile, spawn, type ChildProcess } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { createQaLocalAuthToken } from '../lib/auth/qa-local';
+
+const execFileAsync = promisify(execFile);
+
+const CONTAINER = 'sploot-local-pg';
+const IMAGE = 'pgvector/pgvector:pg16';
+const QA_USER_ID = 'qa-design-user';
+const SEARCH_PROBE_QUERY = 'reaction face meme'; // a PILE_ANCHORS query: qa:seed caches its embedding
+const MIN_SEEDED_ASSETS = 20;
+const APP_ROOT = process.cwd();
+const LOCAL_STATE_DIR = join(APP_ROOT, '..', '..', '.sploot-local');
+
+interface Args {
+  down: boolean;
+  port: number;
+  dbPort: number;
+  doctor: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    down: false,
+    port: Number(process.env.PORT ?? 3001),
+    dbPort: Number(process.env.SPLOOT_LOCAL_PG_PORT ?? 5432),
+    doctor: true,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--down': args.down = true; break;
+      case '--port': args.port = Number(argv[++i]); break;
+      case '--db-port': args.dbPort = Number(argv[++i]); break;
+      case '--no-doctor': args.doctor = false; break;
+    }
+  }
+  if (!Number.isInteger(args.port) || !Number.isInteger(args.dbPort)) {
+    throw new Error('--port and --db-port must be integers');
+  }
+  return args;
+}
+
+function log(message: string) {
+  console.log(`[dev-local] ${message}`);
+}
+
+function fail(message: string): never {
+  console.error(`[dev-local] FAIL ${message}`);
+  process.exit(1);
+}
+
+async function docker(...dockerArgs: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('docker', dockerArgs);
+}
+
+async function ensureDockerUp() {
+  try {
+    await docker('info');
+  } catch {
+    fail('docker is not available. Install/start Docker Desktop (or colima), then re-run `pnpm dev:local`.');
+  }
+}
+
+async function containerState(): Promise<'running' | 'stopped' | 'absent'> {
+  try {
+    const { stdout } = await docker('inspect', '--format', '{{.State.Running}}', CONTAINER);
+    return stdout.trim() === 'true' ? 'running' : 'stopped';
+  } catch {
+    return 'absent';
+  }
+}
+
+async function ensurePostgres(dbPort: number) {
+  const state = await containerState();
+  if (state === 'absent') {
+    log(`provisioning pgvector Postgres (${IMAGE}) as ${CONTAINER} on port ${dbPort}...`);
+    try {
+      await docker(
+        'run', '-d', '--name', CONTAINER,
+        '-e', 'POSTGRES_USER=test',
+        '-e', 'POSTGRES_PASSWORD=test',
+        '-e', 'POSTGRES_DB=sploot_test',
+        '-p', `${dbPort}:5432`,
+        IMAGE
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('port is already allocated') || message.includes('address already in use')) {
+        fail(`port ${dbPort} is taken by another service. Re-run with --db-port <free-port> (DATABASE_URL follows it automatically).`);
+      }
+      fail(`could not start Postgres container: ${message}`);
+    }
+  } else if (state === 'stopped') {
+    log(`starting existing ${CONTAINER} container...`);
+    await docker('start', CONTAINER);
+  } else {
+    log(`reusing running ${CONTAINER} container.`);
+  }
+
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    try {
+      await docker('exec', CONTAINER, 'pg_isready', '-U', 'test', '-d', 'sploot_test');
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
+  fail(`Postgres in ${CONTAINER} did not become ready within 60s (docker logs ${CONTAINER}).`);
+}
+
+function runStep(name: string, command: string, commandArgs: string[], env: NodeJS.ProcessEnv): Promise<void> {
+  log(`${name}: ${command} ${commandArgs.join(' ')}`);
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, commandArgs, { env, cwd: APP_ROOT, stdio: 'inherit' });
+    child.on('close', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${name} exited with code ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function waitForServer(baseUrl: string, timeoutMs = 120_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(baseUrl, { redirect: 'manual' });
+      if (response.status < 500) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`dev server at ${baseUrl} not ready within ${timeoutMs / 1000}s`);
+}
+
+async function hasAgentBrowser(): Promise<boolean> {
+  try {
+    await execFileAsync('agent-browser', ['--version'], { timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface DoctorCheck {
+  name: string;
+  status: 'pass' | 'fail';
+  detail: string;
+  evidence?: string;
+}
+
+async function runDoctor(baseUrl: string, secret: string): Promise<boolean> {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const evidenceDir = join(LOCAL_STATE_DIR, 'doctor', stamp);
+  await mkdir(evidenceDir, { recursive: true });
+  const checks: DoctorCheck[] = [];
+
+  const token = await createQaLocalAuthToken({
+    userId: QA_USER_ID,
+    email: `${QA_USER_ID}@sploot.test`,
+    secret,
+    expiresInSeconds: 30 * 60,
+  });
+  const authHeaders = { cookie: `sploot_qa_auth=${token}` };
+
+  async function record(name: string, evidenceFile: string | undefined, run: () => Promise<{ pass: boolean; detail: string; body?: string }>) {
+    try {
+      const result = await run();
+      if (evidenceFile && result.body !== undefined) {
+        await writeFile(join(evidenceDir, evidenceFile), result.body);
+      }
+      checks.push({ name, status: result.pass ? 'pass' : 'fail', detail: result.detail, evidence: evidenceFile });
+      log(`doctor ${result.pass ? 'PASS' : 'FAIL'} ${name} — ${result.detail}`);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      checks.push({ name, status: 'fail', detail, evidence: evidenceFile });
+      log(`doctor FAIL ${name} — ${detail}`);
+    }
+  }
+
+  await record('health green', 'health.json', async () => {
+    const response = await fetch(`${baseUrl}/api/health`);
+    const body = await response.json();
+    return {
+      pass: response.status === 200 && body.dependencies?.database === 'up',
+      detail: `GET /api/health → ${response.status}, database=${body.dependencies?.database}`,
+      body: JSON.stringify(body, null, 2),
+    };
+  });
+
+  await record('browser sign-in path', 'qa-auth-login.txt', async () => {
+    const response = await fetch(`${baseUrl}/api/qa-auth/login`, { redirect: 'manual' });
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    const pass = response.status === 307 && setCookie.includes('sploot_qa_auth=');
+    return {
+      pass,
+      detail: `GET /api/qa-auth/login → ${response.status}, cookie ${setCookie ? 'set' : 'missing'}, location=${response.headers.get('location')}`,
+      body: `status: ${response.status}\nlocation: ${response.headers.get('location')}\nset-cookie: ${setCookie ? 'sploot_qa_auth=<redacted>' : '(none)'}\n`,
+    };
+  });
+
+  await record('signed-in /app', 'app.txt', async () => {
+    const response = await fetch(`${baseUrl}/app`, { headers: authHeaders, redirect: 'manual' });
+    const html = await response.text();
+    const signedIn = response.status === 200 && !html.includes('/sign-in');
+    return {
+      pass: signedIn,
+      detail: `GET /app with qa cookie → ${response.status} (${signedIn ? 'app shell' : 'sign-in wall'})`,
+      body: `status: ${response.status}\nbytes: ${html.length}\nfirst 500 chars:\n${html.slice(0, 500)}\n`,
+    };
+  });
+
+  await record(`seeded pile ≥ ${MIN_SEEDED_ASSETS} assets`, 'assets.json', async () => {
+    const response = await fetch(`${baseUrl}/api/assets?limit=100`, { headers: authHeaders });
+    const body = await response.json();
+    const count = Array.isArray(body.assets) ? body.assets.length : 0;
+    return {
+      pass: response.status === 200 && count >= MIN_SEEDED_ASSETS,
+      detail: `GET /api/assets → ${response.status}, ${count} assets`,
+      body: JSON.stringify({ statusCode: response.status, count, ids: body.assets?.map((a: { id: string }) => a.id) }, null, 2),
+    };
+  });
+
+  await record('search returns results', 'search.json', async () => {
+    const response = await fetch(`${baseUrl}/api/search`, {
+      method: 'POST',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      body: JSON.stringify({ query: SEARCH_PROBE_QUERY, limit: 10 }),
+    });
+    const body = await response.json();
+    const count = Array.isArray(body.results) ? body.results.length : 0;
+    return {
+      pass: response.status === 200 && count >= 1,
+      detail: `POST /api/search "${SEARCH_PROBE_QUERY}" → ${response.status}, ${count} results`,
+      body: JSON.stringify(body, null, 2),
+    };
+  });
+
+  if (await hasAgentBrowser()) {
+    await record('rendered grid screenshot', 'app-grid.png', async () => {
+      const browser = (...browserArgs: string[]) =>
+        execFileAsync('agent-browser', browserArgs, { timeout: 60_000 });
+      await browser('cookies', 'set', 'sploot_qa_auth', token, '--url', baseUrl);
+      await browser('open', `${baseUrl}/app`);
+      await new Promise((r) => setTimeout(r, 6000));
+      await browser('screenshot', join(evidenceDir, 'app-grid.png'));
+      return { pass: true, detail: `screenshot of signed-in /app grid` };
+    });
+  } else {
+    log('doctor SKIP rendered-grid screenshot (agent-browser CLI not on PATH; HTTP evidence above still proves the loop)');
+  }
+
+  const failed = checks.filter((check) => check.status === 'fail');
+  const summary = [
+    `# dev:local doctor — ${new Date().toISOString()}`,
+    '',
+    `Base URL: ${baseUrl}`,
+    `Verdict: ${failed.length === 0 ? 'PASS' : `FAIL (${failed.length} of ${checks.length} checks)`}`,
+    '',
+    '| Check | Status | Detail | Evidence |',
+    '|---|---|---|---|',
+    ...checks.map((check) => `| ${check.name} | ${check.status.toUpperCase()} | ${check.detail.replace(/\|/g, '\\|')} | ${check.evidence ?? '—'} |`),
+    '',
+  ].join('\n');
+  await writeFile(join(evidenceDir, 'doctor.md'), summary);
+  log(`doctor evidence: ${evidenceDir}`);
+
+  return failed.length === 0;
+}
+
+async function teardown() {
+  const state = await containerState();
+  if (state === 'absent') {
+    log(`no ${CONTAINER} container to remove.`);
+  } else {
+    log(`removing ${CONTAINER} container and its database volume...`);
+    await docker('rm', '--force', '--volumes', CONTAINER);
+  }
+  log('removing generated local files (.sploot-local/, public/qa-blob-seed/)...');
+  await rm(LOCAL_STATE_DIR, { recursive: true, force: true });
+  await rm(join(APP_ROOT, 'public', 'qa-blob-seed'), { recursive: true, force: true });
+  log('teardown complete. `git status` should show no dev:local artifacts.');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.down) {
+    await teardown();
+    return;
+  }
+
+  await ensureDockerUp();
+  await ensurePostgres(args.dbPort);
+
+  const secret = process.env.SPLOOT_QA_AUTH_SECRET ?? randomBytes(24).toString('hex');
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    DATABASE_URL: `postgresql://test:test@localhost:${args.dbPort}/sploot_test?sslmode=disable`,
+    SPLOOT_QA_AUTH_MODE: 'enabled',
+    SPLOOT_QA_AUTH_SECRET: secret,
+    PORT: String(args.port),
+  };
+
+  await runStep('migrate', 'pnpm', ['db:migrate'], env);
+  await runStep('seed', 'pnpm', ['qa:seed'], env);
+
+  const baseUrl = `http://localhost:${args.port}`;
+  log(`starting dev server on ${baseUrl}...`);
+  const server: ChildProcess = spawn('pnpm', ['dev'], { env, cwd: APP_ROOT, stdio: 'inherit' });
+  const serverExit = new Promise<number | null>((resolvePromise) => {
+    server.on('close', (code) => resolvePromise(code));
+  });
+
+  const stop = () => {
+    if (!server.killed) server.kill('SIGINT');
+  };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+
+  try {
+    await waitForServer(baseUrl);
+  } catch (error) {
+    stop();
+    fail(error instanceof Error ? error.message : String(error));
+  }
+
+  let healthy = true;
+  if (args.doctor) {
+    healthy = await runDoctor(baseUrl, secret);
+    if (!healthy) {
+      stop();
+      await serverExit;
+      fail('doctor found failing checks — see the evidence packet above.');
+    }
+  }
+
+  log('');
+  log(`ready. open ${baseUrl}/api/qa-auth/login to land signed-in on /app with the seeded pile.`);
+  log(`teardown later with: pnpm dev:local:down`);
+  log('Ctrl-C stops the server; the database container keeps running for fast restarts.');
+
+  await serverExit;
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.stack ?? error.message : String(error));
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "scripts": {
     "dev": "PORT=${PORT:-3001} VITE_API_BASE_URL=${VITE_API_BASE_URL:-http://localhost:3001} turbo run dev",
     "dev:web": "turbo run dev --filter=web",
+    "dev:local": "pnpm --filter web dev:local",
+    "dev:local:down": "pnpm --filter web dev:local:down",
     "dev:extension": "turbo run dev --filter=extension",
     "build": "turbo run build",
     "lint": "turbo run lint",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## What

One documented command — `pnpm dev:local` — takes a fresh clone to a signed-in `/app` rendering a seeded pile of 24 assets with working text→image search, with **no Clerk/Neon/Blob/Replicate credentials**. `pnpm dev:local:down` tears it all down.

Card: **sploot-072** (Powder).

## How

- **`apps/web/scripts/dev-local.ts`** — provisions a local pgvector Postgres in Docker (`sploot-local-pg`), applies migrations, runs `qa:seed`, boots the dev server with qa-local auth, then runs a **doctor pass that emits evidence** (`.sploot-local/doctor/<ts>/`, gitignored): health green, sign-in path, signed-in `/app`, seeded pile ≥ 20 assets, search response, and a rendered-grid screenshot when `agent-browser` is on PATH. Failing checks fail the boot.
- **`GET /api/qa-auth/login`** — dev-only route (404 unless `SPLOOT_QA_AUTH_MODE=enabled`; hard-refused in production like the rest of the qa-local harness) that mints the qa token, sets the cookie, and redirects to `/app`, so the human lands signed-in in one hop.
- **Search cache-first** — the route now consults the Postgres text-embedding store before requiring the Replicate service, so seeded queries (pile anchors) search offline; uncached queries keep the honest 503.
- **MOCK_MODE expunged** — it was documented in `.env.example`, `API.md`, and `DEPLOYMENT.md` but grepped to zero code. Docs now point at the real credential-free path.
- **Pre-existing fix**: `@sploot/common` exports map lacked a `default` condition, which had broken `qa:seed` under tsx (`ERR_PACKAGE_PATH_NOT_EXPORTED`).

## Evidence (live run 2026-07-07)

`pnpm dev:local` doctor output:

```
doctor PASS health green — GET /api/health → 200, database=up
doctor PASS browser sign-in path — GET /api/qa-auth/login → 307, cookie set
doctor PASS signed-in /app — GET /app with qa cookie → 200 (app shell)
doctor PASS seeded pile ≥ 20 assets — GET /api/assets → 200, 24 assets
doctor PASS search returns results — POST /api/search "reaction face meme" → 200, 4 results
doctor PASS rendered grid screenshot — screenshot of signed-in /app grid
```

Teardown verified: container + volume removed, `.sploot-local/` and `public/qa-blob-seed/` deleted, `git status` clean.

Gates: `pnpm lint` ✅ · `pnpm type-check` ✅ · `pnpm --filter web test` **1043/1043** (with local pgvector DB) ✅ · `pnpm --filter extension build` ✅ · `pnpm lint:design` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)