### PR TITLE
docs(extension): document Chrome Web Store publish/update path (sploot-052)

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -59,6 +59,33 @@ pnpm build:prod:unpacked
 3. Click **Load Unpacked**.
 4. Select `apps/extension/dist/chrome-mv3`.
 
+## 🛒 Publishing to the Chrome Web Store
+
+The extension ships as a **live public listing**:
+**https://chromewebstore.google.com/detail/sploot/fbhkflbcnllfogefckablkafjknmcfnd**
+(also linked from the repo README and the sploot.app footer). A stranger with
+no repo access installs it straight from that URL — no sideloading required.
+
+To publish an **update**:
+
+1. **Bump the version** — set the new `version` in `wxt.config.ts` (the manifest
+   source of truth); Chrome rejects an upload whose version is not strictly
+   higher than the published one.
+2. **Validate the release** — `pnpm --filter extension release:check`
+   (`scripts/validate-store-release.mjs`) verifies the manifest, icons, and
+   production config before you build.
+3. **Build the store zip** — `pnpm --filter extension zip:prod` — produces the
+   production-config `.zip` under `apps/extension/.output/`.
+4. **Upload** the zip to the existing item in the
+   [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+   and submit for review. (Store credentials live with the operator's Google
+   account; there is no CI-automated publish today — this is a deliberate
+   manual gate.)
+5. **Verify** the listing URL still resolves and the new version is live before
+   closing the release.
+
+Firefox has a parallel `zip:firefox` target for a future AMO listing.
+
 ## 🏗️ Architecture
 
 - **Background Script**: Handles context menu clicks and auth token management.


### PR DESCRIPTION
Closes the last open criterion of sploot-052 ("update/release path documented"). The extension is **already published and live** on the Chrome Web Store (v1.0.0, honest copy, linked from README + landing); this documents the update path using the release tooling that already exists (`release:check`, `zip:prod`). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)