### PR TITLE
chore: standalone output for DO App Platform migration

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,7 @@ import {
 } from "./lib/image-config";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   // Image optimization configuration
   images: {
     // QA-only: map the reserved seed host to local files so qa-seed fixtures


### PR DESCRIPTION
## context

This is DigitalOcean App Platform migration prep for Sploot web. It enables Next standalone output so the eventual container image can copy the traced server bundle instead of the full workspace. The Fly spike on 2026-06-23 found a 460MB non-standalone image, so this keeps the DO path leaner.

## deploy impact

- Vercel deploys are unaffected; standalone output is additive for the existing Next build.
- The web build script already uses `next build --webpack`, so there is no Turbopack build-command change.
- CI does not directly run `pnpm --filter web build`; the existing lint/type-check/test/eval jobs remain unchanged.

## verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter web type-check`
- commit/pre-push hooks: gitleaks, secrets, workspace typecheck, commitlint

🤖 Generated with Codex (do-migration campaign)