### PR TITLE
docs(web): link the live Chrome Web Store listing from the site footer

### DIFF
--- a/apps/web/components/global-footer.tsx
+++ b/apps/web/components/global-footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { OverlappingCircles } from "@/components/landing/overlapping-circles"
+import { SPLOOT_EXTENSION_STORE_URL } from "@/components/library/empty-state"
 
 export function GlobalFooter() {
   return (
@@ -33,6 +34,14 @@ export function GlobalFooter() {
             className="text-white/40 hover:text-white transition-colors"
           >
             privacy
+          </Link>
+          <Link
+            href={SPLOOT_EXTENSION_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white/40 hover:text-white transition-colors"
+          >
+            extension
           </Link>
         </div>
 


### PR DESCRIPTION
## Summary
- sploot-052 acceptance requires the CWS listing URL to be discoverable from README, the landing page, and the repo. README (ebc8337) and `apps/extension/STORE_LISTING.md` already carry it; the marketing landing page did not.
- Adds a footer "extension" link on the public site (every page via `GlobalFooter`), reusing the existing `SPLOOT_EXTENSION_STORE_URL` constant from `apps/web/components/library/empty-state.tsx` rather than a second hardcoded literal.

## Context for the reviewer
The Chrome Web Store submission itself already happened (see `apps/extension/STORE_LISTING.md` "Submission Status" log, dated 2026-05-26) — `https://chromewebstore.google.com/detail/sploot/fbhkflbcnllfogefckablkafjknmcfnd` returns HTTP 200 with title "Sploot - Chrome Web Store" as of this PR. This PR only closes the remaining "linked from landing page" acceptance gap; it does not touch anything submission-related.

## Test plan
- [x] `pnpm --filter web type-check` (after clearing a stale `.next` cache unrelated to this change)
- [x] `pnpm --filter web lint`
- [x] `pnpm lint:design`
- [x] `pnpm --filter web test` (1059 tests, 97 files, all pass)
- [x] `pnpm dev` locally, `curl localhost:3001/` confirms the footer renders the `chromewebstore.google.com/detail/sploot/...` link
- [x] `curl -s -o /dev/null -w '%{http_code}' https://chromewebstore.google.com/detail/sploot/fbhkflbcnllfogefckablkafjknmcfnd` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)