### PR TITLE
docs: add user-facing getting-started and iOS shortcut help pages

### DIFF
--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -184,8 +184,11 @@ export default function SettingsPage() {
         <p className="text-xs text-muted-foreground">
           Heads up: sharing images into Sploot from other apps&apos; share
           sheets works on Android. iPhones can&apos;t put web apps in the share
-          sheet — mint an upload token above and wire up the &ldquo;Save to
-          Sploot&rdquo; shortcut to share images from any iOS app.
+          sheet — mint an upload token above and wire up the{" "}
+          <Link href="/help/ios-shortcut" className="text-accent-cyan hover:underline">
+            &ldquo;Save to Sploot&rdquo; shortcut
+          </Link>{" "}
+          to share images from any iOS app.
         </p>
       </section>
 
@@ -212,6 +215,9 @@ export default function SettingsPage() {
           </Link>
         </div>
         <div className="pt-2 border-t border-border flex gap-4 text-sm">
+          <Link href="/help" className="text-muted-foreground hover:text-foreground transition-colors">
+            Getting started
+          </Link>
           <Link href="/support" className="text-muted-foreground hover:text-foreground transition-colors">
             Support
           </Link>

--- a/apps/web/app/help/ios-shortcut/page.tsx
+++ b/apps/web/app/help/ios-shortcut/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Save to Sploot on iPhone - Sploot Help",
+  description:
+    "Set up the Save to Sploot Apple Shortcut so images share straight from any iPhone app into your library.",
+};
+
+export default function IosShortcutHelp() {
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-6 py-12">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground transition-colors mb-8 inline-block"
+        >
+          ← Back to Getting Started
+        </Link>
+
+        <h1
+          className="text-4xl md:text-5xl mb-4 tracking-wide"
+          style={{ fontFamily: "var(--font-bebas-neue)" }}
+        >
+          SAVE TO SPLOOT ON IPHONE
+        </h1>
+        <p className="text-muted-foreground mb-8">
+          iOS (WebKit) doesn&apos;t implement the Web Share Target API, so an
+          installed Sploot PWA can never appear in the iPhone share sheet the
+          way it does on Android. The workaround is an{" "}
+          <strong className="text-foreground">Apple Shortcut</strong>: it
+          sits in the share sheet, accepts an image, and sends it to your
+          library over an authenticated request.
+        </p>
+        <p className="text-muted-foreground mb-8">
+          Shortcuts can&apos;t carry your Sploot login, so they authenticate
+          with a <strong className="text-foreground">personal upload token</strong> instead
+          — a credential that can only upload to your library, never read or
+          delete it.
+        </p>
+
+        <div className="space-y-10">
+          <section>
+            <h2 className="text-xl font-semibold mb-4">1. Mint an upload token</h2>
+            <ol className="list-decimal pl-6 space-y-2 text-muted-foreground">
+              <li>
+                Open Sploot →{" "}
+                <Link href="/app/settings" className="text-accent-cyan hover:underline">
+                  Settings
+                </Link>{" "}
+                → Upload tokens.
+              </li>
+              <li>Name it (e.g. &quot;iphone&quot;) and tap mint token.</li>
+              <li>
+                Copy the <code className="text-foreground">splt_…</code> value.{" "}
+                <strong className="text-foreground">It is shown only once.</strong> If
+                you lose it, revoke it and mint a new one.
+              </li>
+            </ol>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">2. Build the Shortcut</h2>
+            <p className="text-muted-foreground mb-4">
+              In the Shortcuts app, create a new shortcut with these actions:
+            </p>
+            <ol className="list-decimal pl-6 space-y-3 text-muted-foreground">
+              <li>
+                <strong className="text-foreground">Get Contents of URL</strong>
+                <ul className="list-disc pl-6 mt-2 space-y-1">
+                  <li>
+                    URL: <code className="text-foreground">https://www.sploot.app/api/upload</code>
+                  </li>
+                  <li>Method: POST</li>
+                  <li>
+                    Headers: add one — <code className="text-foreground">Authorization</code> ={" "}
+                    <code className="text-foreground">Bearer splt_…</code> (your token, with
+                    the word &quot;Bearer&quot; and a space before it).
+                  </li>
+                  <li>Request Body: Form</li>
+                  <li>
+                    Add a form field: Key = <code className="text-foreground">file</code>, Type
+                    = File, Value = Shortcut Input (the shared image).
+                  </li>
+                </ul>
+              </li>
+              <li>
+                (Optional) Show Result / Show Notification of the response so
+                you get a &quot;saved&quot; confirmation.
+              </li>
+            </ol>
+            <p className="text-muted-foreground mt-4">
+              Then open the shortcut&apos;s settings (the ⓘ / share icon):
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-1 text-muted-foreground">
+              <li>Turn on Show in Share Sheet.</li>
+              <li>
+                Under Share Sheet Types, accept Images (and Media if you want
+                to share from Photos).
+              </li>
+              <li>Name it &quot;Save to Sploot&quot;.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">3. Use it</h2>
+            <p className="text-muted-foreground">
+              From any app, tap Share → Save to Sploot. The image lands in
+              your library. Sploot deduplicates by content hash, so
+              re-sharing the same image is harmless — it returns the existing
+              asset rather than creating a duplicate.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">Responses the Shortcut may see</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-muted-foreground">
+                <thead>
+                  <tr className="border-b border-border text-foreground">
+                    <th className="py-2 pr-4">Status</th>
+                    <th className="py-2">Meaning</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-border/50">
+                    <td className="py-2 pr-4">201</td>
+                    <td className="py-2">Saved. Response includes the new asset.</td>
+                  </tr>
+                  <tr className="border-b border-border/50">
+                    <td className="py-2 pr-4">409</td>
+                    <td className="py-2">Already in your library (duplicate). The existing asset is returned.</td>
+                  </tr>
+                  <tr className="border-b border-border/50">
+                    <td className="py-2 pr-4">401</td>
+                    <td className="py-2">Unauthorized — token missing, mistyped, or revoked.</td>
+                  </tr>
+                  <tr className="border-b border-border/50">
+                    <td className="py-2 pr-4">403</td>
+                    <td className="py-2">Quota exceeded — you&apos;re out of storage.</td>
+                  </tr>
+                  <tr className="border-b border-border/50">
+                    <td className="py-2 pr-4">413</td>
+                    <td className="py-2">The image is larger than the upload limit.</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">503</td>
+                    <td className="py-2">Uploads are temporarily paused.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">Security</h2>
+            <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+              <li>
+                The token is upload-only: presenting it to any read or delete
+                endpoint returns 401. It cannot list, view, or remove your
+                memes.
+              </li>
+              <li>Only a hash of the token is stored server-side; the plaintext is shown once.</li>
+              <li>
+                If a token leaks (lost phone, shared screenshot), open{" "}
+                <Link href="/app/settings" className="text-accent-cyan hover:underline">
+                  Settings → Upload tokens
+                </Link>{" "}
+                and revoke it. Revocation is immediate.
+              </li>
+              <li>&quot;Last used&quot; is shown per token so you can spot one being used unexpectedly.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">Sharing your shortcut (optional)</h2>
+            <p className="text-muted-foreground">
+              Apple shortcuts are device-signed, so a ready-made .shortcut
+              file can only be produced and shared from an Apple device. If
+              you want to share your build with someone else, open the
+              shortcut → Share → Copy iCloud Link and send that. Each person
+              still mints and pastes their own token; never share a token.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Help - Sploot",
+  description: "Getting started, capture channels, and your data on Sploot",
+};
+
+export default function Help() {
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-6 py-12">
+        <Link
+          href="/"
+          className="text-muted-foreground hover:text-foreground transition-colors mb-8 inline-block"
+        >
+          ← Back to Sploot
+        </Link>
+
+        <h1
+          className="text-4xl md:text-5xl mb-4 tracking-wide"
+          style={{ fontFamily: "var(--font-bebas-neue)" }}
+        >
+          GETTING STARTED
+        </h1>
+        <p className="text-muted-foreground mb-8">
+          Sploot is a personal meme library: save from anywhere, find things
+          with plain words instead of folders. Here&apos;s how to get set up.
+        </p>
+
+        <div className="space-y-10">
+          <section>
+            <h2 className="text-xl font-semibold mb-4">1. Sign up</h2>
+            <p className="text-muted-foreground">
+              Create an account at{" "}
+              <a href="https://sploot.app" className="text-accent-cyan hover:underline">
+                sploot.app
+              </a>
+              . That&apos;s it — no setup wizard, no folders to build. Your
+              library starts empty and fills up as you save.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">2. Save your first meme</h2>
+            <p className="text-muted-foreground mb-4">
+              Sploot meets you where the meme already is. Pick whichever of
+              these fits how you actually browse:
+            </p>
+            <div className="space-y-6">
+              <div>
+                <h3 className="font-medium text-foreground">Drag-and-drop or upload on the web app</h3>
+                <p className="text-muted-foreground">
+                  On sploot.app, drag an image onto the library or click the
+                  upload area. Works for single files or a batch at once.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium text-foreground">Chrome extension — right-click anywhere</h3>
+                <p className="text-muted-foreground">
+                  Install the extension, sign in, then right-click any image
+                  on any site and choose &quot;Save to Sploot&quot;. See{" "}
+                  <Link href="/support" className="text-accent-cyan hover:underline">
+                    Support
+                  </Link>{" "}
+                  for install and troubleshooting steps.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium text-foreground">iPhone share sheet — Apple Shortcut</h3>
+                <p className="text-muted-foreground">
+                  iOS doesn&apos;t let installed web apps sit in the share
+                  sheet, so the Save to Sploot shortcut fills that gap: share
+                  an image from any app and it lands in your library. Full
+                  walkthrough:{" "}
+                  <Link href="/help/ios-shortcut" className="text-accent-cyan hover:underline">
+                    Save to Sploot on iPhone
+                  </Link>
+                  .
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium text-foreground">Android share sheet / installed PWA</h3>
+                <p className="text-muted-foreground">
+                  Install Sploot as an app (Settings → Install as app, or
+                  &quot;Add to Home Screen&quot; in your browser menu). Once
+                  installed, Sploot appears as a share target — share an
+                  image from Photos, Chrome, or any app straight into your
+                  library.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium text-foreground">Paste</h3>
+                <p className="text-muted-foreground">
+                  Copy an image (or a link to one) and paste it directly into
+                  the library or upload area on the web app.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">3. Find it again</h2>
+            <p className="text-muted-foreground mb-4">
+              Search describes the meme instead of naming a file. Try what
+              you&apos;d actually say out loud:
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+              <li>&quot;disappointed drake&quot; — finds Drake meme variations</li>
+              <li>&quot;surprised face&quot; — finds reaction images</li>
+              <li>&quot;cat sitting like a human&quot; — finds specific poses</li>
+            </ul>
+            <p className="text-muted-foreground mt-4">
+              Shuffle resurfaces things you forgot you saved, and piles
+              cluster your library automatically as it grows — no folders to
+              maintain by hand. That clustering is a first cut today: it
+              sorts into fixed categories and ranks off one averaged signal,
+              not a model of your personal taste yet. The real per-user taste
+              version is on the roadmap.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">Your data</h2>
+            <p className="text-muted-foreground mb-3">
+              Every meme you save stays viewable and downloadable individually
+              from its detail view on the web app — nothing is locked behind
+              a paywall or held hostage.
+            </p>
+            <p className="text-muted-foreground">
+              What doesn&apos;t exist yet: a single &quot;export everything&quot;
+              action (a zip or archive of your whole library in one click).
+              That&apos;s a real gap against the promise that your memes are
+              never held hostage, and it&apos;s tracked as a follow-up rather
+              than left silent. Until it ships, downloading meme-by-meme is
+              the way out.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-4">Where to get help</h2>
+            <p className="text-muted-foreground">
+              For extension troubleshooting, search tips, and contact info,
+              see{" "}
+              <Link href="/support" className="text-accent-cyan hover:underline">
+                Support
+              </Link>
+              . For the iPhone shortcut setup, see{" "}
+              <Link href="/help/ios-shortcut" className="text-accent-cyan hover:underline">
+                Save to Sploot on iPhone
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -31,6 +31,15 @@ export default function Support() {
               <p>
                 Sploot is a personal meme library with AI-powered semantic search. Save images from anywhere on the web and find them instantly with natural language queries.
               </p>
+              <p>
+                New here? The{" "}
+                <Link href="/help" className="text-accent-cyan hover:underline">
+                  Getting Started guide
+                </Link>{" "}
+                walks through signing up, every way to save a meme
+                (extension, iPhone shortcut, PWA share, paste/upload), and
+                how your data works.
+              </p>
             </div>
           </section>
 

--- a/apps/web/docs/shortcuts/save-to-sploot.md
+++ b/apps/web/docs/shortcuts/save-to-sploot.md
@@ -1,5 +1,10 @@
 # Save to Sploot — iPhone Share-Sheet Shortcut
 
+> This walkthrough is also published where users can actually find it:
+> `/help/ios-shortcut` on the live product, linked from Settings and the
+> Getting Started guide (`/help`). This file is the source copy for
+> repo/operator reference — keep both in sync if you edit either.
+
 iOS (WebKit) does not implement the Web Share Target API, so an installed Sploot
 PWA can never appear in the iPhone share sheet the way it does on Android. The
 sanctioned workaround is an **Apple Shortcut**: it can sit in the share sheet,


### PR DESCRIPTION
## Summary
- Adds `/help` — a real getting-started guide (sign up, every capture channel, search tips, your-data) reachable from the live product, not repo markdown
- Adds `/help/ios-shortcut` — promotes the Save to Sploot Apple Shortcut walkthrough from buried `apps/web/docs/shortcuts/save-to-sploot.md` to a live page; the markdown now points at it as the canonical user-facing copy
- Links both from Settings (Getting started + iOS shortcut link) and Support
- Documents the export/your-data gap honestly (VISION.md promises "export always works"; today only per-asset download exists) instead of describing a feature that doesn't exist, and files sploot-057 as the follow-up to close the gap for real

Closes sploot-054.

## Test plan
- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm lint:design` — passed
- [x] Local dev server: `curl localhost:3001/help`, `/help/ios-shortcut`, `/support` all 200 with expected content
- [x] Pre-commit hooks (gitleaks, secrets, lint-web, typecheck, commitlint) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)