### PR TITLE
Wordmark keeps no-underline under substrate base link style (sploot-032 follow-up)

### DIFF
--- a/apps/web/components/chrome/navbar.tsx
+++ b/apps/web/components/chrome/navbar.tsx
@@ -61,7 +61,7 @@ export function Navbar({
         <Link
           href="/app"
           aria-label="Sploot - Home"
-          className="flex items-center gap-2 group hover:opacity-80 transition-opacity duration-150"
+          className="flex items-center gap-2 group no-underline hover:opacity-80 transition-opacity duration-150"
         >
           <PileMark />
 


### PR DESCRIPTION
One-line follow-up to #256: the aesthetic base layer underlines bare anchors; the SPLOOT navbar wordmark is a logo and now pins no-underline. Verified: lint:design green, navbar tests 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)