### PR TITLE
feat(mcp): ship sploot MCP server + skill, publish token-scoped API contract

### DIFF
--- a/.agents/skills/misty-sploot/SKILL.md
+++ b/.agents/skills/misty-sploot/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: misty-sploot
+description: |
+  Save and search a personal Sploot meme library from any agent session via
+  the sploot MCP server. Sploot is a text→image semantic search library:
+  save a meme once (bytes or URL), later find it by describing what's in it
+  — no tags, no folders, no remembering filenames. Use when: "save this to
+  sploot", "save this meme", "find the meme where...", "search sploot for...".
+  Trigger: /sploot.
+argument-hint: "[save <url-or-path> | search <description>]"
+---
+
+# misty-sploot
+
+Sploot's agent-facing surface is two verbs, exposed as MCP tools by the
+`sploot-mcp` server (`apps/mcp` in the sploot repo) over the published,
+token-scoped contract in `apps/web/docs/PUBLIC_API.md`:
+
+- **`sploot_search`** — semantic text→image search. Describe what's in the
+  image in plain words; this is not a tag or filename lookup.
+- **`sploot_save`** — save an image by URL (Sploot fetches it server-side) or
+  by base64-encoded bytes (when there's no fetchable URL, e.g. a local file
+  or a screenshot you just took).
+
+No other Sploot verb is agent-callable today — reads of the full library,
+tag management, deletes, and token management stay session-only. Don't
+route around the MCP server with raw HTTP calls to routes it doesn't cover;
+if a task needs a verb the server doesn't expose, that's a gap to card, not
+to route around.
+
+## Using the tools
+
+**Search first** when the goal is "find a meme" — send the plain-words
+description as-is, don't pre-tokenize or add filters the user didn't ask for:
+
+```
+sploot_search({ query: "distracted boyfriend reaction" })
+```
+
+Real misses come back as an empty `results` array (never low-similarity
+padding) — report a miss as a miss, don't retry with `threshold: 0` to force
+matches.
+
+**Save** when the goal is "keep this image" — prefer `url` when the image
+already has a public URL (a page you're browsing, a link the human shared);
+use `bytesBase64` only when you're holding raw bytes with no URL (e.g. a
+screenshot or a locally generated image):
+
+```
+sploot_save({ url: "https://example.com/meme.png" })
+sploot_save({ bytesBase64: "<base64>", filename: "meme.png", tags: ["reaction"] })
+```
+
+A `409`/`isDuplicate: true` response means Sploot already has this exact
+image — that's success, not a retry signal.
+
+## Setup (once per environment)
+
+The MCP server needs a personal API token:
+
+1. Mint one at **sploot.app → Settings → Upload tokens** (or
+   `POST /api/upload-tokens` with a signed-in session). The plaintext is
+   shown once — store it in the environment/secret manager registering this
+   MCP server, not in a chat transcript or repo file.
+2. Register the server with `SPLOOT_API_TOKEN` set (and `SPLOOT_API_BASE_URL`
+   only if not targeting production `https://www.sploot.app/api`):
+
+```json
+{
+  "mcpServers": {
+    "sploot": {
+      "command": "node",
+      "args": ["/path/to/sploot/apps/mcp/dist/index.js"],
+      "env": { "SPLOOT_API_TOKEN": "splt_…" }
+    }
+  }
+}
+```
+
+Build the server once with `pnpm --filter @sploot/mcp build` (repo root)
+before pointing a harness at `dist/index.js`.
+
+## Failure modes
+
+- **`401`** — token missing, revoked, or wrong environment (a token minted
+  against localhost won't authenticate against production and vice versa).
+  Re-mint or re-check `SPLOOT_API_BASE_URL`.
+- **`503` on search** — the embedding service is unavailable (Replicate not
+  configured, or paused). Not a query problem — don't retry with a
+  reformulated query.
+- Both tools return `isError: true` with a plain-text explanation on any
+  API-level failure; treat that text as user-facing, not a stack trace to
+  paste back verbatim.
+
+## Ground truth
+
+`apps/web/docs/PUBLIC_API.md` (the published contract) and `apps/mcp/README.md`
+(server implementation/config) are authoritative over this skill if they
+disagree — this skill teaches usage, it doesn't own the contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,15 @@ symlink to this file — they are identical by construction.
 Sploot is a pnpm Turborepo monorepo consolidating:
 - **apps/web** — Next.js 15 meme library: text→image semantic search (CLIP/SigLIP embeddings, pgvector), App Router API routes, Clerk auth, Prisma/Neon pgvector, Vercel Blob, Replicate embeddings, Canary diagnostics, deployed smoke, and Vercel release posture.
 - **apps/extension** — Chrome extension (WXT + React) for one-click image saving: popup/background capture, Clerk extension auth, API client, store assets, and Chrome Web Store release packet.
+- **apps/mcp** — `@sploot/mcp` (`sploot-mcp` bin): MCP server exposing save + search as agent tools over the published token-scoped API contract. Companion skill: `.agents/skills/misty-sploot/`.
 - **packages/common** — `@sploot/common`, shared upload constants and API types consumed by both apps.
 
 ## Ground Truth Pointers
 
 - Product: `VISION.md` — north star, audience, the capture→retrieval→taste→generation arc, and the agent-operability principle
 - Architecture: `ARCHITECTURE.md`, `apps/web/ARCHITECTURE.md`, `apps/extension/ARCHITECTURE.md`
-- Web API docs: `apps/web/docs/API.md` must stay synced with route behavior
+- Web API docs: `apps/web/docs/API.md` must stay synced with route behavior; `apps/web/docs/PUBLIC_API.md` is the published, token-scoped external contract (save + search) — keep both in sync when either changes
+- Agent access: `apps/mcp` (MCP server) + `.agents/skills/misty-sploot/` (skill); five-faces status ledger: `docs/five-faces.md`
 - Shared upload/API contract: `packages/common/src/*`
 - Prisma schema/migrations: `apps/web/prisma`
 - CI: `.github/workflows/ci.yml`; release: `.github/workflows/release.yml`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,19 @@ packages.
 |-----------|------|-------------|
 | **Web App** | [`apps/web`](./apps/web) | Next.js 15 App Router, Vercel Blob, pgvector, Clerk Auth. |
 | **Extension** | [`apps/extension`](./apps/extension) | Chrome Extension (WXT) for one-click saving. |
+| **MCP Server** | [`apps/mcp`](./apps/mcp) | `sploot-mcp` — save + search as agent tools over the [published API](./apps/web/docs/PUBLIC_API.md). |
 | **Common** | [`packages/common`](./packages/common) | Shared constants, types, and utilities. |
+
+## 🤖 Agent access
+
+Agents (and the operator's agent fleet) save and search Sploot without a
+browser: the **sploot MCP server** (`apps/mcp`) exposes `sploot_search` and
+`sploot_save` as tools over a personal API token, and the
+**`misty-sploot`** skill teaches the verbs. See
+[`apps/web/docs/PUBLIC_API.md`](./apps/web/docs/PUBLIC_API.md) for the
+published contract and [`docs/five-faces.md`](./docs/five-faces.md) for
+Sploot's face-by-face status (UI/API/MCP/skill shipped; CLI explicitly
+waived, rationale in that doc).
 
 ![Sploot Architecture](https://img.shields.io/badge/Architecture-Monorepo-black?style=flat-square&logo=turborepo)
 ![Next.js](https://img.shields.io/badge/Next.js-15.5-black?style=flat-square&logo=next.js)

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,0 +1,88 @@
+# @sploot/mcp
+
+MCP server exposing Sploot's two agent-facing verbs — **save** and
+**search** — as tools, over the published, token-scoped external contract in
+[`apps/web/docs/PUBLIC_API.md`](../web/docs/PUBLIC_API.md). It is a thin HTTP
+client: no business logic (dedupe, quota, embeddings, similarity ranking)
+lives here, all of it lives server-side in `apps/web`.
+
+The companion agent skill (`.agents/skills/misty-sploot/SKILL.md`) teaches
+the verbs; this package is the runtime that implements them.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `sploot_search` | Semantic text→image search. `{ query, limit?, threshold? }` |
+| `sploot_save` | Save an image by `url` or `bytesBase64` (+ optional `filename`, `mimeType`, `tags`) |
+
+Both return the underlying API's JSON response as text content on success,
+and `{ isError: true, content: [...] }` with a human-readable message on
+failure (bad/missing token, quota exceeded, embedding service unavailable,
+etc.) — see `PUBLIC_API.md` for the exact response shapes and error codes.
+
+## Setup
+
+1. **Mint a personal API token** — sploot.app → Settings → Upload tokens (or
+   `POST /api/upload-tokens` with a signed-in session). Shown once; store it
+   in your secret manager, not in a config file.
+2. **Build the server:**
+
+   ```bash
+   pnpm --filter @sploot/mcp build   # emits dist/index.js
+   ```
+
+3. **Register it** with your MCP-capable harness (Claude Code, Claude
+   Desktop, etc.):
+
+   ```json
+   {
+     "mcpServers": {
+       "sploot": {
+         "command": "node",
+         "args": ["/absolute/path/to/sploot/apps/mcp/dist/index.js"],
+         "env": {
+           "SPLOOT_API_TOKEN": "splt_…"
+         }
+       }
+     }
+   }
+   ```
+
+## Environment variables
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `SPLOOT_API_TOKEN` | yes | — | Personal API token (`splt_…`) |
+| `SPLOOT_API_BASE_URL` | no | `https://www.sploot.app/api` | Point at a local dev instance (e.g. `http://localhost:3001/api`) instead of production |
+
+The server refuses to start without `SPLOOT_API_TOKEN` and prints the mint
+instructions to stderr.
+
+## Development
+
+```bash
+pnpm --filter @sploot/mcp dev          # run from source with tsx
+pnpm --filter @sploot/mcp type-check
+pnpm --filter @sploot/mcp test         # vitest, mocks fetch — no live instance needed
+pnpm --filter @sploot/mcp build        # tsc -> dist/
+```
+
+`src/client.ts` is the HTTP layer (unit-tested against a mocked `fetch`);
+`src/tools.ts` is the tool-handler logic (unit-tested against a fake
+client); `src/index.ts` wires both into an `McpServer` over stdio. Keep that
+separation — it's what makes the tool logic testable without a real MCP
+transport or a live Sploot instance.
+
+## Manual smoke test against a local instance
+
+```bash
+# 1. Boot a local Sploot with qa-local auth + seeded data (repo root):
+pnpm dev:local
+
+# 2. Mint a token for the seeded qa-design-user (see apps/web/docs/AUTH.md
+#    for qa-local auth), then:
+SPLOOT_API_TOKEN=splt_… SPLOOT_API_BASE_URL=http://localhost:3001/api \
+  node apps/mcp/dist/index.js
+# 3. Point an MCP client (or the Inspector) at that process over stdio.
+```

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sploot/mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing Sploot's save + search verbs as agent tools over the personal-API-token public contract (docs/PUBLIC_API.md).",
+  "type": "module",
+  "bin": {
+    "sploot-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SplootApiError, SplootClient } from '../client.js';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('SplootClient', () => {
+  const config = { baseUrl: 'https://sploot.test/api', token: 'splt_test_token' };
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+  });
+
+  describe('search', () => {
+    it('POSTs to /search with a bearer token and the query body', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ results: [], query: 'cat', total: 0, limit: 30, threshold: 0.2, processingTime: 5 })
+      );
+      const client = new SplootClient(config, fetchMock as unknown as typeof fetch);
+
+      const result = await client.search('cat', { limit: 10, threshold: 0.5 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://sploot.test/api/search');
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Bearer splt_test_token');
+      expect(init.headers['Content-Type']).toBe('application/json');
+      expect(JSON.parse(init.body)).toEqual({ query: 'cat', limit: 10, threshold: 0.5 });
+      expect(result.total).toBe(0);
+    });
+
+    it('throws SplootApiError with the server error message on 401', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401));
+      const client = new SplootClient(config, fetchMock as unknown as typeof fetch);
+
+      await expect(client.search('cat')).rejects.toMatchObject({
+        name: 'SplootApiError',
+        status: 401,
+        message: 'Unauthorized',
+      });
+      await expect(client.search('cat')).rejects.toBeInstanceOf(SplootApiError);
+    });
+
+    it('throws SplootApiError on 503 when embeddings are unavailable', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ error: 'Search is temporarily unavailable: embedding service is not configured.' }, 503)
+      );
+      const client = new SplootClient(config, fetchMock as unknown as typeof fetch);
+
+      await expect(client.search('cat')).rejects.toMatchObject({ status: 503 });
+    });
+  });
+
+  describe('saveUrl', () => {
+    it('POSTs to /upload/url with the bearer token and url body', async () => {
+      const asset = {
+        id: 'a1',
+        blobUrl: 'https://blob.test/a.png',
+        filename: 'a.png',
+        mimeType: 'image/png',
+        size: 10,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        needsEmbedding: true,
+      };
+      fetchMock.mockResolvedValue(
+        jsonResponse({ success: true, isDuplicate: false, asset, message: 'Upload successful' }, 201)
+      );
+      const client = new SplootClient(config, fetchMock as unknown as typeof fetch);
+
+      const result = await client.saveUrl('https://example.com/a.png');
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://sploot.test/api/upload/url');
+      expect(JSON.parse(init.body)).toEqual({ url: 'https://example.com/a.png' });
+      expect(result.asset.id).toBe('a1');
+    });
+
+    it('resolves (does not throw) on a 409 duplicate', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          { success: true, isDuplicate: true, asset: { id: 'a1' }, message: 'This image already exists in your library' },
+          409
+        )
+      );
+      const client = new SplootClient(config, fetchMock as unknown as typeof fetch);
+
+      const result = await client.saveUrl('https://example.com/a.png');
+      expect(result.isDuplicate).toBe(true);
+    });
+  });
+
+  describe('saveBytes', () => {
+    it('POSTs multipart form data to /upload with the bearer token, no Content-Type override', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          { success: true, isDuplicate: false, asset: { id: 'a2' }, message: 'Upload successful' },
+          201
+        )
+      );
+      const client = new SplootClient(config, fetchMock as unknown as typeof fetch);
+
+      const result = await client.saveBytes(new Uint8Array([1, 2, 3]), 'meme.png', 'image/png', ['reaction']);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://sploot.test/api/upload');
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Bearer splt_test_token');
+      // Content-Type is left to FormData/undici to set (with boundary) — an
+      // explicit override would break multipart parsing.
+      expect(init.headers['Content-Type']).toBeUndefined();
+      const form = init.body as FormData;
+      expect(form.get('file')).toBeInstanceOf(Blob);
+      expect(form.get('tags')).toBe(JSON.stringify(['reaction']));
+      expect(result.asset.id).toBe('a2');
+    });
+  });
+});

--- a/apps/mcp/src/__tests__/config.test.ts
+++ b/apps/mcp/src/__tests__/config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_BASE_URL, loadConfigFromEnv, MissingTokenError } from '../config.js';
+
+describe('loadConfigFromEnv', () => {
+  it('throws MissingTokenError when SPLOOT_API_TOKEN is absent', () => {
+    expect(() => loadConfigFromEnv({})).toThrow(MissingTokenError);
+  });
+
+  it('throws MissingTokenError when SPLOOT_API_TOKEN is blank', () => {
+    expect(() => loadConfigFromEnv({ SPLOOT_API_TOKEN: '   ' })).toThrow(MissingTokenError);
+  });
+
+  it('defaults baseUrl to the production public API', () => {
+    const config = loadConfigFromEnv({ SPLOOT_API_TOKEN: 'splt_abc' });
+    expect(config).toEqual({ baseUrl: DEFAULT_BASE_URL, token: 'splt_abc' });
+  });
+
+  it('uses SPLOOT_API_BASE_URL when provided, stripping a trailing slash', () => {
+    const config = loadConfigFromEnv({
+      SPLOOT_API_TOKEN: 'splt_abc',
+      SPLOOT_API_BASE_URL: 'http://localhost:3001/api/',
+    });
+    expect(config.baseUrl).toBe('http://localhost:3001/api');
+  });
+});

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SplootApiError, type SplootClient } from '../client.js';
+import { runSaveTool, runSearchTool } from '../tools.js';
+
+function fakeClient(overrides: Partial<SplootClient> = {}): SplootClient {
+  return {
+    search: vi.fn(),
+    saveUrl: vi.fn(),
+    saveBytes: vi.fn(),
+    ...overrides,
+  } as unknown as SplootClient;
+}
+
+describe('runSearchTool', () => {
+  it('returns the search response as JSON text content', async () => {
+    const client = fakeClient({
+      search: vi.fn().mockResolvedValue({ results: [{ id: 'a1' }], query: 'cat', total: 1 }),
+    });
+
+    const result = await runSearchTool(client, { query: 'cat' });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe('text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({ total: 1 });
+    expect(client.search).toHaveBeenCalledWith('cat', { limit: undefined, threshold: undefined });
+  });
+
+  it('passes limit and threshold through to the client', async () => {
+    const client = fakeClient({ search: vi.fn().mockResolvedValue({ results: [] }) });
+
+    await runSearchTool(client, { query: 'cat', limit: 5, threshold: 0.5 });
+
+    expect(client.search).toHaveBeenCalledWith('cat', { limit: 5, threshold: 0.5 });
+  });
+
+  it('returns an error result when the client throws SplootApiError', async () => {
+    const client = fakeClient({
+      search: vi.fn().mockRejectedValue(new SplootApiError('Unauthorized', 401, { error: 'Unauthorized' })),
+    });
+
+    const result = await runSearchTool(client, { query: 'cat' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('401');
+    expect(result.content[0].text).toContain('Unauthorized');
+  });
+});
+
+describe('runSaveTool', () => {
+  it('calls saveUrl when url is provided', async () => {
+    const client = fakeClient({
+      saveUrl: vi.fn().mockResolvedValue({ success: true, isDuplicate: false, asset: { id: 'a1' } }),
+    });
+
+    const result = await runSaveTool(client, { url: 'https://example.com/a.png' });
+
+    expect(client.saveUrl).toHaveBeenCalledWith('https://example.com/a.png');
+    expect(client.saveBytes).not.toHaveBeenCalled();
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('calls saveBytes with decoded bytes when bytesBase64 is provided', async () => {
+    const client = fakeClient({
+      saveBytes: vi.fn().mockResolvedValue({ success: true, isDuplicate: false, asset: { id: 'a2' } }),
+    });
+    const base64 = Buffer.from('hello').toString('base64');
+
+    await runSaveTool(client, { bytesBase64: base64, filename: 'x.png', mimeType: 'image/png', tags: ['t'] });
+
+    expect(client.saveBytes).toHaveBeenCalledTimes(1);
+    const [bytes, filename, mimeType, tags] = (client.saveBytes as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(Buffer.from(bytes).toString()).toBe('hello');
+    expect(filename).toBe('x.png');
+    expect(mimeType).toBe('image/png');
+    expect(tags).toEqual(['t']);
+  });
+
+  it('defaults filename and mimeType when saving by bytes', async () => {
+    const client = fakeClient({
+      saveBytes: vi.fn().mockResolvedValue({ success: true, isDuplicate: false, asset: { id: 'a3' } }),
+    });
+
+    await runSaveTool(client, { bytesBase64: Buffer.from('x').toString('base64') });
+
+    const [, filename, mimeType] = (client.saveBytes as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(filename).toBe('upload.png');
+    expect(mimeType).toBe('image/png');
+  });
+
+  it('errors when neither url nor bytesBase64 is given', async () => {
+    const client = fakeClient();
+
+    const result = await runSaveTool(client, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/url.*bytesBase64|provide/i);
+    expect(client.saveUrl).not.toHaveBeenCalled();
+    expect(client.saveBytes).not.toHaveBeenCalled();
+  });
+
+  it('errors when both url and bytesBase64 are given', async () => {
+    const client = fakeClient();
+
+    const result = await runSaveTool(client, { url: 'https://example.com/a.png', bytesBase64: 'abc' });
+
+    expect(result.isError).toBe(true);
+    expect(client.saveUrl).not.toHaveBeenCalled();
+    expect(client.saveBytes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -1,0 +1,135 @@
+import type { SplootConfig } from './config.js';
+
+/**
+ * Thin HTTP client over Sploot's published, token-scoped public contract
+ * (apps/web/docs/PUBLIC_API.md): save (bytes or URL) and search. No business
+ * logic lives here — every rule (dedupe, quota, embedding, similarity
+ * threshold) lives server-side; this client only shapes requests/responses.
+ */
+
+export interface AssetTag {
+  id: string;
+  name: string;
+}
+
+export interface UploadedAsset {
+  id: string;
+  blobUrl: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  checksum?: string;
+  createdAt: string;
+  needsEmbedding: boolean;
+}
+
+export interface SaveResponse {
+  success: boolean;
+  isDuplicate: boolean;
+  asset: UploadedAsset;
+  message: string;
+}
+
+export interface SearchResultItem {
+  id: string;
+  blobUrl: string;
+  filename: string;
+  mime: string;
+  favorite: boolean;
+  similarity: number;
+  relevance: number;
+  tags: AssetTag[];
+}
+
+export interface SearchResponse {
+  results: SearchResultItem[];
+  query: string;
+  total: number;
+  limit: number;
+  threshold: number;
+  processingTime: number;
+}
+
+export class SplootApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown
+  ) {
+    super(message);
+    this.name = 'SplootApiError';
+  }
+}
+
+type FetchLike = typeof fetch;
+
+export class SplootClient {
+  constructor(
+    private readonly config: SplootConfig,
+    private readonly fetchImpl: FetchLike = fetch
+  ) {}
+
+  async search(
+    query: string,
+    options: { limit?: number; threshold?: number } = {}
+  ): Promise<SearchResponse> {
+    return this.postJson<SearchResponse>('/search', { query, ...options });
+  }
+
+  async saveUrl(url: string): Promise<SaveResponse> {
+    return this.postJson<SaveResponse>('/upload/url', { url });
+  }
+
+  async saveBytes(
+    bytes: Uint8Array,
+    filename: string,
+    mimeType: string,
+    tags?: string[]
+  ): Promise<SaveResponse> {
+    const form = new FormData();
+    form.append('file', new Blob([bytes], { type: mimeType }), filename);
+    if (tags && tags.length > 0) {
+      form.append('tags', JSON.stringify(tags));
+    }
+    return this.postForm<SaveResponse>('/upload', form);
+  }
+
+  private async postJson<T>(path: string, body: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.config.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.token}`,
+      },
+      body: JSON.stringify(body),
+    });
+    return this.parse<T>(res);
+  }
+
+  private async postForm<T>(path: string, form: FormData): Promise<T> {
+    const res = await this.fetchImpl(`${this.config.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.config.token}`,
+      },
+      body: form,
+    });
+    return this.parse<T>(res);
+  }
+
+  private async parse<T>(res: Response): Promise<T> {
+    const body: unknown = await res.json().catch(() => undefined);
+
+    // 409 is a documented "duplicate" success shape (success: true), not an
+    // error — every other non-2xx status is.
+    if (!res.ok && res.status !== 409) {
+      const message =
+        body && typeof body === 'object' && 'error' in body
+          ? String((body as { error: unknown }).error)
+          : `Sploot API error (${res.status})`;
+      throw new SplootApiError(message, res.status, body);
+    }
+
+    return body as T;
+  }
+}

--- a/apps/mcp/src/config.ts
+++ b/apps/mcp/src/config.ts
@@ -1,0 +1,38 @@
+/**
+ * Environment config for the sploot MCP server. A thin reader — no
+ * validation logic beyond "is a token present" lives here; the client owns
+ * everything about how the token is used.
+ */
+
+export interface SplootConfig {
+  /** Sploot API base URL, no trailing slash, e.g. https://www.sploot.app/api */
+  baseUrl: string;
+  /** Personal API token (`splt_…`) — see apps/web/docs/PUBLIC_API.md. */
+  token: string;
+}
+
+export const DEFAULT_BASE_URL = 'https://www.sploot.app/api';
+
+export class MissingTokenError extends Error {
+  constructor() {
+    super(
+      'SPLOOT_API_TOKEN is required. Mint a personal API token in Sploot ' +
+        '(Settings → Upload tokens or POST /api/upload-tokens with a ' +
+        'signed-in session), then set SPLOOT_API_TOKEN in the environment ' +
+        'running this MCP server. See apps/web/docs/PUBLIC_API.md.'
+    );
+    this.name = 'MissingTokenError';
+  }
+}
+
+export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): SplootConfig {
+  const token = env.SPLOOT_API_TOKEN?.trim();
+  if (!token) {
+    throw new MissingTokenError();
+  }
+
+  const rawBaseUrl = env.SPLOOT_API_BASE_URL?.trim() || DEFAULT_BASE_URL;
+  const baseUrl = rawBaseUrl.replace(/\/+$/, '');
+
+  return { baseUrl, token };
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { loadConfigFromEnv } from './config.js';
+import { SplootClient } from './client.js';
+import { runSaveTool, runSearchTool } from './tools.js';
+
+const SERVER_NAME = 'sploot';
+const SERVER_VERSION = '0.1.0';
+
+function buildServer(client: SplootClient): McpServer {
+  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+
+  server.registerTool(
+    'sploot_search',
+    {
+      title: 'Search Sploot',
+      description:
+        'Semantic text-to-image search over the personal Sploot meme library. ' +
+        'Describe what is in the image in plain words (e.g. "distracted ' +
+        'boyfriend reaction", "cat looking judgmental") — this is not a tag ' +
+        'or filename lookup.',
+      inputSchema: {
+        query: z.string().min(1).max(500).describe('Plain-words description of the meme to find.'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Maximum number of results to return (default 30).'),
+        threshold: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe('Minimum similarity score 0-1 (default 0.2). Real misses return zero results, never low-similarity padding.'),
+      },
+    },
+    async args => runSearchTool(client, args)
+  );
+
+  server.registerTool(
+    'sploot_save',
+    {
+      title: 'Save to Sploot',
+      description:
+        'Save an image to the personal Sploot meme library, either by URL ' +
+        '(Sploot fetches it server-side) or by raw base64-encoded bytes ' +
+        '(when there is no fetchable URL). Duplicates are detected and ' +
+        'reported, not re-saved.',
+      inputSchema: {
+        url: z.string().url().optional().describe('Public URL of the image to fetch and save.'),
+        bytesBase64: z
+          .string()
+          .optional()
+          .describe('Base64-encoded image bytes. Provide this or url, not both.'),
+        filename: z
+          .string()
+          .optional()
+          .describe('Filename to record when saving by bytes (default "upload.png").'),
+        mimeType: z
+          .string()
+          .optional()
+          .describe('MIME type to record when saving by bytes (default "image/png").'),
+        tags: z.array(z.string()).optional().describe('Tag names to attach to the saved asset.'),
+      },
+    },
+    async args => runSaveTool(client, args)
+  );
+
+  return server;
+}
+
+async function main(): Promise<void> {
+  const config = loadConfigFromEnv();
+  const client = new SplootClient(config);
+  const server = buildServer(client);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(error => {
+  console.error('sploot-mcp failed to start:', error);
+  process.exitCode = 1;
+});

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1,0 +1,90 @@
+import { SplootApiError, type SplootClient } from './client.js';
+
+/**
+ * Tool handlers, factored out of index.ts so they can be unit-tested without
+ * standing up a real MCP stdio transport. Each returns the MCP
+ * CallToolResult content shape directly.
+ */
+
+export interface McpToolTextResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+  // The SDK's CallToolResult carries an index signature for forward
+  // compatibility (e.g. structuredContent, _meta) — mirror it here so this
+  // return type stays assignable to server.registerTool's handler contract.
+  [key: string]: unknown;
+}
+
+export interface SearchToolArgs {
+  query: string;
+  limit?: number;
+  threshold?: number;
+}
+
+export interface SaveToolArgs {
+  url?: string;
+  bytesBase64?: string;
+  filename?: string;
+  mimeType?: string;
+  tags?: string[];
+}
+
+const DEFAULT_SAVE_FILENAME = 'upload.png';
+const DEFAULT_SAVE_MIME_TYPE = 'image/png';
+
+export function errorResult(error: unknown): McpToolTextResult {
+  const text =
+    error instanceof SplootApiError
+      ? `Sploot API error (${error.status}): ${error.message}`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+function jsonResult(value: unknown): McpToolTextResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+export async function runSearchTool(
+  client: SplootClient,
+  args: SearchToolArgs
+): Promise<McpToolTextResult> {
+  try {
+    const result = await client.search(args.query, {
+      limit: args.limit,
+      threshold: args.threshold,
+    });
+    return jsonResult(result);
+  } catch (error) {
+    return errorResult(error);
+  }
+}
+
+export async function runSaveTool(
+  client: SplootClient,
+  args: SaveToolArgs
+): Promise<McpToolTextResult> {
+  try {
+    if (!args.url && !args.bytesBase64) {
+      throw new Error('Provide either "url" or "bytesBase64" to save an image.');
+    }
+    if (args.url && args.bytesBase64) {
+      throw new Error('Provide only one of "url" or "bytesBase64", not both.');
+    }
+
+    const result = args.url
+      ? await client.saveUrl(args.url)
+      : await client.saveBytes(
+          Buffer.from(args.bytesBase64 as string, 'base64'),
+          args.filename ?? DEFAULT_SAVE_FILENAME,
+          args.mimeType ?? DEFAULT_SAVE_MIME_TYPE,
+          args.tags
+        );
+
+    return jsonResult(result);
+  } catch (error) {
+    return errorResult(error);
+  }
+}

--- a/apps/mcp/tsconfig.build.json
+++ b/apps/mcp/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/__tests__/**"]
+}

--- a/apps/mcp/tsconfig.json
+++ b/apps/mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "declaration": false,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/__tests__/api/embedding-runtime-gates.test.ts
+++ b/apps/web/__tests__/api/embedding-runtime-gates.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server';
 const mocks = vi.hoisted(() => ({
   getAuth: vi.fn(),
   getAuthWithUser: vi.fn(),
+  authenticatedUserId: 'user-1',
   createEmbeddingService: vi.fn(),
   getSearchResults: vi.fn(),
   setSearchResults: vi.fn(),
@@ -17,6 +18,25 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/lib/auth/server', () => ({
   getAuth: mocks.getAuth,
   getAuthWithUser: mocks.getAuthWithUser,
+}));
+
+// POST /api/search resolves auth through withAuthenticatedApi (sploot-071);
+// getAuthWithUser above still covers /api/embeddings/text and
+// /api/embeddings/image, which stayed on the legacy door.
+vi.mock('@/lib/auth/with-authenticated-api', () => ({
+  withAuthenticatedApi: (handler: any) => async (req: any, context: any = {}) => {
+    if (!mocks.authenticatedUserId) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return handler(req, context, {
+      principal: { userId: mocks.authenticatedUserId },
+      auth: { status: 'authenticated' },
+    });
+  },
 }));
 
 vi.mock('@/lib/embeddings', () => ({
@@ -76,6 +96,7 @@ describe('embedding runtime gates', () => {
     vi.stubEnv('SPLOOT_EMBEDDINGS_ENABLED', 'false');
     mocks.getAuth.mockResolvedValue({ userId: 'user-1' });
     mocks.getAuthWithUser.mockResolvedValue({ userId: 'user-1' });
+    mocks.authenticatedUserId = 'user-1';
     mocks.getSearchResults.mockResolvedValue(null);
     mocks.findFirst.mockResolvedValue({ id: 'asset-1' });
   });
@@ -109,6 +130,7 @@ describe('search degraded-service honesty', () => {
     vi.stubEnv('SPLOOT_EMBEDDINGS_ENABLED', 'true');
     mocks.getAuth.mockResolvedValue({ userId: 'user-1' });
     mocks.getAuthWithUser.mockResolvedValue({ userId: 'user-1' });
+    mocks.authenticatedUserId = 'user-1';
     mocks.getSearchResults.mockResolvedValue(null);
     mocks.logSearch.mockResolvedValue(undefined);
   });

--- a/apps/web/__tests__/api/search-cached-query.test.ts
+++ b/apps/web/__tests__/api/search-cached-query.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 const mocks = vi.hoisted(() => ({
-  getAuthWithUser: vi.fn(),
+  authenticatedUserId: 'qa-design-user',
   createEmbeddingService: vi.fn(),
   getSearchResults: vi.fn(),
   setSearchResults: vi.fn(),
@@ -12,8 +12,24 @@ const mocks = vi.hoisted(() => ({
   logSearch: vi.fn(),
 }));
 
-vi.mock('@/lib/auth/server', () => ({
-  getAuthWithUser: mocks.getAuthWithUser,
+// POST /api/search now resolves auth through withAuthenticatedApi (sploot-071:
+// opted into allowUploadToken so a personal API token can drive search), not
+// getAuthWithUser directly — see search-upload-token-opt-in.test.ts for the
+// wiring proof.
+vi.mock('@/lib/auth/with-authenticated-api', () => ({
+  withAuthenticatedApi: (handler: any) => async (req: any, context: any = {}) => {
+    if (!mocks.authenticatedUserId) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return handler(req, context, {
+      principal: { userId: mocks.authenticatedUserId },
+      auth: { status: 'authenticated' },
+    });
+  },
 }));
 
 vi.mock('@/lib/embeddings', () => ({
@@ -61,7 +77,7 @@ function searchRequest(body: unknown): NextRequest {
 describe('/api/search with a cached query embedding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getAuthWithUser.mockResolvedValue({ userId: 'qa-design-user' });
+    mocks.authenticatedUserId = 'qa-design-user';
     mocks.getSearchResults.mockResolvedValue(null);
     mocks.setSearchResults.mockResolvedValue(undefined);
     mocks.findManyAssetTags.mockResolvedValue([]);

--- a/apps/web/__tests__/api/search-upload-token-opt-in.test.ts
+++ b/apps/web/__tests__/api/search-upload-token-opt-in.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * Wiring proof: POST /api/search must opt into upload-token auth so a
+ * personal API token can drive the read-side of the token-scoped external
+ * contract (sploot-071), not just the upload-only routes. The resolver-level
+ * scope test (upload-token-scope.test.ts) proves the gate; this proves the
+ * route passes allowUploadToken: true through it, mirroring
+ * upload-token-opt-in.test.ts for /api/upload.
+ */
+
+const mocks = vi.hoisted(() => ({
+  authenticateRequest: vi.fn(),
+  createEmbeddingService: vi.fn(),
+  getSearchResults: vi.fn(),
+  setSearchResults: vi.fn(),
+  getTextEmbedding: vi.fn(),
+  findManyAssetTags: vi.fn(),
+  vectorSearch: vi.fn(),
+  logSearch: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ unstable_rethrow: vi.fn() }));
+vi.mock('@/lib/auth/request-auth', () => ({ authenticateRequest: mocks.authenticateRequest }));
+
+vi.mock('@/lib/embeddings', () => ({
+  CLIP_MODEL: 'test/clip:model',
+  createEmbeddingService: mocks.createEmbeddingService,
+  EmbeddingError: class EmbeddingError extends Error {
+    constructor(message: string, public statusCode?: number) {
+      super(message);
+    }
+  },
+}));
+
+vi.mock('@/lib/cache', () => ({
+  getCacheService: () => ({
+    getSearchResults: mocks.getSearchResults,
+    setSearchResults: mocks.setSearchResults,
+    getTextEmbedding: mocks.getTextEmbedding,
+  }),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    assetTag: {
+      findMany: mocks.findManyAssetTags,
+    },
+  },
+  vectorSearch: mocks.vectorSearch,
+  logSearch: mocks.logSearch,
+}));
+
+vi.mock('@/lib/with-observability', () => ({
+  withObservability: (handler: any) => handler,
+}));
+
+import { POST as search } from '@/app/api/search/route';
+
+function searchRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/search', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSearchResults.mockResolvedValue(null);
+  mocks.setSearchResults.mockResolvedValue(undefined);
+  mocks.findManyAssetTags.mockResolvedValue([]);
+  mocks.logSearch.mockResolvedValue(undefined);
+  mocks.getTextEmbedding.mockResolvedValue(new Array(512).fill(0).map((_, i) => (i === 3 ? 1 : 0)));
+  mocks.vectorSearch.mockResolvedValue([]);
+});
+
+describe('POST /api/search opts into upload-token auth', () => {
+  it('calls authenticateRequest with { allowUploadToken: true }', async () => {
+    mocks.authenticateRequest.mockResolvedValue({
+      status: 'authenticated',
+      principal: { userId: 'user-token-1' },
+      syncStatus: 'skipped',
+    });
+
+    const res = await search(searchRequest({ query: 'reaction face meme' }), {} as any);
+
+    expect(res.status).toBe(200);
+    expect(mocks.authenticateRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ allowUploadToken: true })
+    );
+    expect(mocks.vectorSearch).toHaveBeenCalledWith(
+      'user-token-1',
+      expect.any(Array),
+      expect.objectContaining({ limit: 30 })
+    );
+  });
+
+  it('returns the stable 401 contract when the token is rejected', async () => {
+    mocks.authenticateRequest.mockResolvedValue({
+      status: 'unauthenticated',
+      reason: 'upload-token-invalid',
+    });
+
+    const res = await search(searchRequest({ query: 'reaction face meme' }), {} as any);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(mocks.vectorSearch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -4,11 +4,15 @@ import { prisma, vectorSearch, logSearch, type VectorSearchRow } from '@/lib/db'
 import { CLIP_MODEL, createEmbeddingService, EmbeddingError } from '@/lib/embeddings';
 import { getCacheService } from '@/lib/cache';
 import { getAuthWithUser } from '@/lib/auth/server';
+import { withAuthenticatedApi } from '@/lib/auth/with-authenticated-api';
 import { withObservability } from '@/lib/with-observability';
 import { getRuntimeGate, runtimeGateResponse } from '@/lib/runtime-gates';
 import { SEARCH_SIMILARITY_FLOOR } from '@/lib/search-config';
 
-async function postHandler(req: NextRequest) {
+// POST opts into upload-token auth (allowUploadToken: true) so a personal API
+// token can drive search — the read half of the token-scoped external
+// contract in apps/web/docs/PUBLIC_API.md. See sploot-071.
+const postHandler = withAuthenticatedApi(async (req: NextRequest, _context, { principal }) => {
   const startTime = Date.now();
   let query: string = '';
   let limit: number = 30;
@@ -16,13 +20,7 @@ async function postHandler(req: NextRequest) {
   let shuffleSeed: number | undefined = undefined;
 
   try {
-    const { userId } = await getAuthWithUser();
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+    const userId = principal.userId;
 
     const body = await req.json();
     ({ query, limit = 30, threshold = SEARCH_SIMILARITY_FLOOR, shuffleSeed } = body);
@@ -215,7 +213,7 @@ async function postHandler(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+}, { allowUploadToken: true });
 
 export const POST = withObservability(postHandler, { operation: 'search:query' });
 

--- a/apps/web/docs/API.md
+++ b/apps/web/docs/API.md
@@ -19,10 +19,13 @@ User-facing product APIs require authentication through Sploot's auth boundary.
 Production requests are still Clerk-backed. Local and CI authenticated smoke
 tests may use the signed `qa-local` mode documented in `apps/web/docs/AUTH.md`.
 Operational routes such as health and cron endpoints define their own auth
-contracts. The upload routes (`/api/upload`, `/api/upload/url`) additionally
-accept a personal **upload token** (`Authorization: Bearer splt_…`) for
-non-session clients like the iPhone shortcut — see [Personal Upload
-Tokens](#personal-upload-tokens) below.
+contracts. The upload routes (`/api/upload`, `/api/upload/url`) and the search
+route (`/api/search`) additionally accept a personal **API token**
+(`Authorization: Bearer splt_…`) for non-session clients like the iPhone
+shortcut, the sploot MCP server, and other agents — see [Personal Upload
+Tokens](#personal-upload-tokens) below for minting/managing tokens, and
+**[`PUBLIC_API.md`](./PUBLIC_API.md) for the published, token-scoped external
+contract** (save + search) this section's internal detail feeds.
 
 ### Auth Boundary
 
@@ -281,9 +284,11 @@ If the user has too few ready embedded assets:
 
 ### Personal Upload Tokens
 
-Hashed, revocable, **upload-only** credentials for non-session clients (the
-iPhone "Save to Sploot" shortcut, CLIs, automation). See
-`apps/web/docs/shortcuts/save-to-sploot.md` for the end-user recipe and
+Hashed, revocable credentials for non-session clients (the iPhone "Save to
+Sploot" shortcut, the sploot MCP server, other agents/automation), scoped to
+**save + search** — never asset reads/deletes or token management. See
+`apps/web/docs/shortcuts/save-to-sploot.md` for the end-user recipe,
+`apps/web/docs/PUBLIC_API.md` for the published external contract, and
 `apps/web/docs/AUTH.md` for the auth model.
 
 These management endpoints are **session-authenticated** (Clerk/qa-local). An
@@ -332,9 +337,10 @@ curl -X POST https://www.sploot.app/api/upload \
   -F "file=@meme.png"
 ```
 
-`/api/upload` and `/api/upload/url` accept upload tokens; every other route
-returns `401` for one. Dedupe, quota, and the `201`/`409` contracts are
-identical to a session upload.
+`/api/upload`, `/api/upload/url`, and `/api/search` accept a personal API
+token; every other route returns `401` for one. Dedupe, quota, and the
+`201`/`409` contracts are identical to a session upload. See
+[`PUBLIC_API.md`](./PUBLIC_API.md) for the full token-scoped contract.
 
 ---
 

--- a/apps/web/docs/AUTH.md
+++ b/apps/web/docs/AUTH.md
@@ -10,7 +10,7 @@ request APIs directly.
 |---|---|---|---|
 | `clerk` | default | Clerk cookies or Clerk session bearer token | local, preview, production |
 | `qa-local` | `SPLOOT_QA_AUTH_MODE=enabled` plus `SPLOOT_QA_AUTH_SECRET` | signed Sploot QA token | local and CI only |
-| `upload-token` | always available | hashed personal upload token (`Authorization: Bearer splt_…`) | **upload routes only** (`/api/upload`, `/api/upload/url`) |
+| `upload-token` | always available | hashed personal API token (`Authorization: Bearer splt_…`) | **opt-in routes only**: save (`/api/upload`, `/api/upload/url`) + search (`/api/search`) |
 
 `qa-local` is rejected when `NODE_ENV=production` or `VERCEL_ENV=production`,
 even if the mode and secret are present.
@@ -31,20 +31,26 @@ The smoke starts a local Next server with `qa-local` enabled and opens `/app`
 with a signed deterministic principal. Passing the smoke proves the app auth
 boundary can be crossed without manual Clerk login.
 
-## Upload Tokens
+## Upload Tokens (personal API tokens)
 
-Personal upload tokens let a non-session client (the iPhone "Save to Sploot"
-shortcut, a CLI, automation) authenticate **upload-only** API calls. They exist
-because Apple Shortcuts cannot carry a Clerk session.
+Personal API tokens (still called "upload tokens" in the code/table names —
+`upload_tokens`, `/api/upload-tokens` — for continuity with sploot-033) let a
+non-session client (the iPhone "Save to Sploot" shortcut, the sploot MCP
+server, other agents/automation) authenticate save + search API calls without
+a Clerk session.
 
 - Format: `splt_` + 32 random bytes (base64url). Only `sha256(token)` is stored
   (`upload_tokens` table); the plaintext is returned once at mint and never
   again.
 - Scope is enforced by policy, not by a scope field: `authenticateRequest`
   checks an upload token only when a route passes `allowUploadToken: true`.
-  Just the two upload routes opt in, so a token presented anywhere else returns
-  the stable `401`. The `lib/auth/server.ts` auth path (`getAuth*`, used by
-  read/delete routes) never calls the verifier at all.
+  Three routes opt in — the two upload routes plus `POST /api/search`
+  (sploot-071) — so a token presented anywhere else returns the stable `401`.
+  The `lib/auth/server.ts` auth path (`getAuth*`, used by most read/delete
+  routes) never calls the verifier at all; `POST /api/search` itself moved off
+  that path onto `withAuthenticatedApi` to make the opt-in possible (partial,
+  route-scoped step toward the full migration tracked in
+  `backlog.d/035-unify-auth-doors-on-policy-boundary.md`).
 - Verification is throw-safe: a DB error (including a not-yet-migrated table)
   resolves to `401`, never `500`. Revoked and unknown tokens are
   indistinguishable.

--- a/apps/web/docs/PUBLIC_API.md
+++ b/apps/web/docs/PUBLIC_API.md
@@ -1,0 +1,190 @@
+# Sploot Public API (Personal API Token)
+
+This is the **published, token-scoped external API contract** — the surface
+Sploot supports for programmatic clients that are not a browser holding a
+Clerk session: agents, automations, the iPhone "Save to Sploot" shortcut, and
+the [sploot MCP server](../../mcp/README.md). If you are building an
+integration against Sploot, start here, not `API.md` (which documents the
+full session-authenticated product surface consumed by the web app and
+extension).
+
+## Auth: personal API token
+
+Every call in this doc authenticates with a **personal API token** —
+`Authorization: Bearer splt_…`. Mint one from a signed-in session:
+**Settings → Upload tokens** in the web app, or `POST /api/upload-tokens`
+(session-authenticated; see `API.md#personal-upload-tokens`). The plaintext
+token is shown exactly once at mint time; only its hash is ever stored.
+
+- Format: `splt_` + 32 random bytes, base64url-encoded.
+- Hashed at rest (`sha256`); revoked and unknown tokens are indistinguishable
+  (no timing or error-message tell).
+- Not a session cookie: it has no CSRF exposure and never expires on its own —
+  revoke it from Settings when it's no longer needed.
+
+### Scope: what a token can call today
+
+Scope is enforced **per route by an explicit opt-in policy**
+(`allowUploadToken`), not by a scope field baked into the token — every route
+either accepts a token or it doesn't, and the default is closed. As of this
+contract, three routes opt in, covering the product's two core agent-facing
+verbs, **save** and **search**:
+
+| Verb | Route | Notes |
+|---|---|---|
+| Save (bytes) | `POST /api/upload` | multipart form upload |
+| Save (URL) | `POST /api/upload/url` | server fetches and ingests a remote image |
+| Search | `POST /api/search` | semantic text→image search |
+
+Every other route (`/api/assets`, `/api/tags`, `/api/stats`, token
+management, …) is Clerk/qa-local session-only and returns the stable
+`401 {"error":"Unauthorized"}` for a token, by design — a personal API token
+cannot read your full library, delete anything, or manage other tokens. See
+`AUTH.md` for the auth-door architecture this is built on.
+
+## Base URL
+
+```
+Production: https://www.sploot.app/api
+Development: http://localhost:3001/api
+```
+
+## Save — upload bytes
+
+`POST /api/upload` · `multipart/form-data`
+
+Accepted media types: JPEG, PNG, WebP, GIF, MP4, WebM.
+
+**Form fields:**
+
+- `file` (required) — the image/video bytes.
+- `tags` (optional) — JSON array of tag name strings.
+
+**`201` (created):**
+
+```json
+{
+  "success": true,
+  "isDuplicate": false,
+  "asset": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "blobUrl": "https://blob.vercel-storage.com/abc123/funny-meme.jpg",
+    "filename": "funny-meme.jpg",
+    "mimeType": "image/jpeg",
+    "size": 2048576,
+    "checksum": "sha256:abc123...",
+    "createdAt": "2026-07-07T12:00:00.000Z",
+    "needsEmbedding": true
+  },
+  "message": "Upload successful"
+}
+```
+
+**`409` (duplicate):** same shape with `isDuplicate: true` and
+`needsEmbedding: false`.
+
+**Errors:** `400` missing/invalid file · `401` bad or missing token ·
+`403 {"code":"quota_exceeded"}` storage quota exceeded · `413` file too large ·
+`429` rate limited · `503 {"code":"uploads_disabled"}` uploads paused.
+
+```bash
+curl -X POST https://www.sploot.app/api/upload \
+  -H "Authorization: Bearer splt_…" \
+  -F "file=@meme.png"
+```
+
+## Save — upload by URL
+
+`POST /api/upload/url` · `application/json`
+
+Fetches a remote image server-side and ingests it through the same
+dedupe/quota pipeline as bytes upload.
+
+**Request:**
+
+```json
+{ "url": "https://example.com/meme.png" }
+```
+
+**Response contract:** identical `201`/`409` asset shape as bytes upload above.
+
+**Errors:** `400` missing/invalid/private URL · `401` bad or missing token ·
+`422` remote fetch failed or was not an image · `403` quota exceeded ·
+`503` uploads paused.
+
+```bash
+curl -X POST https://www.sploot.app/api/upload/url \
+  -H "Authorization: Bearer splt_…" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/meme.png"}'
+```
+
+## Search
+
+`POST /api/search` · `application/json`
+
+Semantic text→image search over the token owner's library (CLIP/SigLIP
+embeddings, pgvector cosine similarity). Same route and response contract the
+web app itself calls.
+
+**Request:**
+
+```json
+{ "query": "distracted boyfriend", "limit": 30, "threshold": 0.2 }
+```
+
+- `query` (string, required, max 500 chars)
+- `limit` (number, optional, default 30)
+- `threshold` (number, optional, 0–1, default 0.2) — results below this
+  similarity are not returned; a real miss is an empty `results` array, never
+  low-similarity padding.
+
+**`200`:**
+
+```json
+{
+  "results": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "blobUrl": "https://blob.vercel-storage.com/abc123/funny-meme.jpg",
+      "filename": "funny-meme.jpg",
+      "mime": "image/jpeg",
+      "favorite": false,
+      "similarity": 0.95,
+      "relevance": 95,
+      "tags": []
+    }
+  ],
+  "query": "distracted boyfriend",
+  "total": 1,
+  "limit": 30,
+  "threshold": 0.2,
+  "processingTime": 245
+}
+```
+
+**Errors:** `400` missing/invalid/too-long query · `401` bad or missing token
+· `503` embedding service unavailable (Replicate not configured or paused).
+
+```bash
+curl -X POST https://www.sploot.app/api/search \
+  -H "Authorization: Bearer splt_…" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"distracted boyfriend"}'
+```
+
+## Rate limits
+
+- Upload endpoints: 10 requests/minute
+- Search endpoint: 30 requests/minute
+
+Full error-code table: `API.md#error-codes`.
+
+## Changelog
+
+- **2026-07-07 (sploot-071):** `POST /api/search` opted into personal API
+  token auth (previously the token was upload-only). This file published as
+  the token-scoped external contract; superseded the implicit "ask the
+  iPhone-shortcut doc" status quo. Consumers: the sploot MCP server
+  (`apps/mcp`), the `misty-sploot` agent skill.
+- **2026-06-18 (sploot-033/035):** Personal upload tokens shipped, upload-only.

--- a/docs/five-faces.md
+++ b/docs/five-faces.md
@@ -1,0 +1,46 @@
+# Five Faces — Sploot
+
+Status ledger for the Misty Step application-floor "five faces" doctrine
+(one core, every face: **API + CLI + MCP server + shipped skill + UI**, SDK
+where external consumers exist; a face counts only if it covers the core
+verbs — **save** and **search** — not partial credit). Updated with each
+face-completing change; treat a stale entry here as a bug.
+
+| Face | Status | Evidence |
+|---|---|---|
+| **UI** | ✅ Shipped | `apps/web` (Next.js app: `/app` grid, search, upload) + `apps/extension` (Chrome right-click save) + PWA share target. Pre-existing, strongest face. |
+| **API** | ✅ Shipped, published 2026-07-07 | `apps/web/docs/API.md` (full session-authenticated surface) + **`apps/web/docs/PUBLIC_API.md`** (the published, token-scoped external contract: save bytes, save by URL, search — sploot-071). Previously existed only as an internal dev doc with no token-scoped external surface named. |
+| **MCP** | ✅ Shipped 2026-07-07 | `apps/mcp` (`@sploot/mcp`, bin `sploot-mcp`): `sploot_search` + `sploot_save` tools over `PUBLIC_API.md`. Covers both core verbs — capture (save) and retrieval (search) — not a read-only partial. Live-instance evidence: sploot-071 completion proof. |
+| **Skill** | ✅ Shipped 2026-07-07 | `.agents/skills/misty-sploot/SKILL.md` — teaches the two verbs, setup, and failure modes; rides with the MCP server. |
+| **CLI** | **Waived** (see below) | No standalone `sploot` CLI binary. |
+
+## CLI waiver
+
+**Waived, not shipped**, as of 2026-07-07 (sploot-071). Rationale:
+
+- The floor's CLI intent is a scriptable, agent/operator-reachable
+  programmatic surface over the core verbs. For Sploot specifically, the
+  **MCP server already is that surface** for the audience that actually
+  exists today (the operator's agent fleet) — it is stdio-invokable,
+  scriptable, and requires no interactive terminal UX a human CLI would
+  additionally need to earn (arg parsing, `--help`, output formatting,
+  config file discovery).
+- The **documented `curl` recipes in `PUBLIC_API.md`** cover the
+  script-from-a-terminal case a human would reach a CLI for (mint a token,
+  `curl -F file=@meme.png`, `curl -d '{"query":"…"}'`) — a bespoke CLI binary
+  would be a thin wrapper around the same three HTTP calls the MCP server
+  already wraps, with no distinct consumer.
+- No named consumer wants a `sploot` binary specifically (vs. the MCP tool
+  or a curl one-liner) today. If one shows up — e.g. a shell-scripting
+  workflow that wants `sploot search "…"` / `sploot save file.png` without an
+  MCP-capable harness in the loop — that is grounds to revisit this waiver
+  with a real ticket, not a silent gap.
+
+**Revisit trigger:** a concrete user/workflow that needs Sploot from a shell
+without an MCP-capable agent harness present.
+
+## Changelog
+
+- **2026-07-07 (sploot-071):** API published as a real external contract;
+  MCP + skill shipped; CLI waiver recorded. Closes the "no implicit gaps"
+  requirement — every face above has an explicit status, not silence.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,28 @@ importers:
         specifier: ^0.20.26
         version: 0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.2)(rollup@4.60.4)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
+  apps/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.2.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+
   apps/web:
     dependencies:
       '@clerk/backend':
@@ -3231,6 +3253,9 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
@@ -11831,6 +11856,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
@@ -12107,6 +12136,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -12774,7 +12811,7 @@ snapshots:
 
   chrome-launcher@1.2.0:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 20.19.41
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -17292,6 +17329,22 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
+  vite@8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.20.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.48.0
+      tsx: 4.22.3
+      yaml: 2.9.0
+
   vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -17333,6 +17386,37 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.41
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+      '@vitest/ui': 4.1.7(vitest@4.1.7)
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.20.0
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
       '@vitest/ui': 4.1.7(vitest@4.1.7)
       jsdom: 29.1.1(@noble/hashes@1.8.0)


### PR DESCRIPTION
## Summary

Closes the five-faces gaps named in sploot-071 (Powder):

- **API**: `POST /api/search` opts into personal-API-token auth (`allowUploadToken: true` via `withAuthenticatedApi`), so a token can drive save *and* search — previously upload-only. `apps/web/docs/PUBLIC_API.md` publishes the token-scoped external contract (save bytes, save by URL, search).
- **MCP**: `apps/mcp` (`@sploot/mcp`, bin `sploot-mcp`) exposes `sploot_search` + `sploot_save` as agent tools over that contract — thin HTTP client, no duplicated business logic.
- **Skill**: `.agents/skills/misty-sploot/SKILL.md` teaches the two verbs, setup, and failure modes.
- **CLI**: explicitly waived with rationale in `docs/five-faces.md` (MCP + documented curl recipes already cover the audience; revisit trigger named).
- `docs/five-faces.md`: per-face status ledger so the five-faces status is written down with no implicit gaps.

## Test plan

- [x] New failing test first (`search-upload-token-opt-in.test.ts`), then the route migration, then green — TDD on the auth change.
- [x] Updated two existing search tests (`search-cached-query.test.ts`, `embedding-runtime-gates.test.ts`) whose mocks targeted the old auth path.
- [x] `pnpm lint && pnpm type-check && pnpm lint:design && pnpm --filter web test && pnpm --filter extension build` — all green (1067 web tests passed).
- [x] `apps/mcp` unit tests (18, vitest, mocked fetch/client) + `type-check` + `build` green.
- [x] **Live-instance proof**: booted `pnpm dev:local` (qa-local auth + seeded pgvector), minted a real personal API token via the session-authenticated `/api/upload-tokens`, then drove the **built** `sploot-mcp` binary over stdio with the real MCP SDK client — `tools/list` returned both tools; `sploot_search({query:"reaction face meme"})` returned 4 real seeded assets; `sploot_save` created two real assets (base64 bytes, and by URL) with real Vercel Blob writes. MCP tool calls only, no direct HTTP.
- [ ] Residual: same-asset round-trip (save X, then find X by description) blocked locally by the Vercel-KV-backed embedding rate limiter being unavailable in this dev environment (`kv_unavailable`) — an existing local-infra gap unrelated to this change, not a defect in the new auth/MCP code. Save and search were each proven independently against the live local instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)