### PR TITLE
Adopt @misty-step/aesthetic substrate: console-door auth + workbench re-skin (sploot-032)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ next-env.d.ts
 
 # dev:local doctor evidence + local state
 .sploot-local/
+.env*.local

--- a/apps/web/__tests__/components/chrome/navbar.test.tsx
+++ b/apps/web/__tests__/components/chrome/navbar.test.tsx
@@ -90,11 +90,11 @@ describe('Navbar', () => {
       expect(nav).toHaveClass('bg-background', 'border-b', 'border-border');
     });
 
-    it('should have backdrop blur effect', () => {
+    it('should be opaque chrome with no backdrop blur (DESIGN.md bans soft chrome)', () => {
       render(<Navbar />);
 
       const nav = screen.getByRole('navigation');
-      expect(nav).toHaveClass('backdrop-blur-sm');
+      expect(nav.className).not.toMatch(/backdrop-blur/);
     });
 
     it('should apply custom className when provided', () => {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@misty-step/aesthetic" layer(base);
 
 @custom-variant dark (&:is(.dark *));
 
@@ -752,4 +753,63 @@ select:focus-visible {
 
 .to-cyber-blue {
   --tw-gradient-to: var(--accent-violet) var(--tw-gradient-to-position);
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   @misty-step/aesthetic substrate adoption (ADR 0005, card sploot-032)
+
+   Swiss chrome, feral contents: the shadcn semantic layer — everything
+   the /app workbench, the auth door, dialogs, and settings read — is
+   repointed at the aesthetic --ae-* substrate, so quiet chrome gets the
+   kit's ink-on-paper discipline, AA contrast contracts, and light/dark
+   flip for free. Sploot's cyan is steered as the system accent.
+
+   The --sploot-* loud layer above is deliberately NOT remapped: paper,
+   stickers, stamps, hard shadows, and the display register are declared
+   deviations that live on top of the substrate. The full mapping and
+   deviation list: docs/design/aesthetic-adoption.md.
+
+   This block is last in the cascade, so it wins over the legacy oklch
+   token sets above. Dark mode needs no second block: the kit itself
+   flips every --ae-* under :root.dark (next-themes sets that class).
+   ═══════════════════════════════════════════════════════════════════ */
+:root {
+  /* steering: sploot's cyan, on the system's accent (AA on both surfaces) */
+  --ae-accent: #0c6a84;
+  --ae-accent-dark: #00f0ff;
+  /* wire the kit's font slots to the app's next/font families — the
+     brutalist type (Space Grotesk / Space Mono) is a declared deviation
+     from the kit's Geist default */
+  --ae-font: var(--font-geist-sans), "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --ae-font-mono: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+:root,
+.dark {
+  --background: var(--ae-surface);
+  --foreground: var(--ae-ink);
+  --card: var(--ae-surface);
+  --card-foreground: var(--ae-ink);
+  --popover: var(--ae-surface);
+  --popover-foreground: var(--ae-ink);
+  --primary: var(--ae-accent);
+  --primary-foreground: var(--ae-surface);
+  --secondary: var(--ae-wash);
+  --secondary-foreground: var(--ae-ink);
+  --muted: var(--ae-wash);
+  --muted-foreground: var(--ae-ink-muted);
+  --accent: var(--ae-accent);
+  --accent-foreground: var(--ae-surface);
+  --destructive: var(--ae-err);
+  --border: var(--ae-line);
+  --input: var(--ae-line);
+  --ring: var(--ae-ink);
+  --sidebar: var(--ae-surface);
+  --sidebar-foreground: var(--ae-ink);
+  --sidebar-border: var(--ae-line);
+  --sidebar-accent: var(--ae-wash);
+  --sidebar-accent-foreground: var(--ae-ink);
+  --sidebar-ring: var(--ae-ink);
+  /* the cyan accent token the workbench chrome reads = the steered accent */
+  --accent-cyan: var(--ae-accent);
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -813,3 +813,22 @@ select:focus-visible {
   /* the cyan accent token the workbench chrome reads = the steered accent */
   --accent-cyan: var(--ae-accent);
 }
+
+/* Clerk console door (sploot-032): Clerk injects its own high-specificity
+   styles (instance branding ring, footer surfaces) that the appearance
+   classes cannot reach — pin them to the substrate. */
+.cl-formFieldInput {
+  box-shadow: none !important;
+}
+.cl-formFieldInput:focus,
+.cl-formFieldInput:focus-visible {
+  border-color: var(--primary) !important;
+  box-shadow: 0 0 0 1px var(--primary) !important;
+  outline: none !important;
+}
+.cl-footer,
+.cl-footer > *,
+.cl-footerAction {
+  background: var(--background) !important;
+  background-image: none !important;
+}

--- a/apps/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,44 +1,17 @@
 import { SignIn } from "@clerk/nextjs";
+import {
+  ConsoleDoor,
+  consoleDoorAppearance,
+} from "@/components/auth/console-door";
 
 export default function SignInPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-gray-900 to-black">
+    <ConsoleDoor route="/sign-in">
       <SignIn
-        appearance={{
-          elements: {
-            formButtonPrimary:
-              "bg-violet-600 hover:bg-violet-700 transition-colors",
-            footerActionLink:
-              "text-violet-500 hover:text-violet-400",
-            identityPreviewEditButtonIcon:
-              "text-violet-500",
-            formFieldInput:
-              "border-gray-700 bg-gray-900/50 focus:border-violet-500",
-            card:
-              "bg-gray-900/90 backdrop-blur-sm border border-gray-800",
-            headerTitle:
-              "text-white",
-            headerSubtitle:
-              "text-gray-400",
-            socialButtonsBlockButton:
-              "bg-gray-800 hover:bg-gray-700 border-gray-700 text-white",
-            formFieldLabel:
-              "text-gray-300",
-            dividerLine:
-              "bg-gray-700",
-            dividerText:
-              "text-gray-400",
-            formFieldInputShowPasswordButton:
-              "text-gray-400 hover:text-gray-300",
-          },
-          layout: {
-            socialButtonsPlacement: "top",
-            socialButtonsVariant: "blockButton",
-          },
-        }}
+        appearance={consoleDoorAppearance}
         signUpUrl="/sign-up"
         forceRedirectUrl="/app"
       />
-    </div>
+    </ConsoleDoor>
   );
 }

--- a/apps/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,44 +1,17 @@
 import { SignUp } from "@clerk/nextjs";
+import {
+  ConsoleDoor,
+  consoleDoorAppearance,
+} from "@/components/auth/console-door";
 
 export default function SignUpPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-gray-900 to-black">
+    <ConsoleDoor route="/sign-up">
       <SignUp
-        appearance={{
-          elements: {
-            formButtonPrimary:
-              "bg-violet-600 hover:bg-violet-700 transition-colors",
-            footerActionLink:
-              "text-violet-500 hover:text-violet-400",
-            identityPreviewEditButtonIcon:
-              "text-violet-500",
-            formFieldInput:
-              "border-gray-700 bg-gray-900/50 focus:border-violet-500",
-            card:
-              "bg-gray-900/90 backdrop-blur-sm border border-gray-800",
-            headerTitle:
-              "text-white",
-            headerSubtitle:
-              "text-gray-400",
-            socialButtonsBlockButton:
-              "bg-gray-800 hover:bg-gray-700 border-gray-700 text-white",
-            formFieldLabel:
-              "text-gray-300",
-            dividerLine:
-              "bg-gray-700",
-            dividerText:
-              "text-gray-400",
-            formFieldInputShowPasswordButton:
-              "text-gray-400 hover:text-gray-300",
-          },
-          layout: {
-            socialButtonsPlacement: "top",
-            socialButtonsVariant: "blockButton",
-          },
-        }}
+        appearance={consoleDoorAppearance}
         signInUrl="/sign-in"
         forceRedirectUrl="/app"
       />
-    </div>
+    </ConsoleDoor>
   );
 }

--- a/apps/web/components/auth/console-door.tsx
+++ b/apps/web/components/auth/console-door.tsx
@@ -17,30 +17,36 @@ import { ReactNode } from "react";
  *  borders, steered-cyan primary, mono field labels. No violet, no blur. */
 export const consoleDoorAppearance = {
   variables: {
+    // steered accent (light value; the trailing-! utilities below carry the
+    // dark flip through the semantic tokens)
+    colorPrimary: "#0c6a84",
     borderRadius: "0px",
   },
   elements: {
+    // Clerk injects its own styles at high specificity, so the semantic-token
+    // utilities ride the important flag (Tailwind v4 trailing !) to win.
     rootBox: "w-full",
-    cardBox: "w-full rounded-none border-0 shadow-none",
-    card: "bg-background rounded-none border-0 shadow-none",
-    headerTitle: "text-foreground",
-    headerSubtitle: "text-muted-foreground",
+    cardBox: "w-full rounded-none! border-0! shadow-none!",
+    card: "bg-background! rounded-none! border-0! shadow-none!",
+    headerTitle: "text-foreground!",
+    headerSubtitle: "text-muted-foreground!",
     socialButtonsBlockButton:
-      "bg-secondary hover:bg-muted border border-border text-foreground rounded-none shadow-none",
-    dividerLine: "bg-border",
-    dividerText: "font-mono text-[11px] uppercase text-muted-foreground",
+      "bg-secondary! hover:bg-muted! border! border-border! text-foreground! rounded-none! shadow-none!",
+    dividerLine: "bg-border!",
+    dividerText: "font-mono text-[11px] uppercase text-muted-foreground!",
     formFieldLabel:
-      "font-mono text-[11px] uppercase tracking-wide text-muted-foreground",
+      "font-mono text-[11px] uppercase tracking-wide text-muted-foreground!",
     formFieldInput:
-      "bg-background border-border rounded-none text-foreground shadow-none focus:border-primary",
+      "bg-background! border! border-border! rounded-none! text-foreground! shadow-none! focus:border-primary!",
     formButtonPrimary:
-      "bg-primary hover:bg-primary/90 text-primary-foreground rounded-none shadow-none transition-colors",
+      "bg-primary! hover:bg-primary/90! text-primary-foreground! rounded-none! shadow-none! transition-colors",
     formFieldInputShowPasswordButton:
-      "text-muted-foreground hover:text-foreground",
-    identityPreviewEditButtonIcon: "text-primary",
-    footerActionLink: "text-primary hover:text-primary/80",
-    footer: "bg-background",
-    footerAction: "bg-background",
+      "text-muted-foreground! hover:text-foreground!",
+    identityPreviewEditButtonIcon: "text-primary!",
+    footerActionLink: "text-primary! hover:text-primary/80!",
+    footer: "bg-background!",
+    footerAction: "bg-background!",
+    footerActionText: "text-muted-foreground!",
   },
   layout: {
     socialButtonsPlacement: "top" as const,

--- a/apps/web/components/auth/console-door.tsx
+++ b/apps/web/components/auth/console-door.tsx
@@ -1,0 +1,75 @@
+import { ReactNode } from "react";
+
+/**
+ * The console door — sploot's auth surfaces framed as a labeled instrument
+ * console (DESIGN.md §4: "the search box is a labeled console with an ink
+ * titlebar; the machinery is on display"). Winner of the sploot-032 design
+ * lab (explorations/lab-032-auth-workbench.html, option 1): quiet
+ * aesthetic-substrate chrome — hairlines, wash, steered cyan — with the
+ * machinery strip on display and zero glassmorphism.
+ *
+ * Everything reads the shadcn semantic layer, which resolves to the
+ * @misty-step/aesthetic --ae-* substrate (globals.css), so the door follows
+ * light/dark automatically.
+ */
+
+/** Clerk appearance mapped onto the substrate: square corners, hairline
+ *  borders, steered-cyan primary, mono field labels. No violet, no blur. */
+export const consoleDoorAppearance = {
+  variables: {
+    borderRadius: "0px",
+  },
+  elements: {
+    rootBox: "w-full",
+    cardBox: "w-full rounded-none border-0 shadow-none",
+    card: "bg-background rounded-none border-0 shadow-none",
+    headerTitle: "text-foreground",
+    headerSubtitle: "text-muted-foreground",
+    socialButtonsBlockButton:
+      "bg-secondary hover:bg-muted border border-border text-foreground rounded-none shadow-none",
+    dividerLine: "bg-border",
+    dividerText: "font-mono text-[11px] uppercase text-muted-foreground",
+    formFieldLabel:
+      "font-mono text-[11px] uppercase tracking-wide text-muted-foreground",
+    formFieldInput:
+      "bg-background border-border rounded-none text-foreground shadow-none focus:border-primary",
+    formButtonPrimary:
+      "bg-primary hover:bg-primary/90 text-primary-foreground rounded-none shadow-none transition-colors",
+    formFieldInputShowPasswordButton:
+      "text-muted-foreground hover:text-foreground",
+    identityPreviewEditButtonIcon: "text-primary",
+    footerActionLink: "text-primary hover:text-primary/80",
+    footer: "bg-background",
+    footerAction: "bg-background",
+  },
+  layout: {
+    socialButtonsPlacement: "top" as const,
+    socialButtonsVariant: "blockButton" as const,
+  },
+};
+
+interface ConsoleDoorProps {
+  /** The route shown in the machinery strip, e.g. "/sign-in". */
+  route: string;
+  children: ReactNode;
+}
+
+/** Ink titlebar + hairline frame + machinery strip around a Clerk card. */
+export function ConsoleDoor({ route, children }: ConsoleDoorProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-secondary px-4 py-12">
+      <div className="w-full max-w-md border border-foreground bg-background">
+        <div className="flex items-center justify-between bg-foreground px-3 py-1.5 font-mono text-[11px] uppercase tracking-wide text-background">
+          <span>sploot / auth.console</span>
+          <span aria-hidden="true">&#9679; ready</span>
+        </div>
+        <div className="flex justify-center [&>div]:w-full">{children}</div>
+        <div className="flex gap-4 border-t border-border px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+          <span>route: {route}</span>
+          <span>auth: clerk</span>
+          <span>mode: private</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/chrome/navbar.tsx
+++ b/apps/web/components/chrome/navbar.tsx
@@ -43,8 +43,10 @@ export function Navbar({
         'pt-[env(safe-area-inset-top)]',
         'pl-[env(safe-area-inset-left)]',
         'pr-[env(safe-area-inset-right)]',
-        // Background and border - using shadcn design tokens
-        'bg-background border-b border-border backdrop-blur-sm',
+        // Background and border - semantic tokens on the aesthetic substrate.
+        // No backdrop blur: DESIGN.md bans soft chrome; the bar is opaque
+        // paper with a hairline rule (sploot-032 console-door grammar).
+        'bg-background border-b border-border',
         // Layout
         'flex items-center',
         // Padding - progressive increase for larger screens

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "@clerk/backend": "^2.33.4",
     "@clerk/nextjs": "^6.39.4",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "@misty-step/aesthetic": "github:misty-step/aesthetic#v2.24.0",
     "@prisma/client": "^6.19.3",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/docs/adr/0005-close-pr-228-redo-aesthetic-adoption.md
+++ b/docs/adr/0005-close-pr-228-redo-aesthetic-adoption.md
@@ -1,0 +1,73 @@
+# ADR 0005: Close PR #228; redo the @misty-step/aesthetic adoption fresh on master
+
+- Status: Accepted
+- Date: 2026-07-07
+
+## Context
+
+Two visual-system efforts forked in June 2026:
+
+- **PR #228** ("Adopt @misty-step/aesthetic as the substrate", opened
+  2026-06-13, untouched since 2026-06-13): 13 files, +148/−14. It pins
+  `github:misty-step/aesthetic#v2.5.1`, imports the kit's CSS into
+  `globals.css` at `layer(base)`, repoints the shadcn semantic token layer
+  (`--background`, `--primary`, …) at the `--ae-*` substrate with sploot's
+  cyan steered as the accent, and swaps DM Sans / JetBrains Mono / Bebas
+  Neue for Geist + Geist Mono — deleting the display face outright.
+- **Master** meanwhile shipped the bespoke neo-brutalist system as the
+  first visual-system slice (2026-06-26): DESIGN.md, `design-contract.md`,
+  `docs/design/tokens.md` + `component-library.md`, the `--sploot-*` token
+  layer (paper/ink, 4px borders, hard offset shadows), twelve
+  `components/sploot/*` wrappers, the re-cut landing, `/styleguide`, and a
+  repaired `pnpm lint:design` gate that structurally enforces all of it.
+
+Live evidence gathered 2026-07-07:
+
+- `gh pr view 228` reports `mergeable: CONFLICTING`. Both of its code
+  targets (`globals.css`, `layout.tsx`) were rewritten by the 2026-06-26
+  slice.
+- The pinned substrate is stale: `#v2.5.1` vs `v2.24.0` current — nineteen
+  minor versions of token/law drift in the kit itself.
+- Backlog card 032's own notes gate #228 behind a "deviation doc" (the
+  declared sploot loud-layer exceptions) that was never written, and state:
+  merging #228 as-is "ships a *quieter* sploot (the opposite of the
+  brief). Do not let #228 be the final landing state."
+- The Bebas display face #228 deletes is now load-bearing: the shipped
+  landing hero and section stamps read `--font-display`, and DESIGN.md
+  names the display register part of the brand.
+- The PR's evidence (before/after screenshots) predates the landing re-cut
+  and is unusable for review.
+
+## Decision
+
+**Close PR #228 without merging and redo the adoption fresh on master.**
+
+Rebasing was rejected: after resolving conflicts against a rewritten
+`globals.css`/`layout.tsx`, re-pinning v2.5.1→v2.24.x, restoring the
+display face the PR deletes, and re-shooting all evidence, nothing of the
+original commits survives — a "rebase" is a redo with extra archaeology.
+The PR's durable value is its wiring pattern, which the redo keeps:
+
+1. Depend on `github:misty-step/aesthetic#v2.24.0` (public, MIT); import
+   its CSS at `layer(base)` in `globals.css`.
+2. Repoint the shadcn semantic token layer at `--ae-*` with sploot cyan as
+   the steered accent — this is what re-skins the generic-shadcn `/app`
+   workbench and the violet-glassmorphism auth door (both violations of
+   DESIGN.md §3, which bans "purple-on-black AI glassmorphism") onto
+   ink-on-paper in one move.
+3. **Unlike #228:** keep Bebas as the declared display-register deviation,
+   keep the `--sploot-*` loud layer (stickers, stamps, hard shadows, the
+   landing) as named project tokens on top of the substrate, and document
+   both in the token-mapping/deviation doc the card requires. This is the
+   card's "Swiss chrome, feral contents" resolution: aesthetic is the
+   disciplined frame; the sploot layer is the loud contents.
+
+## Consequences
+
+- #228 closes with a comment linking this ADR; its branch is not deleted
+  (history stays inspectable).
+- The redo lands via card sploot-032 with a design lab
+  (`explorations/`) covering the auth door and workbench chrome, per the
+  design-lab law.
+- Future aesthetic upgrades are ordinary dependency bumps against a
+  documented deviation list instead of silent brand flattening.

--- a/docs/design/aesthetic-adoption.md
+++ b/docs/design/aesthetic-adoption.md
@@ -1,0 +1,75 @@
+# @misty-step/aesthetic adoption — token mapping & declared deviations
+
+Card sploot-032, ADR 0005 (`docs/adr/0005-close-pr-228-redo-aesthetic-adoption.md`).
+Substrate: `github:misty-step/aesthetic#v2.24.0` (pinned tag; upgrades are
+ordinary dependency bumps audited against this document).
+
+The bet is **"Swiss chrome, feral contents"**: the disciplined substrate owns
+every quiet chrome surface (workbench shell, auth door, dialogs, settings,
+forms), and sploot's loudness is spent inside high-variance **content
+objects** (meme tiles, sticker tabs, stamps, pile borders) — never on chrome.
+
+## What the substrate owns (the mapping)
+
+`apps/web/app/globals.css` imports the kit at `layer(base)` and repoints the
+shadcn semantic layer at `--ae-*` in a final cascade block. Dark mode is free:
+the kit flips every `--ae-*` under `:root.dark`, which next-themes sets.
+
+| Semantic token (what components read) | Substrate source |
+|---|---|
+| `--background`, `--card`, `--popover`, `--sidebar` | `--ae-surface` |
+| `--foreground`, `--*-foreground` (on surface) | `--ae-ink` |
+| `--secondary`, `--muted`, `--sidebar-accent` | `--ae-wash` |
+| `--muted-foreground` | `--ae-ink-muted` |
+| `--primary`, `--accent`, `--accent-cyan` | `--ae-accent` (steered) |
+| `--destructive` | `--ae-err` |
+| `--border`, `--input`, `--sidebar-border` | `--ae-line` |
+| `--ring`, `--sidebar-ring` | `--ae-ink` |
+
+Steering: `--ae-accent: #0c6a84` (AA 6.00 on light surface),
+`--ae-accent-dark: #00f0ff` (AA 13.30 on dark surface) — sploot's cyan as the
+system accent. `--radius` was already `0`, matching `--ae-radius`.
+
+## What stayed sploot (the declared deviations)
+
+These are deliberate, named exceptions to the kit's invariants. They are the
+brand; flattening them re-opens ADR 0005.
+
+1. **The display register.** The kit forbids display type; sploot keeps ONE
+   display face (Archivo Black, in the `--font-display` /
+   `--font-bebas-neue` slot) for the landing hero, section stamps, and the
+   navbar wordmark only. Never on dense control labels, tables, or metadata.
+2. **The brutalist text stack.** The kit defaults to Geist/Geist Mono; sploot
+   wires `--ae-font` → Space Grotesk and `--ae-font-mono` → Space Mono
+   (DESIGN.md §4 typography, shipped 2026-06-26). The card's original
+   2026-06-22 draft prescribed Geist; the live DESIGN.md-governed stack
+   supersedes it and is recorded here as the deviation instead.
+3. **The `--sploot-*` loud layer.** Unbleached paper (`--sploot-paper`), the
+   saturated block palette (blue/cyan/magenta/yellow/orange/lime), 4–6px ink
+   borders, and hard offset shadows are NOT remapped to `--ae-*`. They style
+   content objects and the landing's zine surfaces. PR #228 remapped them to
+   the substrate — that is the "quieter sploot" failure mode this doc exists
+   to prevent.
+4. **Filled pills & hard shadows on content objects.** `StickerTab`,
+   `BangerStamp`, pile borders, and the match ring keep their filled
+   saturated blocks and offset-ink shadows — kit-illegal, deviation-legal,
+   content-objects only.
+5. **The three motion beats.** Resolve-once, interaction-triggered only:
+   (a) `splootStamp` overshoot on banger-mark, (b) staggered tile cascade on
+   pile reshuffle, (c) the summon beat. No loops, no ambient drift — this
+   part matches the kit's motion law.
+
+## Surface split
+
+| Surface | Register |
+|---|---|
+| Auth door (`/sign-in`, `/sign-up`) | Substrate console (`components/auth/console-door.tsx`) — ink titlebar, hairline card, machinery strip, steered cyan. No violet, no glassmorphism (DESIGN.md §3 ban). |
+| `/app` workbench chrome (navbar, dialogs, settings, forms) | Substrate quiet: semantic tokens → `--ae-*`, opaque bars, hairline rules. |
+| Meme tiles, stamps, stickers, piles | Loud layer (`--sploot-*`), unchanged. |
+| Landing | Loud zine surfaces on `--sploot-paper`; body copy rides the semantic layer. |
+
+## Verification
+
+`pnpm lint:design` asserts the substrate import, this document, and the
+console door exist. Visual evidence for the adoption pass lives in the PR for
+sploot-032.

--- a/explorations/lab-032-auth-workbench.html
+++ b/explorations/lab-032-auth-workbench.html
@@ -1,0 +1,393 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>sploot-032 lab — auth door + workbench on the aesthetic substrate</title>
+<style>
+  /* ── substrate: @misty-step/aesthetic v2.24.0 tokens (verbatim) ── */
+  :root{
+    --ae-surface:#fcfcfc; --ae-wash:#f3f3f3; --ae-ink:#151515;
+    --ae-ink-muted:#737373; --ae-ink-faint:#a3a3a3; --ae-line:#e9e9e9;
+    --ae-accent:#0c6a84; /* sploot cyan steered, AA 6.00 on surface */
+    --ae-err:#a84138; --ae-ok:#15714b;
+    --ae-font:'Geist','Helvetica Neue',Helvetica,Arial,sans-serif;
+    --ae-font-mono:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --ae-w-regular:400; --ae-w-medium:550; --ae-w-black:800;
+    /* ── sploot loud layer (declared deviations, from globals.css) ── */
+    --sploot-ink:#0a0a0a; --sploot-paper:#f3efe4; --sploot-paper-warm:#e9e4d6;
+    --sploot-blue:#1f4cff; --sploot-cyan:#00e5d4; --sploot-magenta:#ff2d9b;
+    --sploot-yellow:#ffe600; --sploot-lime:#9cff2e; --sploot-orange:#ff5a1f;
+    --sploot-border:4px solid var(--sploot-ink);
+    --sploot-shadow-sm:5px 5px 0 var(--sploot-ink);
+    --font-display:'Bebas Neue','Arial Narrow',Impact,sans-serif;
+  }
+  *{box-sizing:border-box;margin:0}
+  body{font-family:var(--ae-font);font-size:16px;color:var(--ae-ink);
+       background:var(--ae-wash);line-height:1.5;-webkit-font-smoothing:antialiased}
+  .mono{font-family:var(--ae-font-mono);font-size:.8em;letter-spacing:.02em}
+  header.lab{padding:1.5em 2em;border-bottom:1px solid var(--ae-line);background:var(--ae-surface)}
+  header.lab h1{font-size:1em;font-weight:var(--ae-w-black)}
+  header.lab p{color:var(--ae-ink-muted);max-width:68rem}
+  nav.pager{display:flex;gap:.5em;flex-wrap:wrap;padding:1em 2em;background:var(--ae-surface);
+            border-bottom:1px solid var(--ae-line);position:sticky;top:0;z-index:5}
+  nav.pager button{font:inherit;font-family:var(--ae-font-mono);font-size:13px;padding:.4em .8em;
+            border:1px solid var(--ae-line);background:var(--ae-surface);cursor:pointer}
+  nav.pager button.on{background:var(--ae-ink);color:var(--ae-surface);border-color:var(--ae-ink)}
+  section.opt{display:none;padding:2em;max-width:80rem;margin:0 auto}
+  section.opt.on{display:block}
+  .meta{margin-bottom:1.5em}
+  .meta h2{font-size:1em;font-weight:var(--ae-w-black)}
+  .meta p{color:var(--ae-ink-muted);max-width:68rem}
+  .meta .verdictline{margin-top:.5em;font-family:var(--ae-font-mono);font-size:12px;color:var(--ae-ink)}
+  .stage{display:grid;grid-template-columns:minmax(0,26rem) minmax(0,1fr);gap:2em;align-items:start}
+  @media(max-width:64rem){.stage{grid-template-columns:1fr}}
+  .surface-label{font-family:var(--ae-font-mono);font-size:11px;text-transform:uppercase;
+                 color:var(--ae-ink-faint);margin:0 0 .5em}
+  /* shared clerk-ish form guts */
+  .f label{display:block;font-family:var(--ae-font-mono);font-size:11px;text-transform:uppercase;
+           color:var(--ae-ink-muted);margin:1em 0 .3em}
+  .f input{width:100%;font:inherit;padding:.5em .6em;border:1px solid var(--ae-line);
+           background:var(--ae-surface);color:var(--ae-ink)}
+  .f input:focus{outline:2px solid var(--ae-accent);outline-offset:-1px}
+  .f .btn{width:100%;margin-top:1.2em;font:inherit;font-weight:var(--ae-w-medium);padding:.6em;
+          border:1px solid var(--ae-accent);background:var(--ae-accent);color:#fff;cursor:pointer}
+  .f .alt{margin-top:.8em;text-align:center;font-size:.85em;color:var(--ae-ink-muted)}
+  .f .alt a{color:var(--ae-accent)}
+  .f .social{width:100%;font:inherit;padding:.5em;border:1px solid var(--ae-line);
+             background:var(--ae-wash);cursor:pointer;margin-bottom:.5em}
+  /* workbench mock guts */
+  .wb{border:1px solid var(--ae-line);background:var(--ae-surface);min-height:22rem}
+  .wb .bar{display:flex;align-items:center;gap:1em;padding:.6em 1em;border-bottom:1px solid var(--ae-line)}
+  .wb .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(7rem,1fr));gap:.8em;padding:1em}
+  .tile{aspect-ratio:1;border:3px solid var(--sploot-ink);box-shadow:4px 4px 0 var(--sploot-ink);
+        background:linear-gradient(135deg,var(--sploot-cyan),var(--sploot-magenta));position:relative}
+  .tile:nth-child(2){background:linear-gradient(45deg,var(--sploot-yellow),var(--sploot-orange));transform:rotate(-1.2deg)}
+  .tile:nth-child(3){background:linear-gradient(200deg,var(--sploot-blue),var(--sploot-cyan));transform:rotate(.8deg)}
+  .tile:nth-child(4){background:linear-gradient(320deg,var(--sploot-magenta),var(--sploot-blue))}
+  .tile:nth-child(5){background:linear-gradient(10deg,var(--sploot-lime),var(--sploot-cyan));transform:rotate(-.6deg)}
+  .tile:nth-child(6){background:linear-gradient(250deg,var(--sploot-orange),var(--sploot-magenta));transform:rotate(1.4deg)}
+  .tile .fn{position:absolute;left:0;right:0;bottom:0;background:var(--sploot-ink);color:#fff;
+            font-family:var(--ae-font-mono);font-size:9px;padding:2px 4px;text-transform:lowercase}
+  .banger{position:absolute;top:-8px;right:-8px;background:var(--sploot-magenta);color:var(--sploot-ink);
+          border:3px solid var(--sploot-ink);font-family:var(--ae-font-mono);font-size:9px;
+          font-weight:700;padding:2px 5px;transform:rotate(6deg)}
+  .wordmark{font-family:var(--font-display);font-size:1.5em;letter-spacing:.06em;color:var(--ae-ink)}
+  .status{margin-left:auto;font-family:var(--ae-font-mono);font-size:11px;color:var(--ae-ink-muted)}
+  footer.verdict{max-width:80rem;margin:0 auto;padding:2em;border-top:1px solid var(--ae-line)}
+  footer.verdict h2{font-size:1em;font-weight:var(--ae-w-black);margin-bottom:.5em}
+  footer.verdict p{color:var(--ae-ink-muted);max-width:68rem;margin-bottom:.6em}
+</style>
+</head>
+<body>
+<header class="lab">
+  <h1>sploot-032 design lab — the auth door &amp; the workbench chrome</h1>
+  <p>Direction is locked by ADR 0005: <strong>Swiss chrome, feral contents</strong> on the
+  <span class="mono">@misty-step/aesthetic</span> v2.24.0 substrate — quiet ink-on-paper chrome,
+  cyan steered as the accent, all loudness spent inside content objects. Six structurally
+  distinct cuts of the two DESIGN.md-violating surfaces: the violet-glassmorphism auth door and
+  the generic-shadcn workbench. Every option uses real substrate tokens. Delegated mode:
+  winner picked below with rationale; operator can re-verdict.</p>
+</header>
+<nav class="pager" id="pager"></nav>
+
+<!-- ═══════════ OPTION 1 — CONSOLE DOOR ═══════════ -->
+<section class="opt" data-name="1 · console door">
+  <div class="meta">
+    <h2>Option 1 — the console door</h2>
+    <p>The auth door is a labeled instrument console: mono titlebar, hairline card, the machinery
+    (route, mode, build) on display in a footer strip. Straight out of DESIGN.md §4 — “the search
+    box is a labeled console with an ink titlebar; the machinery is on display.” The workbench
+    chrome is the same instrument panel: hairline bar, mono status line, zero decoration; the meme
+    grid supplies every drop of loudness.</p>
+    <p class="verdictline">chrome loudness: none · deviation spend: display wordmark only</p>
+  </div>
+  <div class="stage">
+    <div>
+      <p class="surface-label">/sign-in</p>
+      <div style="border:1px solid var(--ae-ink);background:var(--ae-surface)">
+        <div style="display:flex;justify-content:space-between;background:var(--ae-ink);color:var(--ae-surface);padding:.35em .7em" class="mono">
+          <span>sploot / auth.console</span><span>● ready</span>
+        </div>
+        <div class="f" style="padding:1.2em 1.4em">
+          <button class="social mono">CONTINUE WITH GOOGLE</button>
+          <label>email</label><input value="you@example.com">
+          <label>password</label><input type="password" value="••••••••">
+          <button class="btn">Sign in</button>
+          <p class="alt">No account? <a href="#">Sign up</a></p>
+        </div>
+        <div class="mono" style="display:flex;gap:1.2em;border-top:1px solid var(--ae-line);padding:.4em .7em;color:var(--ae-ink-muted)">
+          <span>route: /sign-in</span><span>auth: clerk</span><span>mode: private</span>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="surface-label">/app workbench</p>
+      <div class="wb">
+        <div class="bar">
+          <span class="wordmark">SPLOOT</span>
+          <span class="mono" style="border:1px solid var(--ae-line);padding:.2em .6em;flex:1;max-width:20rem;color:var(--ae-ink-faint)">search your memes…</span>
+          <span class="status">1,204 indexed · siglip2 · 12ms</span>
+        </div>
+        <div class="grid">
+          <div class="tile"><span class="fn">cat_scream.png</span></div>
+          <div class="tile"><span class="banger">BANGER</span><span class="fn">deal_with_it.gif</span></div>
+          <div class="tile"><span class="fn">this_is_fine.jpg</span></div>
+          <div class="tile"><span class="fn">galaxy_brain.png</span></div>
+          <div class="tile"><span class="fn">stonks.webp</span></div>
+          <div class="tile"><span class="fn">sploot_irl.jpg</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════ OPTION 2 — STAMPED PAPER ═══════════ -->
+<section class="opt" data-name="2 · stamped paper">
+  <div class="meta">
+    <h2>Option 2 — stamped paper</h2>
+    <p>The door sits on sploot’s unbleached paper with the grid faintly printed; the card wears a
+    thick ink border, a hard offset shadow, and one filled sticker tab — the landing’s zine
+    grammar walks right into the door. Workbench keeps the paper field and stamps the wordmark.
+    Loudest chrome of the six; spends the filled-pill deviation on a first-touch surface.</p>
+    <p class="verdictline">chrome loudness: high · deviation spend: display face + filled pill + hard shadow</p>
+  </div>
+  <div class="stage">
+    <div>
+      <p class="surface-label">/sign-in</p>
+      <div style="background:var(--sploot-paper);background-image:repeating-linear-gradient(0deg,rgba(10,10,10,.05) 0 1px,transparent 1px 24px),repeating-linear-gradient(90deg,rgba(10,10,10,.05) 0 1px,transparent 1px 24px);padding:2em 1.5em">
+        <div style="position:relative;border:var(--sploot-border);box-shadow:var(--sploot-shadow-sm);background:var(--ae-surface)">
+          <span class="mono" style="position:absolute;top:-14px;left:14px;background:var(--sploot-cyan);border:3px solid var(--sploot-ink);padding:1px 8px;font-weight:700">MEMBERS</span>
+          <div class="f" style="padding:1.6em 1.4em 1.2em">
+            <span class="wordmark" style="font-size:2.2em">SPLOOT</span>
+            <label>email</label><input value="you@example.com">
+            <label>password</label><input type="password" value="••••••••">
+            <button class="btn" style="background:var(--sploot-blue);border-color:var(--sploot-ink);border-width:3px;box-shadow:3px 3px 0 var(--sploot-ink)">SIGN IN</button>
+            <p class="alt">No account? <a href="#">Sign up</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="surface-label">/app workbench</p>
+      <div class="wb" style="background:var(--sploot-paper-warm)">
+        <div class="bar" style="background:var(--ae-surface)">
+          <span class="wordmark" style="color:var(--sploot-blue)">SPLOOT</span>
+          <span class="mono" style="border:3px solid var(--sploot-ink);padding:.2em .6em;flex:1;max-width:20rem;background:#fff">search your memes…</span>
+          <span class="status">1,204 indexed</span>
+        </div>
+        <div class="grid">
+          <div class="tile"><span class="fn">cat_scream.png</span></div>
+          <div class="tile"><span class="banger">BANGER</span><span class="fn">deal_with_it.gif</span></div>
+          <div class="tile"><span class="fn">this_is_fine.jpg</span></div>
+          <div class="tile"><span class="fn">galaxy_brain.png</span></div>
+          <div class="tile"><span class="fn">stonks.webp</span></div>
+          <div class="tile"><span class="fn">sploot_irl.jpg</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════ OPTION 3 — SPLIT BRAND WALL ═══════════ -->
+<section class="opt" data-name="3 · split brand wall">
+  <div class="meta">
+    <h2>Option 3 — split brand wall</h2>
+    <p>The door is a diptych: the left half is feral contents (a jittered pile of meme cells with a
+    banger stamp — the product proving itself before sign-in), the right half is a pure-substrate
+    quiet form. The frame/contents split becomes literal architecture. Workbench chrome stays
+    quiet; the pile rail carries the color.</p>
+    <p class="verdictline">chrome loudness: contained to left panel · deviation spend: content objects only</p>
+  </div>
+  <div class="stage">
+    <div style="grid-column:1/-1">
+      <p class="surface-label">/sign-in</p>
+      <div style="display:grid;grid-template-columns:1fr 1fr;border:1px solid var(--ae-ink);min-height:20rem">
+        <div style="background:var(--sploot-paper);padding:1.5em;display:grid;grid-template-columns:repeat(3,1fr);gap:.9em;align-content:center">
+          <div class="tile"><span class="fn">cat_scream.png</span></div>
+          <div class="tile"><span class="banger">BANGER</span><span class="fn">deal_with_it.gif</span></div>
+          <div class="tile"><span class="fn">this_is_fine.jpg</span></div>
+          <div class="tile"><span class="fn">galaxy_brain.png</span></div>
+          <div class="tile"><span class="fn">stonks.webp</span></div>
+          <div class="tile"><span class="fn">sploot_irl.jpg</span></div>
+        </div>
+        <div class="f" style="background:var(--ae-surface);padding:2em 2.5em;align-self:center">
+          <p style="font-weight:var(--ae-w-black)">Your memes. Findable.</p>
+          <label>email</label><input value="you@example.com">
+          <label>password</label><input type="password" value="••••••••">
+          <button class="btn">Sign in</button>
+          <p class="alt">No account? <a href="#">Sign up</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════ OPTION 4 — PURE INSTRUMENT PANEL ═══════════ -->
+<section class="opt" data-name="4 · pure instrument panel">
+  <div class="meta">
+    <h2>Option 4 — pure instrument panel</h2>
+    <p>The most Swiss pole: no display face anywhere in chrome, weight-only hierarchy
+    (400/550/800), wash panels, hairlines. The wordmark is Geist 800 caps. The full aesthetic
+    orthodoxy — which means it spends zero of sploot’s permitted deviations and reads closest to a
+    generic Misty Step product. Included as the control arm.</p>
+    <p class="verdictline">chrome loudness: none · deviation spend: zero (control)</p>
+  </div>
+  <div class="stage">
+    <div>
+      <p class="surface-label">/sign-in</p>
+      <div style="background:var(--ae-wash);padding:2em 1.5em">
+        <div class="f" style="border:1px solid var(--ae-line);background:var(--ae-surface);padding:1.6em 1.4em">
+          <p style="font-weight:var(--ae-w-black);letter-spacing:.04em">SPLOOT</p>
+          <p style="color:var(--ae-ink-muted);font-size:.85em">Sign in to your archive</p>
+          <label>email</label><input value="you@example.com">
+          <label>password</label><input type="password" value="••••••••">
+          <button class="btn">Sign in</button>
+          <p class="alt">No account? <a href="#">Sign up</a></p>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="surface-label">/app workbench</p>
+      <div class="wb">
+        <div class="bar">
+          <span style="font-weight:var(--ae-w-black);letter-spacing:.04em">SPLOOT</span>
+          <span class="mono" style="border:1px solid var(--ae-line);padding:.2em .6em;flex:1;max-width:20rem;color:var(--ae-ink-faint)">search…</span>
+          <span class="status">1,204</span>
+        </div>
+        <div class="grid">
+          <div class="tile"><span class="fn">cat_scream.png</span></div>
+          <div class="tile"><span class="banger">BANGER</span><span class="fn">deal_with_it.gif</span></div>
+          <div class="tile"><span class="fn">this_is_fine.jpg</span></div>
+          <div class="tile"><span class="fn">galaxy_brain.png</span></div>
+          <div class="tile"><span class="fn">stonks.webp</span></div>
+          <div class="tile"><span class="fn">sploot_irl.jpg</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════ OPTION 5 — INDEX CARD ═══════════ -->
+<section class="opt" data-name="5 · index card">
+  <div class="meta">
+    <h2>Option 5 — index card / archive drawer</h2>
+    <p>The door is a catalog index card: corner brackets, numbered mono field labels
+    (“FIELD 01 — EMAIL”), a ruled header line. The workbench header becomes a drawer label —
+    “DRAWER A — ALL MEMES” — with the same brackets. The archive/database metaphor carried by
+    typographic apparatus instead of ink weight; chrome stays substrate-quiet.</p>
+    <p class="verdictline">chrome loudness: none · deviation spend: display wordmark only</p>
+  </div>
+  <div class="stage">
+    <div>
+      <p class="surface-label">/sign-in</p>
+      <div style="position:relative;border:1px solid var(--ae-ink);background:var(--ae-surface);padding:1.6em 1.4em">
+        <span style="position:absolute;top:-1px;left:-1px;width:14px;height:14px;border-top:3px solid var(--ae-ink);border-left:3px solid var(--ae-ink)"></span>
+        <span style="position:absolute;top:-1px;right:-1px;width:14px;height:14px;border-top:3px solid var(--ae-ink);border-right:3px solid var(--ae-ink)"></span>
+        <span style="position:absolute;bottom:-1px;left:-1px;width:14px;height:14px;border-bottom:3px solid var(--ae-ink);border-left:3px solid var(--ae-ink)"></span>
+        <span style="position:absolute;bottom:-1px;right:-1px;width:14px;height:14px;border-bottom:3px solid var(--ae-ink);border-right:3px solid var(--ae-ink)"></span>
+        <div class="mono" style="display:flex;justify-content:space-between;border-bottom:2px solid var(--ae-ink);padding-bottom:.4em">
+          <span>CARD № 001</span><span>SPLOOT ARCHIVE</span>
+        </div>
+        <div class="f">
+          <label>FIELD 01 — EMAIL</label><input value="you@example.com">
+          <label>FIELD 02 — PASSWORD</label><input type="password" value="••••••••">
+          <button class="btn">FILE REQUEST → SIGN IN</button>
+          <p class="alt">Unregistered? <a href="#">Open a card</a></p>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="surface-label">/app workbench</p>
+      <div class="wb">
+        <div class="bar mono" style="text-transform:uppercase">
+          <span style="font-weight:700">Drawer A — All Memes</span>
+          <span style="border:1px solid var(--ae-line);padding:.2em .6em;flex:1;max-width:20rem;color:var(--ae-ink-faint);text-transform:none">search…</span>
+          <span class="status">1,204 cards</span>
+        </div>
+        <div class="grid">
+          <div class="tile"><span class="fn">cat_scream.png</span></div>
+          <div class="tile"><span class="banger">BANGER</span><span class="fn">deal_with_it.gif</span></div>
+          <div class="tile"><span class="fn">this_is_fine.jpg</span></div>
+          <div class="tile"><span class="fn">galaxy_brain.png</span></div>
+          <div class="tile"><span class="fn">stonks.webp</span></div>
+          <div class="tile"><span class="fn">sploot_irl.jpg</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════ OPTION 6 — TICKET STUB ═══════════ -->
+<section class="opt" data-name="6 · ticket stub">
+  <div class="meta">
+    <h2>Option 6 — ticket stub</h2>
+    <p>The door is an admission ticket: perforated divider, a single acid-yellow “ADMIT ONE” block
+    (the one highlight per viewport, per the color law), mono serial number. Playful and deadpan,
+    but the metaphor is entry-event, not archive — it doesn’t generalize to the workbench, which
+    falls back to quiet chrome plus one yellow selected-pile beat.</p>
+    <p class="verdictline">chrome loudness: one yellow beat · deviation spend: display face + highlight block</p>
+  </div>
+  <div class="stage">
+    <div>
+      <p class="surface-label">/sign-in</p>
+      <div style="display:flex;border:2px solid var(--ae-ink);background:var(--ae-surface)">
+        <div style="writing-mode:vertical-rl;background:var(--sploot-yellow);border-right:2px dashed var(--ae-ink);padding:.6em .3em;font-family:var(--ae-font-mono);font-size:11px;font-weight:700;text-transform:uppercase">Admit one · № 0451</div>
+        <div class="f" style="padding:1.4em;flex:1">
+          <span class="wordmark" style="font-size:1.8em">SPLOOT</span>
+          <label>email</label><input value="you@example.com">
+          <label>password</label><input type="password" value="••••••••">
+          <button class="btn" style="background:var(--ae-ink);border-color:var(--ae-ink)">Tear here → sign in</button>
+          <p class="alt">No ticket? <a href="#">Sign up</a></p>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="surface-label">/app workbench</p>
+      <div class="wb">
+        <div class="bar">
+          <span class="wordmark">SPLOOT</span>
+          <span class="mono" style="background:var(--sploot-yellow);border:1px solid var(--ae-ink);padding:.2em .6em">pile: reaction cats</span>
+          <span class="mono" style="border:1px solid var(--ae-line);padding:.2em .6em;flex:1;max-width:16rem;color:var(--ae-ink-faint)">search…</span>
+          <span class="status">1,204</span>
+        </div>
+        <div class="grid">
+          <div class="tile"><span class="fn">cat_scream.png</span></div>
+          <div class="tile"><span class="banger">BANGER</span><span class="fn">deal_with_it.gif</span></div>
+          <div class="tile"><span class="fn">this_is_fine.jpg</span></div>
+          <div class="tile"><span class="fn">galaxy_brain.png</span></div>
+          <div class="tile"><span class="fn">stonks.webp</span></div>
+          <div class="tile"><span class="fn">sploot_irl.jpg</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer class="verdict">
+  <h2>Verdict (delegated) — Option 1, the console door</h2>
+  <p><strong>Why it wins:</strong> it is the only option that extends DESIGN.md’s core metaphor
+  (“exposed database — a labeled console with an ink titlebar, machinery on display”) to both
+  broken surfaces with one grammar. The auth door becomes the first instrument the user touches;
+  the workbench bar is the same instrument at working density. It honors the substrate (hairlines,
+  wash, steered cyan, mono chrome register) while spending exactly one deviation — the display
+  wordmark — so the feral contents (tiles, stamps, piles) stay the loudest thing on every screen,
+  which is the whole “Swiss chrome, feral contents” bet.</p>
+  <p><strong>Why not the others:</strong> 2 (stamped paper) is the strongest runner-up but spends
+  loudness on chrome at the door, competing with content and fighting Clerk’s DOM at its most
+  brittle point; 3 (split wall) is a landing-page move, weak on mobile where the pile collapses;
+  4 (pure panel) erases sploot’s voice — the control arm proves the deviations earn their keep;
+  5 (index card) is charming but its apparatus (numbered fields) fights Clerk’s fixed field
+  markup; 6 (ticket) doesn’t generalize past the door.</p>
+  <p class="mono">constraint: ADR 0005 · substrate v2.24.0 · options 6 · winner 1 · 2026-07-07 ·
+  operator may re-verdict; each option is implementable from this file</p>
+</footer>
+
+<script>
+  const opts=[...document.querySelectorAll('section.opt')],pager=document.getElementById('pager');
+  opts.forEach((s,i)=>{const b=document.createElement('button');b.textContent=s.dataset.name;
+    b.onclick=()=>{opts.forEach(o=>o.classList.remove('on'));pager.querySelectorAll('button').forEach(x=>x.classList.remove('on'));
+    s.classList.add('on');b.classList.add('on')};pager.appendChild(b);if(i===0){s.classList.add('on');b.classList.add('on')}});
+</script>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@ffmpeg-installer/ffmpeg':
         specifier: ^1.1.0
         version: 1.1.0
+      '@misty-step/aesthetic':
+        specifier: github:misty-step/aesthetic#v2.24.0
+        version: https://codeload.github.com/misty-step/aesthetic/tar.gz/27378184e7d45ad67e0cf1e579f7e836f7df9c47(@playwright/test@1.60.0)
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
@@ -1551,6 +1554,12 @@ packages:
   '@formkit/auto-animate@0.8.4':
     resolution: {integrity: sha512-DHHC01EJ1p70Q0z/ZFRBIY8NDnmfKccQoyoM84Tgb6omLMat6jivCdf272Y8k3nf4Lzdin/Y4R9q8uFtU0GbnA==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1738,6 +1747,26 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@misty-step/aesthetic@https://codeload.github.com/misty-step/aesthetic/tar.gz/27378184e7d45ad67e0cf1e579f7e836f7df9c47':
+    resolution: {tarball: https://codeload.github.com/misty-step/aesthetic/tar.gz/27378184e7d45ad67e0cf1e579f7e836f7df9c47}
+    version: 2.24.0
+    hasBin: true
+    peerDependencies:
+      '@playwright/test': '>=1.40.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -3756,6 +3785,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -3971,6 +4008,10 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -4031,6 +4072,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
@@ -4283,6 +4328,14 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
@@ -4319,6 +4372,14 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
@@ -4330,6 +4391,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
@@ -4894,6 +4959,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -4908,6 +4981,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -5008,6 +5091,10 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
@@ -5058,9 +5145,17 @@ packages:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
     engines: {node: '>= 18'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -5168,6 +5263,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -5278,6 +5374,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
+    engines: {node: '>=16.9.0'}
+
   hook-std@4.0.0:
     resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
     engines: {node: '>=20'}
@@ -5332,6 +5432,10 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.1:
     resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
@@ -5419,6 +5523,14 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-absolute@0.1.7:
     resolution: {integrity: sha512-Xi9/ZSn4NFapG8RP98iNPMOeaV3mXPisxKxzKtHVqr3g56j/fBn+yZmnxSVAA8lmZbl2J9b/a4kJvfU3hqQYgA==}
@@ -5579,6 +5691,9 @@ packages:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -5735,6 +5850,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -5790,6 +5908,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -6169,11 +6290,19 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-options@3.0.4:
@@ -6766,6 +6895,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -6837,6 +6969,10 @@ packages:
   pino@9.7.0:
     resolution: {integrity: sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
@@ -6953,6 +7089,10 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   publish-browser-extension@4.0.5:
     resolution: {integrity: sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==}
     engines: {node: '>=18.0.0'}
@@ -6979,6 +7119,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -6994,6 +7138,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -7233,6 +7381,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rpc-websockets@9.3.9:
     resolution: {integrity: sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==}
 
@@ -7264,6 +7416,9 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sanitize-html@2.17.4:
     resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
@@ -7316,6 +7471,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
@@ -7327,6 +7486,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -7389,6 +7552,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -7920,6 +8087,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -8121,6 +8292,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   viem@2.51.0:
     resolution: {integrity: sha512-8C0Ca+eEapXE29vHMUW59NqKENl1X4s9P6xSNC9Nvw6EvAeAhn/LNUlgztk6TOw7KN1Gzz5a/n9Wv4okUfmY9g==}
@@ -8564,6 +8739,11 @@ packages:
 
   zip-dir@2.0.0:
     resolution: {integrity: sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -10030,6 +10210,10 @@ snapshots:
 
   '@formkit/auto-animate@0.8.4': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.28)':
+    dependencies:
+      hono: 4.12.28
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -10180,6 +10364,38 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@misty-step/aesthetic@https://codeload.github.com/misty-step/aesthetic/tar.gz/27378184e7d45ad67e0cf1e579f7e836f7df9c47(@playwright/test@1.60.0)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@playwright/test': 1.60.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.28)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.28
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -12199,6 +12415,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
       ajv: 8.20.0
@@ -12434,6 +12654,20 @@ snapshots:
 
   bn.js@5.2.3: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   borsh@0.7.0:
@@ -12513,6 +12747,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   c12@3.1.0(magicast@0.3.5):
     dependencies:
@@ -12793,6 +13029,10 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   content-type@2.0.0: {}
 
   conventional-changelog-angular@8.3.1:
@@ -12824,6 +13064,10 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
@@ -12835,6 +13079,11 @@ snapshots:
   core-js@3.41.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -13520,6 +13769,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -13550,6 +13805,44 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -13643,6 +13936,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-root@1.1.0: {}
 
   find-up-simple@1.0.1: {}
@@ -13691,7 +13995,11 @@ snapshots:
 
   formdata-node@6.0.3: {}
 
+  forwarded@0.2.0: {}
+
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@11.3.5:
     dependencies:
@@ -13918,6 +14226,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hono@4.12.28: {}
+
   hook-std@4.0.0: {}
 
   hookable@6.1.1: {}
@@ -13983,6 +14293,10 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb-keyval@6.2.1: {}
 
@@ -14051,6 +14365,10 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-absolute@0.1.7:
     dependencies:
@@ -14182,6 +14500,8 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   is-primitive@3.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -14353,6 +14673,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   js-base64@3.7.8: {}
 
   js-cookie@3.0.7: {}
@@ -14408,6 +14730,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -14770,9 +15094,13 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0: {}
+
   memoize-one@5.2.1: {}
 
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-options@3.0.4:
     dependencies:
@@ -15406,6 +15734,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -15476,6 +15806,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-conf@2.1.0:
     dependencies:
@@ -15585,6 +15917,11 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   publish-browser-extension@4.0.5:
     dependencies:
       cac: 6.7.14
@@ -15615,6 +15952,11 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -15626,6 +15968,13 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc9@2.1.2:
     dependencies:
@@ -15961,6 +16310,16 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rpc-websockets@9.3.9:
     dependencies:
       '@swc/helpers': 0.5.22
@@ -16004,6 +16363,8 @@ snapshots:
       is-regex: 1.2.1
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
 
   sanitize-html@2.17.4:
     dependencies:
@@ -16094,6 +16455,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@2.1.0: {}
 
   serialize-javascript@7.0.5: {}
@@ -16104,6 +16481,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16204,6 +16590,14 @@ snapshots:
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -16692,6 +17086,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -16912,6 +17312,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3):
     dependencies:
@@ -17626,6 +18028,10 @@ snapshots:
     dependencies:
       async: 3.2.6
       jszip: 3.10.1
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -172,6 +172,42 @@ for (const [path, phrases] of Object.entries({
   }
 }
 
+// sploot-032: the @misty-step/aesthetic substrate is wired and documented.
+// The semantic layer must resolve to --ae-*, the deviation doc must exist,
+// and the auth door must be the substrate console (no violet glassmorphism).
+assertFile('docs/design/aesthetic-adoption.md');
+for (const phrase of ['@misty-step/aesthetic', 'declared deviations', 'Swiss chrome']) {
+  assertIncludes('docs/design/aesthetic-adoption.md', phrase, 'substrate deviation contract');
+}
+for (const phrase of [
+  '@import "@misty-step/aesthetic" layer(base)',
+  '--ae-accent',
+  '--background: var(--ae-surface)',
+  '--accent-cyan: var(--ae-accent)',
+]) {
+  assertIncludes(cssPath, phrase, 'aesthetic substrate wiring');
+}
+for (const [doorPath, phrases] of Object.entries({
+  'apps/web/components/auth/console-door.tsx': ['auth.console', 'consoleDoorAppearance'],
+  'apps/web/app/sign-in/[[...sign-in]]/page.tsx': ['ConsoleDoor'],
+  'apps/web/app/sign-up/[[...sign-up]]/page.tsx': ['ConsoleDoor'],
+})) {
+  for (const phrase of phrases) {
+    assertIncludes(doorPath, phrase, 'substrate console auth door');
+  }
+}
+for (const doorPath of [
+  'apps/web/app/sign-in/[[...sign-in]]/page.tsx',
+  'apps/web/app/sign-up/[[...sign-up]]/page.tsx',
+]) {
+  const content = read(doorPath);
+  for (const forbidden of ['violet', 'backdrop-blur', 'bg-gradient-']) {
+    if (content.includes(forbidden)) {
+      fail(`${doorPath}: auth door must stay on the substrate console — found ${forbidden} (DESIGN.md bans glassmorphism)`);
+    }
+  }
+}
+
 const landingSystemFiles = [
   'apps/web/app/page.tsx',
   'apps/web/app/styleguide/page.tsx',
@@ -239,12 +275,13 @@ const trackedUiFiles = execSync(
 
 const migrationExceptions = new Map([
   ['apps/web/app/not-found.tsx', ['bg-clip-text']],
-  ['apps/web/app/sign-in/[[...sign-in]]/page.tsx', ['bg-gradient-', 'backdrop-blur']],
-  ['apps/web/app/sign-up/[[...sign-up]]/page.tsx', ['bg-gradient-', 'backdrop-blur']],
+  // sploot-032 ratchet: the auth door (sign-in/sign-up) and the navbar lost
+  // their gradient/blur exceptions when they moved onto the aesthetic
+  // substrate — do not re-add them. app/page.tsx + image-tile blur is the
+  // lightbox scrim (content overlay), not chrome glassmorphism.
   ['apps/web/components/library/image-skeleton.tsx', ['bg-gradient-']],
   ['apps/web/components/ui/delete-confirmation-modal.tsx', ['bg-gradient-']],
   ['apps/web/app/app/page.tsx', ['backdrop-blur']],
-  ['apps/web/components/chrome/navbar.tsx', ['backdrop-blur']],
   ['apps/web/components/library/image-tile.tsx', ['backdrop-blur']],
 ]);
 


### PR DESCRIPTION
## What

Executes card **sploot-032** ("Swiss chrome, feral contents") after resolving the PR #228 fork:

- **ADR 0005** (`docs/adr/0005-close-pr-228-redo-aesthetic-adoption.md`): closed #228 (CONFLICTING, pinned v2.5.1 vs v2.24.0, deleted the display face master now depends on) and redid the adoption fresh, keeping its wiring pattern.
- **Substrate**: `github:misty-step/aesthetic#v2.24.0` imported at `layer(base)`; the shadcn semantic layer (`--background`, `--primary`, …) repoints at `--ae-*` with sploot cyan steered as the accent (`#0c6a84` light / `#00f0ff` dark, both AA). The `--sploot-*` loud layer is deliberately NOT remapped — deviations declared in `docs/design/aesthetic-adoption.md`.
- **Console door**: the violet-glassmorphism auth door (banned by DESIGN.md §3) becomes the substrate console — ink titlebar, hairline card, machinery strip. Lab winner of 6 options: `explorations/lab-032-auth-workbench.html`.
- **Workbench chrome**: rides the semantic repoint onto ink-on-paper; navbar loses `backdrop-blur`.
- **Gate ratchet**: `lint:design` now asserts the substrate wiring, deviation doc, and console door, and the auth-door/navbar gradient+blur exceptions are removed.

## Evidence (local dev, Clerk dev instance)

Sign-in light/dark: console frame, steered focus + button, dark flip clean. Landing + /styleguide + /changelog visually unchanged (loud layer intact); /changelog headings pick up the steered accent. Production before-shots captured for the card evidence packet.

## Verification

- `pnpm lint` / `pnpm type-check` / `pnpm lint:design` — green locally.
- Web tests need pgvector — CI runs them.
- Local walk: `/sign-in`, `/sign-up`, `/`, `/styleguide`, `/changelog` on `pnpm dev:web`, light + dark.

Card: sploot-032 · ADR: 0005 · Lab: `explorations/lab-032-auth-workbench.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a refreshed visual treatment for sign-in and sign-up screens, with a consistent framed layout and updated form styling.
  * Added a new design exploration page for comparing auth and workbench layout options.

* **Bug Fixes**
  * Improved auth form and footer styling to better match the app’s overall theme.
  * Updated the top navigation bar to use cleaner, more consistent surface styling.

* **Documentation**
  * Added design notes covering the updated visual system and auth styling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->