### PR TITLE
fix(release): pre-stable 0.x release rules + version-reset note

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -2,7 +2,20 @@
 module.exports = {
   branches: ['main', 'master'],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    // Pre-stable 0.x semantics (Powder landmark-016/017): sploot runs
+    // semantic-release directly with no landmark action in front of it, so it
+    // gets no automatic pre-stable detection. These releaseRules mirror
+    // landmark's configs/.releaserc.prestable.json — Cargo-style bumps
+    // (breaking→minor, feat/fix→patch) that never cross 1.0.0 automatically.
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        releaseRules: [
+          { breaking: true, release: 'minor' },
+          { type: 'feat', release: 'patch' },
+        ],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/github',
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ back to protected branches. When `GEMINI_API_KEY` is configured, the release
 workflow may synthesize the GitHub Release notes after semantic-release
 publishes them; GitHub Releases remain the authoritative changelog.
 
+## Version reset: v1.23.2 → v0.23.2 (2026-07-08)
+
+The fleet moved to pre-stable 0.x semantics (Powder landmark-016/017): versions below 1.0.0 use Cargo-style bumps (breaking→minor, feat/fix→patch) and never cross 1.0.0 automatically; promotion to 1.0.0 is a deliberate manual tag. v0.23.2 is the same commit as v1.23.2. Earlier 1.x/2.x entries below record real history under the old numbering; their tags and GitHub releases were retired.
+
 # 1.0.0 (2026-01-24)
 
 


### PR DESCRIPTION
## Summary
- Adds pre-stable 0.x commit-analyzer releaseRules to `.releaserc.js` (Powder landmark-016/017): breaking→minor, feat→patch, mirroring landmark's `configs/.releaserc.prestable.json`. sploot runs semantic-release directly (no landmark action in front), so it needs its own copy of these rules — nothing auto-detects pre-stable for it.
- Prepends a version-reset note to CHANGELOG.md explaining the fleet's move to pre-stable 0.x semantics.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] lefthook pre-commit (gitleaks, secrets, typecheck) passed locally

Agent-Task: landmark-017