### PR TITLE
fix(ops): move cron ownership to DigitalOcean

### DIFF
--- a/apps/web/__tests__/api/cron/audit-assets.test.ts
+++ b/apps/web/__tests__/api/cron/audit-assets.test.ts
@@ -435,6 +435,34 @@ describe('/api/cron/audit-assets', () => {
         })
       );
     });
+
+    it('audits large libraries concurrently without an unbounded request fanout', async () => {
+      const mockAssets = Array.from({ length: 96 }, (_, index) => ({
+        id: `asset-${index}`,
+        blobUrl: `https://blob.vercel-storage.com/asset-${index}.jpg`,
+        pathname: `asset-${index}.jpg`,
+        ownerUserId: 'user-1',
+      }));
+      mockPrisma.asset.findMany.mockResolvedValue(mockAssets);
+
+      let active = 0;
+      let maxActive = 0;
+      (global.fetch as any).mockImplementation(async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return { ok: true, status: 200 };
+      });
+
+      const response = await GET({} as NextRequest);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.stats.validCount).toBe(mockAssets.length);
+      expect(maxActive).toBeGreaterThan(1);
+      expect(maxActive).toBeLessThanOrEqual(32);
+    });
   });
 
   describe('Error Handling', () => {

--- a/apps/web/__tests__/unit/privacy-copy-contract.test.ts
+++ b/apps/web/__tests__/unit/privacy-copy-contract.test.ts
@@ -68,14 +68,19 @@ describe('privacy copy contract', () => {
   });
 
   it('schedules the retention job promised by the privacy policy', () => {
-    const vercelConfig = JSON.parse(read('vercel.json')) as {
-      crons?: Array<{ path?: string; schedule?: string }>;
-    };
+    const schedules = JSON.parse(read('cron-schedules.json')) as Array<{
+      path?: string;
+      schedule?: string;
+    }>;
 
-    expect(vercelConfig.crons).toContainEqual(
+    expect(schedules).toContainEqual(
       expect.objectContaining({
         path: '/api/cron/purge-search-logs',
+        schedule: '0 4 * * *',
       })
     );
+
+    const vercelConfig = JSON.parse(read('vercel.json')) as { crons?: unknown };
+    expect(vercelConfig).not.toHaveProperty('crons');
   });
 });

--- a/apps/web/app/api/cron/audit-assets/route.ts
+++ b/apps/web/app/api/cron/audit-assets/route.ts
@@ -23,6 +23,8 @@ interface UserAuditResult {
   }>;
 }
 
+const AUDIT_CONCURRENCY = 32;
+
 /**
  * GET /api/cron/audit-assets
  *
@@ -30,7 +32,7 @@ interface UserAuditResult {
  * Detects broken blobs (404/403) and logs alerts if >10 broken assets found.
  *
  * Authorization: Uses Bearer token from CRON_SECRET environment variable
- * Schedule: Daily via Vercel Cron (configured in vercel.json)
+ * Schedule: Daily via the production scheduler (declared in cron-schedules.json)
  */
 async function getHandler(request: NextRequest) {
   const startTime = Date.now();
@@ -101,45 +103,60 @@ async function getHandler(request: NextRequest) {
     // Track broken assets per user for reporting
     const userAuditMap = new Map<string, UserAuditResult>();
 
-    // Validate each blob URL with HEAD request
-    for (const asset of assets) {
-      try {
-        // Use HEAD request to check if blob exists without downloading
-        const response = await fetch(asset.blobUrl, {
-          method: 'HEAD',
-          signal: AbortSignal.timeout(5000), // 5s timeout
-        });
+    // Keep the daily audit inside one HTTP job without opening thousands of
+    // sockets at once. Workers share a monotonically increasing index; JS runs
+    // each index claim synchronously before the worker reaches its first await.
+    let nextAssetIndex = 0;
+    async function auditNextAsset() {
+      while (true) {
+        const assetIndex = nextAssetIndex++;
+        if (assetIndex >= assets.length) return;
+        const asset = assets[assetIndex];
 
-        if (response.ok) {
-          stats.validCount++;
-        } else {
-          // 404 (Not Found), 403 (Forbidden), or other error status
-          stats.brokenCount++;
-          stats.brokenAssetIds.push(asset.id);
+        try {
+          // Use HEAD request to check if blob exists without downloading.
+          const response = await fetch(asset.blobUrl, {
+            method: 'HEAD',
+            signal: AbortSignal.timeout(5000), // 5s timeout
+          });
 
-          // Track per user
-          if (!userAuditMap.has(asset.ownerUserId)) {
-            userAuditMap.set(asset.ownerUserId, {
-              userId: asset.ownerUserId,
-              brokenCount: 0,
-              brokenAssets: [],
+          if (response.ok) {
+            stats.validCount++;
+          } else {
+            // 404 (Not Found), 403 (Forbidden), or other error status.
+            stats.brokenCount++;
+            stats.brokenAssetIds.push(asset.id);
+
+            if (!userAuditMap.has(asset.ownerUserId)) {
+              userAuditMap.set(asset.ownerUserId, {
+                userId: asset.ownerUserId,
+                brokenCount: 0,
+                brokenAssets: [],
+              });
+            }
+
+            const userResult = userAuditMap.get(asset.ownerUserId)!;
+            userResult.brokenCount++;
+            userResult.brokenAssets.push({
+              id: asset.id,
+              blobUrl: asset.blobUrl,
+              filename: asset.pathname.split('/').pop() || asset.pathname,
             });
           }
-
-          const userResult = userAuditMap.get(asset.ownerUserId)!;
-          userResult.brokenCount++;
-          userResult.brokenAssets.push({
-            id: asset.id,
-            blobUrl: asset.blobUrl,
-            filename: asset.pathname.split('/').pop() || asset.pathname,
-          });
+        } catch (err) {
+          // Network error, timeout, or other fetch failure.
+          stats.errorCount++;
+          logger.logError('cron:audit-assets:asset-check-failed', err as Error, { assetId: asset.id });
         }
-      } catch (err) {
-        // Network error, timeout, or other fetch failure
-        stats.errorCount++;
-        logger.logError('cron:audit-assets:asset-check-failed', err as Error, { assetId: asset.id });
       }
     }
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(AUDIT_CONCURRENCY, assets.length) },
+        () => auditNextAsset()
+      )
+    );
 
     stats.usersAffected = userAuditMap.size;
     const totalTime = Date.now() - startTime;

--- a/apps/web/app/api/cron/process-embeddings/route.ts
+++ b/apps/web/app/api/cron/process-embeddings/route.ts
@@ -25,7 +25,7 @@ interface ProcessingStats {
  * GET /api/cron/process-embeddings
  *
  * Cron job endpoint to process assets that need embeddings.
- * Can be triggered by Vercel Cron or manually.
+ * Can be triggered by the production scheduler or manually.
  *
  * Authorization: Uses Bearer token from CRON_SECRET environment variable
  */
@@ -214,7 +214,7 @@ async function getHandler(request: NextRequest) {
   }
 }
 
-// GET only: Vercel Cron invokes this on the */5 schedule, and a manual run is
+// GET only: the production scheduler invokes this on the */5 schedule, and a manual run is
 // the same idempotent, CRON_SECRET-gated call. There is deliberately no POST
 // variant — it would just duplicate GET and invite an "options" knob, and the
 // only knob worth having (re-embed everything) is the runaway this route must

--- a/apps/web/app/api/cron/purge-deleted-assets/route.ts
+++ b/apps/web/app/api/cron/purge-deleted-assets/route.ts
@@ -25,7 +25,7 @@ interface PurgeStats {
  * 3. Delete database records (cascades to embeddings and tags)
  *
  * Authorization: Uses Bearer token from CRON_SECRET environment variable
- * Schedule: Daily via Vercel Cron (configured in vercel.json)
+ * Schedule: Daily via the production scheduler (declared in cron-schedules.json)
  */
 async function getHandler(request: NextRequest) {
   const startTime = Date.now();

--- a/apps/web/cron-schedules.json
+++ b/apps/web/cron-schedules.json
@@ -1,0 +1,18 @@
+[
+  {
+    "path": "/api/cron/process-embeddings",
+    "schedule": "*/5 * * * *"
+  },
+  {
+    "path": "/api/cron/audit-assets",
+    "schedule": "0 2 * * *"
+  },
+  {
+    "path": "/api/cron/purge-deleted-assets",
+    "schedule": "0 3 * * *"
+  },
+  {
+    "path": "/api/cron/purge-search-logs",
+    "schedule": "0 4 * * *"
+  }
+]

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,21 +1,3 @@
 {
-  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "crons": [
-    {
-      "path": "/api/cron/process-embeddings",
-      "schedule": "*/5 * * * *"
-    },
-    {
-      "path": "/api/cron/audit-assets",
-      "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/purge-deleted-assets",
-      "schedule": "0 3 * * *"
-    },
-    {
-      "path": "/api/cron/purge-search-logs",
-      "schedule": "0 4 * * *"
-    }
-  ]
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile"
 }


### PR DESCRIPTION
## Goal

Move all Sploot scheduled work off Vercel onto DigitalOcean without changing route behavior, and keep the 3,231-object audit within a practical execution window.

## Change

- removes Vercel cron registration
- adds provider-neutral schedule declarations matching the live DigitalOcean job spec
- bounds asset audit HEAD requests to 32 concurrent workers
- adds behavioral coverage for the worker bound and for Vercel cron retirement

## Live proof

The DigitalOcean scheduled job invocation 8ba5fe63-fd16-47bc-a7cb-9308bb7651c3 succeeded. Web logs recorded authenticated 200 responses at 22:01:47Z, 22:06:48Z, and 22:11:48Z, preserving the existing five-minute embedding cadence.

## Gates

- focused tests: 20/20
- full pgvector-backed suite: 102 files, 1,078 tests
- lint, design lint, type-check, and extension build
- pre-commit and pre-push secret/gitleaks/type-check gates
- fresh-context critic: PASS

Agent: codex-orchestrator
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5
Agent-Task: sploot-do-cron-cutover