### PR TITLE
ci(design): enforce lint:design as a required merge-gate step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,23 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo run type-check
 
+  design:
+    name: Design
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Enforces DESIGN.md / design-contract.md (the aesthetic ratchet): fails
+      # the diff on reintroduced banned patterns (e.g. violet-on-black
+      # gradient, backdrop-blur on the auth door) rather than staying
+      # advisory-only. See scripts/check-design-system.mjs.
+      - run: pnpm lint:design
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -132,15 +149,15 @@ jobs:
   merge-gate:
     name: merge-gate
     if: always()
-    needs: [secrets, lint, type-check, test, extension]
+    needs: [secrets, lint, type-check, design, test, extension]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs
         run: |
-          results=("${{ needs.secrets.result }}" "${{ needs.lint.result }}" "${{ needs.type-check.result }}" "${{ needs.test.result }}" "${{ needs.extension.result }}")
+          results=("${{ needs.secrets.result }}" "${{ needs.lint.result }}" "${{ needs.type-check.result }}" "${{ needs.design.result }}" "${{ needs.test.result }}" "${{ needs.extension.result }}")
           for r in "${results[@]}"; do
             if [[ "$r" != "success" ]]; then
-              echo "One or more jobs failed: secrets=${{ needs.secrets.result }} lint=${{ needs.lint.result }} type-check=${{ needs.type-check.result }} test=${{ needs.test.result }} extension=${{ needs.extension.result }}"
+              echo "One or more jobs failed: secrets=${{ needs.secrets.result }} lint=${{ needs.lint.result }} type-check=${{ needs.type-check.result }} design=${{ needs.design.result }} test=${{ needs.test.result }} extension=${{ needs.extension.result }}"
               exit 1
             fi
           done

--- a/.omp/commands/gate.md
+++ b/.omp/commands/gate.md
@@ -1,21 +1,23 @@
 Run the sploot ship gate — CI parity — and report pass/fail per step.
 
 Run these in order, from the repo root, and do not stop at the first failure —
-run all four so I see the full picture:
+run all five so I see the full picture:
 
 1. `pnpm lint`              (Turbo → web + extension + common)
 2. `pnpm type-check`        (Turbo → web + extension + common)
-3. `CI=1 pnpm --filter web test`  (the exact CI test script; `CI=1` forces
+3. `pnpm lint:design`       (design-system ratchet — DESIGN.md/design-contract.md
+   conformance; required, not advisory; a required `design` CI job runs it too)
+4. `CI=1 pnpm --filter web test`  (the exact CI test script; `CI=1` forces
    Vitest run-once so it can't drop into watch mode under omp's interactive PTY)
-4. `pnpm --filter extension build`
+5. `pnpm --filter extension build`
 
 This is the local ship gate AGENTS.md defines. DB-backed web tests need
 `DATABASE_URL` pointing at a pgvector-capable Postgres. If it is unset, say so
 and label those results "DB path unverified" rather than treating skips as passes.
 
-Then summarize: a ✅/❌ table of the four steps, and for any ❌ the exact failing
+Then summarize: a ✅/❌ table of the five steps, and for any ❌ the exact failing
 command + the first real error. Do NOT propose lowering a gate to get green —
 diagnose env/DB/migration/WXT/auth setup instead. GitHub CI adds checks on top
-of these four — a frozen-lockfile install, `pnpm --filter web db:migrate`,
+of these five — a frozen-lockfile install, `pnpm --filter web db:migrate`,
 extension lint/test, and the `merge-gate` aggregate job — so a green local gate
 is necessary but not a 100% guarantee CI is green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ pnpm --filter web db:studio       # Open Prisma Studio
 
 ## Gate Contract
 
-Ship gate equals CI parity: `pnpm lint && pnpm type-check && pnpm --filter web test && pnpm --filter extension build`, with Prisma/pgvector DB-backed paths requiring `DATABASE_URL` against a pgvector-capable Postgres or explicit `DB path unverified` evidence. GitHub CI adds frozen install, `pnpm --filter web db:migrate` against `pgvector/pgvector:pg15`, turbo lint/type-check, web tests, the retrieval-quality eval (`pnpm --filter web eval:search`, ratcheted against `apps/web/eval/baseline.json` — see `apps/web/eval/README.md`; changes touching embeddings, similarity thresholds, or query SQL must carry their paired eval delta), extension lint/test/build, and the `merge-gate` aggregate job.
+Ship gate equals CI parity: `pnpm lint && pnpm type-check && pnpm lint:design && pnpm --filter web test && pnpm --filter extension build`, with Prisma/pgvector DB-backed paths requiring `DATABASE_URL` against a pgvector-capable Postgres or explicit `DB path unverified` evidence. GitHub CI adds frozen install, `pnpm --filter web db:migrate` against `pgvector/pgvector:pg15`, turbo lint/type-check, the design-system ratchet (`pnpm lint:design`, enforced as a required `design` job — not advisory), web tests, the retrieval-quality eval (`pnpm --filter web eval:search`, ratcheted against `apps/web/eval/baseline.json` — see `apps/web/eval/README.md`; changes touching embeddings, similarity thresholds, or query SQL must carry their paired eval delta), extension lint/test/build, and the `merge-gate` aggregate job.
 
 ### Git Hooks (Lefthook)
 


### PR DESCRIPTION
## Summary
- The design-system ratchet (`scripts/check-design-system.mjs`, which bans violet-glassmorphism/backdrop-blur on the auth door) had zero CI enforcement — `pnpm lint:design` only ran when someone remembered to run it locally.
- Adds a required `design` CI job that runs `pnpm lint:design` on every PR.
- Wires `design` into `merge-gate`'s `needs` list, so a violation fails the required status check (branch protection only requires `merge-gate`, confirmed via `gh api repos/misty-step/sploot/branches/master/protection` — no separate branch-protection change needed).
- Updates `AGENTS.md` gate contract and `.omp/commands/gate.md` to keep local-parity docs in sync.

## Test plan
- [x] `pnpm lint:design` passes locally on this branch
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Proved the gate bites: reintroduced a banned auth-door pattern on a throwaway branch off this one, pushed, watched the new `design` CI job (and therefore `merge-gate`) go red, then reverted — see card `sploot-ci-enforce-lint-design` for the run link.
- [ ] CI green on this PR (`gh pr checks`)

Agent-Task: sploot-ci-enforce-lint-design