### PR TITLE
feat(web): lab-035 spine convergence — landing, chrome, detail, upload, settings

### DIFF
--- a/apps/web/__tests__/components/upload/upload-drop-zone.test.tsx
+++ b/apps/web/__tests__/components/upload/upload-drop-zone.test.tsx
@@ -7,7 +7,7 @@ describe('UploadDropZone', () => {
   it('does not advertise unsupported background upload replay', () => {
     render(<UploadDropZone onFilesAdded={vi.fn()} />);
 
-    expect(screen.getByText(/drag & drop memes/i)).toBeInTheDocument();
+    expect(screen.getByText(/drag chaos here/i)).toBeInTheDocument();
     expect(screen.queryByText(new RegExp(`background ${'sync'}`, 'i'))).not.toBeInTheDocument();
     expect(screen.queryByText(new RegExp(`background ${'upload'}`, 'i'))).not.toBeInTheDocument();
   });

--- a/apps/web/app/app/meme/[id]/page.tsx
+++ b/apps/web/app/app/meme/[id]/page.tsx
@@ -151,7 +151,8 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
       const res = await fetch(`/api/assets/${asset.id}`, { method: 'DELETE' });
       if (res.ok) {
         closeDeleteConfirmation();
-        router.push('/app');
+        // replace, not push — Back must not resurrect the deleted meme's URL
+        router.replace('/app');
       } else {
         throw new Error('Delete request failed');
       }
@@ -232,7 +233,11 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
   const sidebarSimilar = similarAssets.slice(0, SIMILAR_SIDEBAR_LIMIT);
   const overflowSimilar = similarAssets.slice(SIMILAR_SIDEBAR_LIMIT);
   const vectorId = asset.embedding?.assetId ?? asset.id;
-  const modelName = asset.embedding?.modelName;
+  // An embedding row exists from the moment processing starts — only call it
+  // "embedded" once its status is ready (legacy rows have no status column).
+  const embeddingReady =
+    !!asset.embedding && (asset.embedding.status == null || asset.embedding.status === 'ready');
+  const modelName = embeddingReady ? asset.embedding?.modelName : undefined;
 
   return (
     <div className="flex flex-col min-h-[calc(100vh-4rem)]">
@@ -331,9 +336,15 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
           </div>
 
           <p className="min-w-0 break-words font-mono text-xs lowercase text-muted-foreground">
-            saved {formatDate(asset.createdAt)}
+            saved {formatDate(asset.createdAt)} · {asset.mime}
             {modelName ? ` · embedded with ${modelName}` : ' · embedding pending'}
           </p>
+
+          {asset.tags && asset.tags.length > 0 && (
+            <p className="min-w-0 break-words font-mono text-xs lowercase text-muted-foreground">
+              tags: {asset.tags.map((t) => t.name).join(', ')}
+            </p>
+          )}
 
           {/* Similar saves — always present; quiet notes cover the not-ready states */}
           <div className="space-y-2.5 border-t-2 border-dashed border-border pt-4">
@@ -364,19 +375,25 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
                       className="sploot-press-sm flex w-full items-center gap-2.5 rounded-[var(--sploot-radius-inner)] border-2 border-sploot-ink bg-sploot-panel p-1.5 text-left"
                     >
                       <span className="relative size-11 shrink-0 overflow-hidden rounded-[calc(var(--sploot-radius-inner)-2px)] bg-sploot-paper-warm">
-                        <Image
-                          src={resolveQaSeedSrc(similar.thumbnailUrl || similar.blobUrl)}
-                          alt={similar.filename || 'Similar meme'}
-                          fill
-                          sizes="44px"
-                          className="object-cover"
-                          unoptimized={isAnimatedImageMimeType(similar.mime)}
-                        />
+                        {isVideoMimeType(similar.mime) && !similar.thumbnailUrl ? (
+                          <span className="flex h-full w-full items-center justify-center font-mono text-[0.6rem] font-bold lowercase text-muted-foreground">
+                            {similar.mime.split('/')[1] ?? 'video'}
+                          </span>
+                        ) : (
+                          <Image
+                            src={resolveQaSeedSrc(similar.thumbnailUrl || similar.blobUrl)}
+                            alt={similar.filename || 'Similar meme'}
+                            fill
+                            sizes="44px"
+                            className="object-cover"
+                            unoptimized={isAnimatedImageMimeType(similar.mime)}
+                          />
+                        )}
                       </span>
                       <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
                         {similar.filename || 'untitled save'}
                       </span>
-                      <span className="sploot-sticker-shadow shrink-0 rounded-[var(--sploot-radius-pill)] border-2 border-sploot-ink bg-sploot-yellow px-2 py-0.5 font-mono text-[0.65rem] font-bold text-sploot-ink">
+                      <span className="sploot-sticker-shadow shrink-0 rounded-[var(--sploot-radius-pill)] border-2 border-sploot-ink bg-sploot-yellow px-2 py-0.5 font-mono text-[0.65rem] font-bold text-[#1c1547]">
                         {Math.round(similar.relevance ?? (similar.similarity ?? 0) * 100)}%
                       </span>
                     </button>

--- a/apps/web/app/app/meme/[id]/page.tsx
+++ b/apps/web/app/app/meme/[id]/page.tsx
@@ -403,16 +403,14 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
             )}
           </div>
 
-          {asset.size > 0 && (
-            <button
-              type="button"
-              onClick={handleDownload}
-              className="inline-flex items-center gap-1.5 self-start font-mono text-xs lowercase text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <Download className="size-3.5" />
-              download original
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="inline-flex items-center gap-1.5 self-start font-mono text-xs lowercase text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Download className="size-3.5" />
+            download original
+          </button>
         </aside>
       </div>
 

--- a/apps/web/app/app/meme/[id]/page.tsx
+++ b/apps/web/app/app/meme/[id]/page.tsx
@@ -3,16 +3,21 @@
 import { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Heart, Download, ImageOff, Loader2, Share2 } from 'lucide-react';
+import { ArrowLeft, Heart, Download, ImageOff, Loader2, Share2, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useShareMeme } from '@/components/library/share-button';
 import { ImageGrid } from '@/components/library/image-grid';
 import { StateSurface } from '@/components/sploot/state-surface';
-import { IconButton } from '@/components/sploot';
+import { IconButton, StatBlock, StickerTab } from '@/components/sploot';
+import { DeleteConfirmationModal, useDeleteConfirmation } from '@/components/ui/delete-confirmation-modal';
 import type { Asset } from '@/lib/types';
 import { error as logError } from '@/lib/logger';
 import { isAnimatedImageMimeType, isVideoMimeType } from '@sploot/common';
 import { resolveQaSeedSrc } from '@/lib/qa/qa-image-loader';
+
+// The sidebar keeps the read tight: a handful of scored neighbors beside the
+// media, with the rest (if any) flowing into a full grid below the split.
+const SIMILAR_SIDEBAR_LIMIT = 4;
 
 interface MemeDetailPageProps {
   params: Promise<{ id: string }>;
@@ -128,6 +133,47 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
     [router]
   );
 
+  // Delete reuses the same confirmation flow (and DELETE /api/assets/:id
+  // endpoint) as the library grid's tile rail, so the "skip confirmation"
+  // preference stays consistent across both surfaces.
+  const {
+    isOpen: isDeleteModalOpen,
+    loading: isDeleting,
+    setLoading: setIsDeleting,
+    openConfirmation: openDeleteConfirmation,
+    closeConfirmation: closeDeleteConfirmation,
+  } = useDeleteConfirmation();
+
+  const handleDeleteAsset = useCallback(async () => {
+    if (!asset) return;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/assets/${asset.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        closeDeleteConfirmation();
+        router.push('/app');
+      } else {
+        throw new Error('Delete request failed');
+      }
+    } catch (err) {
+      logError('Failed to delete asset:', err);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [asset, closeDeleteConfirmation, router, setIsDeleting]);
+
+  const handleDeleteClick = useCallback(() => {
+    if (!asset) return;
+    const shouldSkip = openDeleteConfirmation({
+      id: asset.id,
+      imageUrl: asset.thumbnailUrl || asset.blobUrl,
+      imageName: asset.filename,
+    });
+    if (shouldSkip) {
+      handleDeleteAsset();
+    }
+  }, [asset, openDeleteConfirmation, handleDeleteAsset]);
+
   // Share runs the exact same flow as the library tile rail (native file share
   // → desktop image clipboard → share-link fallback), now driven by the shared
   // toybox IconButton so the three detail controls share one grammar.
@@ -183,10 +229,15 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
     );
   }
 
+  const sidebarSimilar = similarAssets.slice(0, SIMILAR_SIDEBAR_LIMIT);
+  const overflowSimilar = similarAssets.slice(SIMILAR_SIDEBAR_LIMIT);
+  const vectorId = asset.embedding?.assetId ?? asset.id;
+  const modelName = asset.embedding?.modelName;
+
   return (
     <div className="flex flex-col min-h-[calc(100vh-4rem)]">
-      {/* Top bar */}
-      <div className="flex items-center justify-between px-4 py-3 sm:px-6 border-b border-border">
+      {/* Back nav */}
+      <div className="flex items-center px-4 py-3 sm:px-6 border-b border-border">
         <Button
           variant="ghost"
           size="sm"
@@ -196,33 +247,11 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
           <ArrowLeft className="h-4 w-4" />
           <span className="hidden sm:inline">Back</span>
         </Button>
-
-        <div className="flex items-center gap-1.5">
-          {/* Favorite — banger heart (filled = banger) */}
-          <IconButton
-            label={asset.favorite ? 'remove banger' : 'mark as banger'}
-            pressed={asset.favorite}
-            onClick={handleFavoriteToggle}
-            disabled={favoriteLoading}
-          >
-            <Heart fill={asset.favorite ? 'currentColor' : 'none'} />
-          </IconButton>
-
-          {/* Share */}
-          <IconButton label="share meme" onClick={handleShare} disabled={shareLoading}>
-            {shareLoading ? <Loader2 className="animate-spin" /> : <Share2 />}
-          </IconButton>
-
-          {/* Download */}
-          <IconButton label="download meme" onClick={handleDownload}>
-            <Download />
-          </IconButton>
-        </div>
       </div>
 
-      {/* Main meme view */}
-      <div className="flex-1 flex items-center justify-center p-4 sm:p-8">
-        <div className="relative max-w-4xl w-full">
+      {/* Editorial split: uncropped media left, identity + actions + related sidebar right */}
+      <div className="flex-1 grid gap-6 p-4 sm:p-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,22rem)] lg:items-start">
+        <div className="sploot-card flex items-center justify-center overflow-hidden p-4 sm:p-6">
           {imageError ? (
             <div className="flex flex-col items-center justify-center gap-3 py-20">
               <ImageOff className="h-16 w-16 text-muted-foreground" />
@@ -245,7 +274,7 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
               alt={asset.filename || 'Meme'}
               width={asset.width || 1200}
               height={asset.height || 630}
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 900px"
+              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 80vw, 60vw"
               className="w-full h-auto max-h-[75vh] object-contain"
               priority
               quality={90}
@@ -254,67 +283,152 @@ export default function MemeDetailPage({ params }: MemeDetailPageProps) {
             />
           )}
         </div>
-      </div>
 
-      {/* Metadata bar */}
-      <div className="flex items-center justify-center px-4 py-2 border-t border-border">
-        <div className="flex items-center gap-3 font-mono text-xs text-muted-foreground">
-          {asset.width && asset.height && (
-            <span className="tabular-nums">{asset.width}x{asset.height}</span>
-          )}
-          {asset.size > 0 && (
-            <>
-              <span className="text-muted-foreground/30">|</span>
-              <span className="tabular-nums">{formatFileSize(asset.size)}</span>
-            </>
-          )}
-          <span className="text-muted-foreground/30">|</span>
-          <span>{asset.mime}</span>
-          <span className="text-muted-foreground/30">|</span>
-          <span>{formatDate(asset.createdAt)}</span>
-          {asset.tags && asset.tags.length > 0 && (
-            <>
-              <span className="text-muted-foreground/30">|</span>
-              <span>{asset.tags.map((t: { name: string }) => t.name).join(', ')}</span>
-            </>
-          )}
-        </div>
-      </div>
-
-      {/* Related memes section */}
-      <div className="border-t border-border">
-        <div className="px-4 sm:px-6 pt-6 pb-2">
-          <h2
-            className="text-2xl tracking-wider text-foreground"
-            style={{ fontFamily: 'var(--font-bebas-neue)' }}
-          >
-            RELATED MEMES
-          </h2>
-          <p className="text-xs text-muted-foreground font-mono mt-1">
-            semantically similar via CLIP embeddings
-          </p>
-        </div>
-
-        {similarLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <aside className="flex flex-col gap-5 lg:sticky lg:top-6">
+          <div className="space-y-2">
+            <StickerTab tone="cyan">meme detail</StickerTab>
+            <h1 className="font-display text-3xl leading-[0.95] text-foreground sm:text-4xl break-words">
+              {asset.filename || 'untitled save'}
+            </h1>
           </div>
-        ) : similarAssets.length === 0 ? (
-          <div className="px-4 sm:px-6 pb-12 pt-2">
-            <p className="font-mono text-xs lowercase text-muted-foreground">
-              {similarReason === 'source-unembedded'
-                ? 'still embedding this one. related memes show up once its vector is ready.'
-                : 'nothing else in the pile lands close yet. save a few more and they will show up here.'}
+
+          {/* Identical-grammar action trio: same IconButton, same size, never mixed raised/flat */}
+          <div className="flex items-center gap-1.5" role="group" aria-label="meme actions">
+            <IconButton
+              label={asset.favorite ? 'remove banger' : 'mark as banger'}
+              pressed={asset.favorite}
+              onClick={handleFavoriteToggle}
+              disabled={favoriteLoading}
+              className={asset.favorite ? '!bg-transparent !text-sploot-magenta' : undefined}
+            >
+              <Heart fill={asset.favorite ? 'currentColor' : 'none'} />
+            </IconButton>
+            <IconButton label="share meme" onClick={handleShare} disabled={shareLoading}>
+              {shareLoading ? <Loader2 className="animate-spin" /> : <Share2 />}
+            </IconButton>
+            <IconButton label="delete meme" onClick={handleDeleteClick}>
+              <Trash2 />
+            </IconButton>
+          </div>
+
+          {/* Candy stat toys */}
+          <div className="grid grid-cols-2 gap-2.5">
+            <StatBlock
+              label="vector id"
+              value={<span className="text-lg sm:text-xl">#{vectorId.slice(0, 8)}</span>}
+            />
+            <StatBlock
+              label="dims · size"
+              value={
+                <span className="flex flex-col text-lg leading-tight sm:text-xl">
+                  {asset.width && asset.height ? `${asset.width}×${asset.height}` : '—'}
+                  <span className="font-sans text-xs font-normal normal-case opacity-70">
+                    {asset.size > 0 ? formatFileSize(asset.size) : ''}
+                  </span>
+                </span>
+              }
+            />
+          </div>
+
+          <p className="min-w-0 break-words font-mono text-xs lowercase text-muted-foreground">
+            saved {formatDate(asset.createdAt)}
+            {modelName ? ` · embedded with ${modelName}` : ' · embedding pending'}
+          </p>
+
+          {/* Similar saves — always present; quiet notes cover the not-ready states */}
+          <div className="space-y-2.5 border-t-2 border-dashed border-border pt-4">
+            <div className="flex items-baseline justify-between gap-2">
+              <StickerTab tone="lime">similar saves</StickerTab>
+              <span className="font-mono text-[0.65rem] lowercase text-muted-foreground/70">
+                ranked by cosine similarity
+              </span>
+            </div>
+
+            {similarLoading ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : sidebarSimilar.length === 0 ? (
+              <p className="font-mono text-xs lowercase text-muted-foreground">
+                {similarReason === 'source-unembedded'
+                  ? 'still embedding this one. related memes show up once its vector is ready.'
+                  : 'nothing else in the pile lands close yet. save a few more and they will show up here.'}
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {sidebarSimilar.map((similar) => (
+                  <li key={similar.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSimilarAssetSelect(similar)}
+                      className="sploot-press-sm flex w-full items-center gap-2.5 rounded-[var(--sploot-radius-inner)] border-2 border-sploot-ink bg-sploot-panel p-1.5 text-left"
+                    >
+                      <span className="relative size-11 shrink-0 overflow-hidden rounded-[calc(var(--sploot-radius-inner)-2px)] bg-sploot-paper-warm">
+                        <Image
+                          src={resolveQaSeedSrc(similar.thumbnailUrl || similar.blobUrl)}
+                          alt={similar.filename || 'Similar meme'}
+                          fill
+                          sizes="44px"
+                          className="object-cover"
+                          unoptimized={isAnimatedImageMimeType(similar.mime)}
+                        />
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                        {similar.filename || 'untitled save'}
+                      </span>
+                      <span className="sploot-sticker-shadow shrink-0 rounded-[var(--sploot-radius-pill)] border-2 border-sploot-ink bg-sploot-yellow px-2 py-0.5 font-mono text-[0.65rem] font-bold text-sploot-ink">
+                        {Math.round(similar.relevance ?? (similar.similarity ?? 0) * 100)}%
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {asset.size > 0 && (
+            <button
+              type="button"
+              onClick={handleDownload}
+              className="inline-flex items-center gap-1.5 self-start font-mono text-xs lowercase text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Download className="size-3.5" />
+              download original
+            </button>
+          )}
+        </aside>
+      </div>
+
+      {/* Overflow: remaining related memes that didn't fit the sidebar */}
+      {overflowSimilar.length > 0 && (
+        <div className="border-t border-border">
+          <div className="px-4 sm:px-6 pt-6 pb-2">
+            <h2 className="font-display text-2xl tracking-wider text-foreground">
+              MORE FROM THE PILE
+            </h2>
+            <p className="text-xs text-muted-foreground font-mono mt-1">
+              semantically similar via CLIP embeddings
             </p>
           </div>
-        ) : (
           <ImageGrid
-            assets={similarAssets}
+            assets={overflowSimilar}
             onAssetSelect={handleSimilarAssetSelect}
             showSimilarityScores
           />
-        )}
-      </div>
+        </div>
+      )}
+
+      <DeleteConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onClose={closeDeleteConfirmation}
+        onConfirm={handleDeleteAsset}
+        title="Delete meme"
+        description="Are you sure you want to delete this meme? This action cannot be undone."
+        imageUrl={asset.thumbnailUrl || asset.blobUrl}
+        imageName={asset.filename}
+        loading={isDeleting}
+        showDontAskAgain={true}
+      />
     </div>
   );
 }

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -23,17 +23,17 @@ import { getEmbeddingQueueManager } from '@/lib/embedding-queue';
 import { ShareButton } from '@/components/library/share-button';
 import { error as logError } from '@/lib/logger';
 import type { EmbeddingQueueItem } from '@/lib/embedding-queue';
-import { useKeyboardShortcut, useSearchShortcut, useSlashSearchShortcut } from '@/hooks/use-keyboard-shortcut';
+import { useSearchShortcut, useSlashSearchShortcut } from '@/hooks/use-keyboard-shortcut';
 import { CommandPalette, useCommandPalette } from '@/components/chrome/command-palette';
-import { KeyboardShortcutsHelp, useKeyboardShortcutsHelp } from '@/components/chrome/keyboard-shortcuts-help';
 import { useSortPreferences } from '@/hooks/use-sort-preferences';
 import { useFilter } from '@/contexts/filter-context';
 import { UploadButton } from '@/components/chrome/upload-button';
 import { FilterChips, type FilterType } from '@/components/chrome/filter-chips';
 import { SortDropdown } from '@/components/chrome/sort-dropdown';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { PileFilterRail, StickerTab } from '@/components/sploot';
+import { PileFilterRail, StickerTab, IconButton } from '@/components/sploot';
 import { RotateCcw, Shuffle, X, Trash2 } from 'lucide-react';
 import { DeleteConfirmationModal, useDeleteConfirmation } from '@/components/ui/delete-confirmation-modal';
 import { track } from '@/lib/analytics';
@@ -67,9 +67,6 @@ function AppPageClient() {
   // Command palette state
   const { isOpen: isCommandPaletteOpen, openPalette, closePalette } = useCommandPalette();
 
-  // Keyboard shortcuts help state
-  const { isOpen: isHelpOpen, openHelp, closeHelp } = useKeyboardShortcutsHelp();
-
   // Delete confirmation modal state
   const {
     isOpen: isDeleteModalOpen,
@@ -90,6 +87,7 @@ function AppPageClient() {
     getSortColumn,
   } = useSortPreferences();
   const [failedEmbeddings, setFailedEmbeddings] = useState<EmbeddingQueueItem[]>([]);
+  const [cookingCount, setCookingCount] = useState(0);
   const [showRetryModal, setShowRetryModal] = useState(false);
   const [retryProgress, setRetryProgress] = useState({ current: 0, total: 0, processing: false });
 
@@ -205,12 +203,15 @@ function AppPageClient() {
   // Also add "/" key shortcut to focus search
   useSlashSearchShortcut(focusSearchBar);
 
-  // Monitor failed embeddings
+  // Monitor failed embeddings + the in-flight "cooking" count for the
+  // command bar's mono readout (row two of the AFD-NAV-1 chrome).
   useEffect(() => {
     const checkFailedEmbeddings = () => {
       const manager = getEmbeddingQueueManager();
       const failed = manager.getFailedItems();
       setFailedEmbeddings(failed);
+      const status = manager.getStatus();
+      setCookingCount(status.queued + status.processing);
     };
 
     // Check immediately
@@ -221,9 +222,7 @@ function AppPageClient() {
 
     // Subscribe to queue events
     const unsubscribe = getEmbeddingQueueManager().subscribe((event) => {
-      if (event.type === 'failed' || event.type === 'completed') {
-        checkFailedEmbeddings();
-      }
+      checkFailedEmbeddings();
     });
 
     return () => {
@@ -382,13 +381,6 @@ function AppPageClient() {
       window.scrollTo({ top: desiredTop });
     }
   }, []);
-
-  // ? for keyboard shortcuts help
-  useKeyboardShortcut({
-    key: '?',
-    callback: openHelp,
-    enabled: true,
-  });
 
   const gridContainerClassName = cn(
     'h-full overflow-y-auto overflow-x-hidden',
@@ -676,7 +668,10 @@ function AppPageClient() {
       <div className="border-b-[3px] border-sploot-cyan bg-background px-2 pb-2 pt-2 md:px-6 2xl:px-10">
         <div className="mx-auto w-full max-w-7xl 2xl:max-w-[1920px]">
           <header className="flex flex-col gap-2">
-            <div className="hidden items-center gap-2 md:grid md:grid-cols-[minmax(20rem,1fr)_auto]">
+            {/* Row one — the search pill owns the center; upload/retry sit
+                right of it. Compact ink-mini grammar continues from the
+                global mast's help/theme controls above. */}
+            <div className="hidden items-center gap-3 md:flex">
               <SearchBar
                 onSearch={handleInlineSearch}
                 inline
@@ -690,18 +685,11 @@ function AppPageClient() {
                             'idle'
                 }
                 resultCount={searchAssets.length}
-                className="min-w-0"
+                className="min-w-0 flex-1"
                 placeholder="search your memes..."
               />
 
-              <div className="flex flex-wrap justify-end gap-2">
-                <UploadButton
-                  onClick={() => setShowUploadPanel((prev) => !prev)}
-                  isActive={showUploadPanel}
-                  size="sm"
-                  showLabel={false}
-                  className="md:hidden"
-                />
+              <div className="flex flex-none items-center gap-2">
                 <UploadButton
                   onClick={() => setShowUploadPanel((prev) => !prev)}
                   isActive={showUploadPanel}
@@ -719,10 +707,20 @@ function AppPageClient() {
                     RETRY ({failedEmbeddings.length})
                   </Button>
                 )}
+              </div>
+            </div>
+
+            {/* Hairline divider between the search row and the filter row. */}
+            <Separator className="hidden md:block" />
+
+            {/* Row two — hairline-divided: tabs, sort, shuffle read left to
+                right; the machine's mono readout anchors the right edge. */}
+            <div className="hidden items-center justify-between gap-3 md:flex">
+              <div className="flex flex-wrap items-center gap-2">
                 <FilterChips
                   activeFilter={bangersOnly ? 'bangers' : 'all'}
                   onFilterChange={handleBangersFilterChange}
-                  size="lg"
+                  size="sm"
                   showLabels={true}
                 />
                 <SortDropdown
@@ -730,27 +728,23 @@ function AppPageClient() {
                   direction={sortOrder}
                   onChange={handleSortChange}
                 />
-
-                <Button
-                  variant={sortBy === 'shuffle' ? 'accent' : 'outline'}
-                  size="lg"
+                <IconButton
+                  label="shuffle the pile"
+                  pressed={sortBy === 'shuffle'}
                   onClick={() => {
                     handleSortChange('shuffle', 'desc');
                     requestAnimationFrame(() => {
                       gridScrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
                     });
                   }}
-                  className="gap-2"
-                  aria-pressed={sortBy === 'shuffle'}
                 >
-                  <Shuffle className="h-4 w-4" />
-                  shuffle
-                </Button>
+                  <Shuffle />
+                </IconButton>
 
                 {tagIdParam && (
                   <Button
                     variant="outline"
-                    size="lg"
+                    size="sm"
                     onClick={clearTagFilter}
                     className="gap-1"
                   >
@@ -760,6 +754,11 @@ function AppPageClient() {
                   </Button>
                 )}
               </div>
+
+              <span className="shrink-0 font-mono text-xs lowercase tabular-nums text-muted-foreground">
+                {total.toLocaleString()} in the pile
+                {cookingCount > 0 ? ` · ${cookingCount.toLocaleString()} cooking` : ''}
+              </span>
             </div>
 
             <div className={cn('md:hidden', showMobileSearch ? 'block' : 'hidden')}>
@@ -1195,12 +1194,6 @@ function AppPageClient() {
           await signOut();
           router.push('/');
         }}
-      />
-
-      {/* Keyboard Shortcuts Help */}
-      <KeyboardShortcutsHelp
-        isOpen={isHelpOpen}
-        onClose={closeHelp}
       />
 
       {/* Delete Confirmation Modal */}

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -6,10 +6,12 @@ import { useAuthUser, useAuthActions } from '@/lib/auth/client';
 import { usePwaInstallPrompt } from '@/hooks/use-pwa-install';
 import { UploadTokensCard } from '@/components/settings/upload-tokens-card';
 import { Button } from '@/components/ui/button';
+import { StatBlock, StickerTab } from '@/components/sploot';
 // Fallback while /api/version (latest landfall release tag) loads.
 const APP_VERSION_FALLBACK = process.env.NEXT_PUBLIC_APP_VERSION || 'v0';
 
 interface StorageStats {
+  assetCount: number;
   storageBytes: number;
   storageLimitBytes: number;
   storageRemainingBytes: number;
@@ -29,6 +31,7 @@ export default function SettingsPage() {
   const { installable, installed, requiresManualInstall, promptInstall } = usePwaInstallPrompt();
   const [signOutLoading, setSignOutLoading] = useState(false);
   const [storageStats, setStorageStats] = useState<StorageStats | null>(null);
+  const [embeddedCount, setEmbeddedCount] = useState<number | null>(null);
   const [appVersion, setAppVersion] = useState<string>(APP_VERSION_FALLBACK);
 
   useEffect(() => {
@@ -49,6 +52,7 @@ export default function SettingsPage() {
       const data = await response.json();
       if (!cancelled) {
         setStorageStats({
+          assetCount: data.assetCount ?? 0,
           storageBytes: data.storageBytes ?? 0,
           storageLimitBytes: data.storageLimitBytes ?? 0,
           storageRemainingBytes: data.storageRemainingBytes ?? 0,
@@ -59,10 +63,29 @@ export default function SettingsPage() {
 
     loadStorageStats().catch(() => {});
 
+    // The automatic-piles endpoint always reports the ready-embedding count
+    // (regardless of whether any pile clears the minimum-size bar), which is
+    // the cheapest existing source for "embedded" — no dedicated stats route
+    // for it exists yet.
+    async function loadEmbeddedCount() {
+      const response = await fetch('/api/piles?limit=1');
+      if (!response.ok) return;
+      const data = await response.json();
+      if (!cancelled && typeof data?.embeddedAssetCount === 'number') {
+        setEmbeddedCount(data.embeddedAssetCount);
+      }
+    }
+
+    loadEmbeddedCount().catch(() => {});
+
     return () => {
       cancelled = true;
     };
   }, []);
+
+  const totalCount = storageStats?.assetCount ?? null;
+  const cookingCount =
+    totalCount !== null && embeddedCount !== null ? Math.max(0, totalCount - embeddedCount) : null;
 
   const handleSignOut = async () => {
     setSignOutLoading(true);
@@ -79,12 +102,35 @@ export default function SettingsPage() {
 
   return (
     <div className="p-6 md:p-8 space-y-6 max-w-3xl mx-auto">
-      <header className="space-y-1">
-        <h1 className="text-3xl font-bold text-foreground">Settings</h1>
+      <header className="space-y-2">
+        <StickerTab tone="violet">settings</StickerTab>
+        <h1 className="font-display text-4xl leading-[0.95] text-foreground sm:text-5xl">
+          the knobs
+        </h1>
         <p className="text-muted-foreground text-sm">
           Tune your meme bunker vibes, manage your login, and flex the PWA drip.
         </p>
       </header>
+
+      <div className="flex flex-wrap gap-2.5">
+        <StatBlock
+          label="in the pile"
+          value={totalCount !== null ? totalCount.toLocaleString() : '—'}
+          tone="blue"
+          className="flex-1 min-w-[8.5rem]"
+        />
+        <StatBlock
+          label="embedded"
+          value={embeddedCount !== null ? embeddedCount.toLocaleString() : '—'}
+          className="flex-1 min-w-[8.5rem]"
+        />
+        <StatBlock
+          label="cooking"
+          value={cookingCount !== null ? cookingCount.toLocaleString() : '—'}
+          tone="magenta"
+          className="flex-1 min-w-[8.5rem]"
+        />
+      </div>
 
       <section className="sploot-card p-5 space-y-4">
         <div>
@@ -107,6 +153,23 @@ export default function SettingsPage() {
             {signOutLoading ? 'Yeeting…' : 'Sign out'}
           </Button>
         </div>
+      </section>
+
+      <UploadTokensCard />
+
+      <section className="sploot-card p-5 space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Embeddings</h2>
+          <p className="text-muted-foreground text-sm mt-1">
+            {embeddedCount !== null && totalCount !== null
+              ? `${embeddedCount.toLocaleString()} of ${totalCount.toLocaleString()} saves embedded${cookingCount ? `, ${cookingCount.toLocaleString()} still cooking.` : '.'}`
+              : 'Checking embedding coverage...'}
+          </p>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Every save gets a CLIP vector on arrival so text search can find it.
+          Failed embeddings retry from the library&apos;s retry banner.
+        </p>
       </section>
 
       <section className="sploot-card p-5 space-y-4">
@@ -132,8 +195,6 @@ export default function SettingsPage() {
           </div>
         </div>
       </section>
-
-      <UploadTokensCard />
 
       <section className="sploot-card p-5 space-y-3">
         <div>

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -125,7 +125,7 @@ export default function SettingsPage() {
           className="flex-1 min-w-[8.5rem]"
         />
         <StatBlock
-          label="cooking"
+          label="not yet searchable"
           value={cookingCount !== null ? cookingCount.toLocaleString() : '—'}
           tone="magenta"
           className="flex-1 min-w-[8.5rem]"
@@ -162,7 +162,7 @@ export default function SettingsPage() {
           <h2 className="text-lg font-semibold text-foreground">Embeddings</h2>
           <p className="text-muted-foreground text-sm mt-1">
             {embeddedCount !== null && totalCount !== null
-              ? `${embeddedCount.toLocaleString()} of ${totalCount.toLocaleString()} saves embedded${cookingCount ? `, ${cookingCount.toLocaleString()} still cooking.` : '.'}`
+              ? `${embeddedCount.toLocaleString()} of ${totalCount.toLocaleString()} saves embedded${cookingCount ? `, ${cookingCount.toLocaleString()} not yet searchable (cooking or awaiting retry).` : '.'}`
               : 'Checking embedding coverage...'}
           </p>
         </div>

--- a/apps/web/components/chrome/navbar.tsx
+++ b/apps/web/components/chrome/navbar.tsx
@@ -2,10 +2,13 @@
 
 import { ReactNode } from 'react';
 import Link from 'next/link';
+import { HelpCircle } from 'lucide-react';
 import { UserAvatar } from './user-avatar';
 import { ThemeToggle } from '@/components/theme-toggle';
-import { PileMark } from '@/components/sploot';
+import { PileMark, IconButton } from '@/components/sploot';
 import { cn } from '@/lib/utils';
+import { useKeyboardShortcut } from '@/hooks/use-keyboard-shortcut';
+import { KeyboardShortcutsHelp, useKeyboardShortcutsHelp } from './keyboard-shortcuts-help';
 
 interface NavbarProps {
   children?: ReactNode;
@@ -28,6 +31,10 @@ export function Navbar({
   onSignOut,
   statusLine,
 }: NavbarProps) {
+  // Help control lives in the mast itself (AFD-NAV-1): the "?" shortcut and
+  // its dialog are global chrome, not tied to any one route.
+  const { isOpen: isHelpOpen, openHelp, closeHelp } = useKeyboardShortcutsHelp();
+  useKeyboardShortcut({ key: '?', callback: openHelp, enabled: true });
 
   return (
     <>
@@ -76,10 +83,16 @@ export function Navbar({
         {/* Spacer to push user menu to the right */}
         <div className="flex-1" />
 
-        {/* Right section: Status line, theme toggle, and user menu */}
-        <div className="flex items-center gap-4">
+        {/* Right section: Status line, help, theme toggle, and user menu —
+            compact ink-mini icon buttons share identical grammar. */}
+        <div className="flex items-center gap-2 md:gap-3">
           {/* Terminal-style status line */}
           {statusLine}
+
+          {/* Help control */}
+          <IconButton label="keyboard shortcuts" onClick={openHelp}>
+            <HelpCircle />
+          </IconButton>
 
           {/* Theme toggle */}
           <ThemeToggle />
@@ -99,6 +112,7 @@ export function Navbar({
         {children}
       </div>
     </nav>
+    <KeyboardShortcutsHelp isOpen={isHelpOpen} onClose={closeHelp} />
     </>
   );
 }

--- a/apps/web/components/landing/landing-hero.tsx
+++ b/apps/web/components/landing/landing-hero.tsx
@@ -1,52 +1,64 @@
+'use client';
+
+import { useRef } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { SearchField, StatBlock, StatusBar, StickerTab } from '@/components/sploot';
+import { SearchField, type SearchFieldHandle, StatBlock, StatusBar, StickerTab } from '@/components/sploot';
 
 /**
- * The toybox landing hero (lab-034, AFD-8). The first viewport is the product
- * mechanism itself: a search console that ranks a demo pile by meaning, sitting
- * on the dotted candy shelf. No fake window chrome, no centered SaaS emptiness —
- * the machine is on the table, running.
+ * The toybox landing hero (lab-035, IMPEC-LAND-3 convergence). A 5:7 split:
+ * a sticky copy tower on the left sells the claim, a working search console
+ * + demo wall on the right proves it. No fake window chrome — the machine is
+ * on the table, running, and the tower's "shuffle the demo" CTA drives the
+ * same shuffle as the wall header's control (SearchFieldHandle).
  */
 export function LandingHero() {
+  const searchFieldRef = useRef<SearchFieldHandle>(null);
+
   return (
     <section className="relative bg-sploot-workbench text-sploot-ink">
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-5 pb-16 pt-24 sm:px-8">
-        <div className="flex flex-col items-start gap-5">
+      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-10 px-5 pb-16 pt-24 sm:px-8 lg:grid-cols-12 lg:items-start lg:gap-8">
+        {/* left tower: sticky on large screens, stacks above the console on mobile */}
+        <div className="flex flex-col items-start gap-5 lg:sticky lg:top-24 lg:col-span-5">
           <StickerTab tone="cyan" tilt="left">
             it&rsquo;s a search box. for memes.
           </StickerTab>
           <h1
-            aria-label="type words. get the picture."
+            aria-label="search the pile. live."
             className="font-display text-[3.1rem] leading-[0.95] tracking-normal text-sploot-ink min-[420px]:text-6xl md:text-7xl"
           >
-            <span className="block">type words.</span>
+            <span className="block">search the pile.</span>
             <span className="block">
-              get the <em className="not-italic text-sploot-red">picture.</em>
+              <em className="not-italic text-sploot-red">live.</em>
             </span>
           </h1>
-          <p className="max-w-xl font-sans text-lg font-medium leading-8 text-sploot-ink/80 md:text-xl">
-            drop every meme you own into the machine. it lines them up by meaning, then
-            hands you the one you meant. no folders. just vibes.
+          <p className="max-w-md font-sans text-lg font-medium leading-8 text-sploot-ink/80 md:text-xl">
+            that panel on the right is real. type what you half remember, hit find, and
+            eight starter memes re-rank in front of you. no account, no upload — just the
+            machine doing its thing.
           </p>
+          <div className="flex flex-wrap gap-3">
+            <Button asChild variant="primary" size="lg">
+              <Link href="/sign-up">start your own pile</Link>
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="lg"
+              onClick={() => searchFieldRef.current?.shuffle()}
+            >
+              shuffle the demo
+            </Button>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <StatBlock label="demo classics, embedded" value="8" tone="paper" />
+            <StatBlock label="re-rank on every search" value="instant" tone="magenta" />
+          </div>
         </div>
 
-        {/* the centerpiece: a live search console over a real toy-card pile */}
-        <SearchField />
-
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <StatBlock label="demo vectors" value="8" tone="magenta" />
-          <StatBlock label="folders required" value="0" tone="blue" />
-          <StatBlock label="scorer mode" value="local" tone="paper" />
-        </div>
-
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
-          <Button asChild variant="primary" size="lg">
-            <Link href="/sign-up">claim your library</Link>
-          </Button>
-          <p className="font-mono text-xs lowercase tracking-normal text-sploot-ink/60">
-            no social feed. no ads. your export stays yours.
-          </p>
+        {/* right column: the working console + demo wall, filling the wide 7-span */}
+        <div className="lg:col-span-7">
+          <SearchField ref={searchFieldRef} className="max-w-none" />
         </div>
       </div>
 

--- a/apps/web/components/landing/landing-hero.tsx
+++ b/apps/web/components/landing/landing-hero.tsx
@@ -33,9 +33,9 @@ export function LandingHero() {
             </span>
           </h1>
           <p className="max-w-md font-sans text-lg font-medium leading-8 text-sploot-ink/80 md:text-xl">
-            that panel on the right is real. type what you half remember, hit find, and
-            eight starter memes re-rank in front of you. no account, no upload — just the
-            machine doing its thing.
+            that panel on the right works. type what you half remember, hit find, and
+            eight starter memes re-rank in front of you. no account, no upload — a
+            taste of how your pile answers.
           </p>
           <div className="flex flex-wrap gap-3">
             <Button asChild variant="primary" size="lg">
@@ -51,7 +51,7 @@ export function LandingHero() {
             </Button>
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <StatBlock label="demo classics, embedded" value="8" tone="paper" />
+            <StatBlock label="demo classics in the wall" value="8" tone="paper" />
             <StatBlock label="re-rank on every search" value="instant" tone="magenta" />
           </div>
         </div>

--- a/apps/web/components/landing/landing-story.tsx
+++ b/apps/web/components/landing/landing-story.tsx
@@ -67,10 +67,10 @@ export function LandingStory() {
 
         <div className="flex flex-col items-start gap-4 rounded-[var(--sploot-radius)] border-[3px] border-sploot-ink bg-sploot-yellow p-8 sploot-shadow sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-col gap-1">
-            <p className="font-display text-2xl leading-tight tracking-normal text-sploot-ink">
+            <p className="font-display text-2xl leading-tight tracking-normal text-[#1c1547]">
               upload chaos. get order for free.
             </p>
-            <p className="font-sans text-base text-sploot-ink/80">
+            <p className="font-sans text-base text-[#1c1547]/80">
               your library is private — only you can see your pile.
             </p>
           </div>

--- a/apps/web/components/settings/upload-tokens-card.tsx
+++ b/apps/web/components/settings/upload-tokens-card.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { StickerTab } from '@/components/sploot';
 
 interface UploadToken {
   id: string;
@@ -174,8 +175,11 @@ export function UploadTokensCard() {
           {tokens.map((token) => (
             <li key={token.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
               <div className="min-w-0">
-                <p className="text-sm text-foreground truncate">{token.name}</p>
-                <p className="text-xs text-muted-foreground">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm text-foreground truncate">{token.name}</p>
+                  <StickerTab tone="cyan" className="shrink-0">upload only</StickerTab>
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">
                   <span className="font-mono">{token.prefix}…</span> · {formatWhen(token.lastUsedAt)}
                 </p>
               </div>

--- a/apps/web/components/sploot/index.ts
+++ b/apps/web/components/sploot/index.ts
@@ -6,7 +6,7 @@ export { MemeCell, type MemeCellState } from './meme-cell';
 export { MemeDoodle } from './meme-doodle';
 export { PileFilterRail, visiblePileFilters } from './pile-filter-rail';
 export { PileMark } from './pile-mark';
-export { SearchField } from './search-field';
+export { SearchField, type SearchFieldHandle, type SearchFieldProps } from './search-field';
 export { StatBlock } from './stat-block';
 export { DeadShareLinkState, StateSurface } from './state-surface';
 export { StatusBar, type StatusCell } from './status-bar';

--- a/apps/web/components/sploot/search-field.tsx
+++ b/apps/web/components/sploot/search-field.tsx
@@ -143,6 +143,9 @@ export const SearchField = forwardRef<SearchFieldHandle, SearchFieldProps>(funct
     return {
       states,
       found,
+      // when a search hits, the wall re-ranks to score order — the copy
+      // promises re-ranking, so the tiles actually move
+      rankedOrder: ranked.map((r) => TILES.indexOf(r.tile)),
       topSim: best.s.toFixed(2),
       hit: found ? best.tile.file : 'none',
       scanned: TILES.length,
@@ -217,7 +220,7 @@ export const SearchField = forwardRef<SearchFieldHandle, SearchFieldProps>(funct
           className="flex flex-wrap gap-x-6 gap-y-1 bg-sploot-void px-4 py-2.5 font-mono text-[0.72rem] lowercase text-sploot-on-void"
         >
           <span>
-            scan: <b className="text-sploot-yellow sploot-tabular">{result.scanned}</b> vectors
+            scan: <b className="text-sploot-yellow sploot-tabular">{result.scanned}</b> tiles
           </span>
           <span>
             top sim:{' '}
@@ -234,7 +237,7 @@ export const SearchField = forwardRef<SearchFieldHandle, SearchFieldProps>(funct
           <span>
             {result.found
               ? 'located 1 of 8 demo classics. every search re-ranks what you see below.'
-              : '8 demo classics, embedded. every search re-ranks what you see below.'}
+              : '8 demo classics. every search re-ranks what you see below.'}
           </span>
           <IconButton
             label="shuffle the demo pile"
@@ -251,7 +254,7 @@ export const SearchField = forwardRef<SearchFieldHandle, SearchFieldProps>(funct
           role="list"
           aria-label="sample meme library"
         >
-          {order.map((tileIndex) => {
+          {(result.found ? result.rankedOrder : order).map((tileIndex) => {
             const tile = TILES[tileIndex];
             const cell = result.states.get(tile.file)!;
             return (

--- a/apps/web/components/sploot/search-field.tsx
+++ b/apps/web/components/sploot/search-field.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, Shuffle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { IconButton } from './icon-button';
 import { MemeCell, type MemeCellState } from './meme-cell';
 import { type MemeDoodleKind } from './meme-doodle';
 
 // Signed-out demo pile: license-safe doodles with enough keywords for the
 // console to find the intended sample.
+// TODO(backlog.d/059-live-demo-pile-on-landing.md): swap this static 8-tile
+// pile for the live 1,000-classic public corpus once that ingest ships.
 type Tile = {
   doodle: MemeDoodleKind;
   src?: string;
@@ -73,15 +77,43 @@ const THRESHOLD = 0.2;
 
 type Ranked = { tile: Tile; s: number };
 
+function shuffledOrder(length: number): number[] {
+  const order = Array.from({ length }, (_, i) => i);
+  for (let i = order.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [order[i], order[j]] = [order[j], order[i]];
+  }
+  return order;
+}
+
+export interface SearchFieldHandle {
+  /** Reshuffles the at-rest tile order — wired to the tower's "shuffle the demo" CTA. */
+  shuffle: () => void;
+}
+
+export interface SearchFieldProps {
+  /** Overrides the default `max-w-2xl` cap (e.g. to fill a wider layout column). */
+  className?: string;
+}
+
 /**
  * The centerpiece: a search console for your own memes. The best tile gets the
  * lime match ring, near matches get an orange inset ring, and everything else
- * recedes.
+ * recedes. Imperatively exposes `shuffle()` so a page-level CTA outside this
+ * card (the landing tower's "shuffle the demo" button) can reorder the wall.
  */
-export function SearchField() {
+export const SearchField = forwardRef<SearchFieldHandle, SearchFieldProps>(function SearchField(
+  { className },
+  ref
+) {
   const router = useRouter();
   const [query, setQuery] = useState('two cats arguing at a table');
   const [reducedMotion, setReducedMotion] = useState(false);
+  const [order, setOrder] = useState<number[]>(() => TILES.map((_, i) => i));
+
+  useImperativeHandle(ref, () => ({
+    shuffle: () => setOrder(shuffledOrder(TILES.length)),
+  }));
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return;
@@ -119,7 +151,7 @@ export function SearchField() {
   }, [query]);
 
   return (
-    <div className="w-full max-w-2xl">
+    <div className={cn('w-full max-w-2xl', className)}>
       <div className="sploot-shadow-lg overflow-hidden rounded-[var(--sploot-radius)] border-[3px] border-sploot-ink bg-sploot-panel">
         {/* console titlebar with the 3 candy LEDs */}
         <div className="flex items-center justify-between gap-3 bg-sploot-void px-4 py-2.5 font-mono text-[0.7rem] lowercase text-sploot-on-void">
@@ -197,21 +229,30 @@ export function SearchField() {
           </span>
         </output>
 
-        {/* grid head */}
+        {/* wall head: honest scope + a shuffle control for the at-rest order */}
         <div className="flex flex-wrap items-center justify-between gap-2 border-b-[3px] border-sploot-ink bg-sploot-magenta px-4 py-3 font-mono text-[0.74rem] font-bold lowercase text-[#1c1547]">
           <span>
-            {result.found ? 'located 1 of 8 demo cells. i had a meme for this.' : '8 demo cells. zero folders.'}
+            {result.found
+              ? 'located 1 of 8 demo classics. every search re-ranks what you see below.'
+              : '8 demo classics, embedded. every search re-ranks what you see below.'}
           </span>
-          <span aria-hidden="true">[ showing 8 sample vectors ]</span>
+          <IconButton
+            label="shuffle the demo pile"
+            onClick={() => setOrder(shuffledOrder(TILES.length))}
+            className="!border-[#1c1547] !text-[#1c1547]"
+          >
+            <Shuffle />
+          </IconButton>
         </div>
 
         {/* the pile: search lights up the match, everything else recedes */}
         <div
-          className="grid grid-cols-2 gap-3 bg-sploot-paper-warm p-4 sm:grid-cols-4"
+          className="grid grid-cols-2 gap-3 bg-sploot-paper-warm p-4 sm:grid-cols-3"
           role="list"
           aria-label="sample meme library"
         >
-          {TILES.map((tile) => {
+          {order.map((tileIndex) => {
+            const tile = TILES[tileIndex];
             const cell = result.states.get(tile.file)!;
             return (
               <div role="listitem" key={tile.file}>
@@ -248,4 +289,4 @@ export function SearchField() {
       </div>
     </div>
   );
-}
+});

--- a/apps/web/components/upload/upload-drop-zone.tsx
+++ b/apps/web/components/upload/upload-drop-zone.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, DragEvent, ClipboardEvent, useEffect, useCallback } f
 import { Upload, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { showToast } from '@/components/ui/toast';
 import { UPLOAD } from '@sploot/common';
 
@@ -179,21 +180,27 @@ export function UploadDropZone({
             <Upload className={cn('size-10 transition-colors', isDragging ? 'text-sploot-blue' : 'text-muted-foreground')} strokeWidth={2.5} />
           </div>
 
-          <h2
-            className="text-4xl md:text-5xl mb-3 tracking-wider"
-            style={{ fontFamily: "var(--font-bebas-neue)" }}
-          >
+          <h2 className="font-display text-4xl md:text-5xl mb-3 tracking-wider lowercase">
             {isDragging ? (
-              <span className="text-sploot-blue">DROP MEMES HERE</span>
+              <span className="text-sploot-blue">drop it in the pile</span>
             ) : (
-              <span className="text-muted-foreground">DRAG & DROP MEMES</span>
+              <span className="text-muted-foreground">drag chaos here</span>
             )}
           </h2>
-          <p className="text-sm text-muted-foreground mb-4">
-            or click to browse • paste an image or its url
+          <p className="font-mono text-xs text-muted-foreground mb-5">
+            jpeg, png, webp, gif, mp4, webm · zips &amp; bookmark exports too · max {UPLOAD.maxSizeMB}mb per file
           </p>
-          <p className="font-mono text-xs text-muted-foreground">
-            JPEG, PNG, WebP, GIF, MP4, WebM • zips & bookmark exports too • Max {UPLOAD.maxSizeMB}MB per file
+          <Button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              fileInputRef.current?.click();
+            }}
+          >
+            pick files
+          </Button>
+          <p className="text-xs text-muted-foreground mt-3">
+            or click anywhere here to browse • paste an image or its url
           </p>
         </CardContent>
       </Card>

--- a/apps/web/components/upload/upload-file-list.tsx
+++ b/apps/web/components/upload/upload-file-list.tsx
@@ -95,10 +95,10 @@ export function UploadFileList({
                 transform: `translateY(${virtualItem.start}px)`,
               }}
             >
-              <Card className="h-[60px] p-3 flex items-center rounded-md">
+              <Card className="h-[60px] p-3 flex items-center rounded-[var(--sploot-radius-inner)] border-2 border-sploot-ink shadow-none">
                 <div className="flex items-center gap-3 w-full">
                   {/* File icon/preview */}
-                  <div className="w-12 h-12 bg-muted flex items-center justify-center overflow-hidden flex-shrink-0 rounded">
+                  <div className="w-12 h-12 bg-sploot-paper-warm flex items-center justify-center overflow-hidden flex-shrink-0 rounded-[calc(var(--sploot-radius-inner)-2px)] border-2 border-sploot-ink">
                     {file.blobUrl ? (
                       <Image
                         src={file.blobUrl}
@@ -127,15 +127,15 @@ export function UploadFileList({
                     {file.status === 'uploading' && (
                       <div className="flex items-center gap-2">
                         <Progress value={file.progress} className="w-24 h-1" />
-                        <Badge variant="default" className="gap-1">
+                        <span className="sploot-sticker-shadow inline-flex items-center gap-1 rounded-[var(--sploot-radius-pill)] border-2 border-sploot-ink bg-sploot-yellow px-2 py-0.5 font-mono text-[0.65rem] font-bold text-sploot-ink">
                           <Loader2 className="size-3 animate-spin" />
                           {file.progress}%
-                        </Badge>
+                        </span>
                       </div>
                     )}
 
                     {file.status === 'queued' && (
-                      <Badge variant="outline">Queued</Badge>
+                      <span className="font-mono text-xs lowercase text-muted-foreground">queued</span>
                     )}
 
                     {file.status === 'success' && (
@@ -190,7 +190,7 @@ export function UploadFileList({
                     )}
 
                     {file.status === 'pending' && (
-                      <Badge variant="outline">Waiting...</Badge>
+                      <span className="font-mono text-xs lowercase text-muted-foreground">waiting…</span>
                     )}
                   </div>
                 </div>

--- a/apps/web/components/upload/upload-file-list.tsx
+++ b/apps/web/components/upload/upload-file-list.tsx
@@ -127,7 +127,7 @@ export function UploadFileList({
                     {file.status === 'uploading' && (
                       <div className="flex items-center gap-2">
                         <Progress value={file.progress} className="w-24 h-1" />
-                        <span className="sploot-sticker-shadow inline-flex items-center gap-1 rounded-[var(--sploot-radius-pill)] border-2 border-sploot-ink bg-sploot-yellow px-2 py-0.5 font-mono text-[0.65rem] font-bold text-sploot-ink">
+                        <span className="sploot-sticker-shadow inline-flex items-center gap-1 rounded-[var(--sploot-radius-pill)] border-2 border-sploot-ink bg-sploot-yellow px-2 py-0.5 font-mono text-[0.65rem] font-bold text-[#1c1547]">
                           <Loader2 className="size-3 animate-spin" />
                           {file.progress}%
                         </span>

--- a/apps/web/components/upload/upload-zone.tsx
+++ b/apps/web/components/upload/upload-zone.tsx
@@ -42,6 +42,7 @@ import { logger } from '@/lib/logger';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { StickerTab } from '@/components/sploot';
 import { UPLOAD, prepareImageForUpload } from '@sploot/common';
 
 // Lightweight metadata for display - only ~300 bytes per file vs 5MB for File object
@@ -1227,8 +1228,30 @@ export function UploadZone({
     router.push('/app');
   };
 
+  // "the queue" state summary — mono, right-aligned, only the nonzero buckets.
+  const queuedCount = uploadStats
+    ? Math.max(0, uploadStats.totalFiles - uploadStats.uploaded - uploadStats.failed)
+    : 0;
+  const queueSummary = uploadStats
+    ? [
+        uploadStats.ready > 0 ? `${uploadStats.ready} in the pile` : null,
+        uploadStats.processingEmbeddings > 0 ? `${uploadStats.processingEmbeddings} cooking` : null,
+        queuedCount > 0 ? `${queuedCount} queued` : null,
+        uploadStats.failed > 0 ? `${uploadStats.failed} failed` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    : '';
+
   return (
-    <div className="w-full">
+    <div className="w-full space-y-5">
+      <div className="space-y-1.5">
+        <StickerTab tone="violet">upload</StickerTab>
+        <h1 className="font-display text-4xl leading-[0.95] text-foreground sm:text-5xl">
+          feed <em className="not-italic text-sploot-magenta">the pile</em>
+        </h1>
+      </div>
+
       {/* Recovery notification */}
       {showRecoveryNotification && (
         <Alert className="mb-4 animate-in fade-in duration-200">
@@ -1252,7 +1275,14 @@ export function UploadZone({
 
       {/* File list */}
       {filesArray.length > 0 && (
-        <div className="mt-6 space-y-4">
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h2 className="font-display text-2xl tracking-wide text-foreground">the queue</h2>
+            {queueSummary && (
+              <span className="font-mono text-xs lowercase text-muted-foreground">{queueSummary}</span>
+            )}
+          </div>
+
           {/* Batch Upload Progress Header */}
           <UploadBatchProgressCard
             files={filesArray}

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 const eslintConfig = [
   ...nextCoreWebVitals,
   {
-    ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts"],
+    ignores: ["node_modules/**", ".next/**", ".next-*/**", "out/**", "build/**", "next-env.d.ts"],
   },
 ];
 

--- a/apps/web/lib/types/index.ts
+++ b/apps/web/lib/types/index.ts
@@ -16,6 +16,9 @@ export interface AssetEmbedding {
   assetId: string;
   modelName: string;
   modelVersion?: string;
+  // pending | processing | ready | failed — the API returns the full row,
+  // so a present embedding is NOT necessarily a ready one.
+  status?: string | null;
   createdAt: Date | string;
 }
 

--- a/apps/web/scripts/qa-spine-shots.ts
+++ b/apps/web/scripts/qa-spine-shots.ts
@@ -1,0 +1,77 @@
+/* one-off: authed shots of the spine-converged views, both themes.
+   usage: SPLOOT_QA_AUTH_SECRET=... pnpm exec tsx scripts/qa-spine-shots.ts <base> <outdir> */
+import { chromium } from '@playwright/test';
+import { createQaLocalAuthToken } from '../lib/auth/qa-local';
+import fs from 'node:fs';
+
+const base = process.argv[2] ?? 'http://localhost:3474';
+const out = process.argv[3] ?? '/tmp/spine-shots';
+fs.mkdirSync(out, { recursive: true });
+
+async function main() {
+  const token = await createQaLocalAuthToken({
+    userId: 'qa-design-user',
+    secret: process.env.SPLOOT_QA_AUTH_SECRET!,
+  });
+
+  const browser = await chromium.launch();
+  const problems: string[] = [];
+
+  for (const theme of ['light', 'dark'] as const) {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    await ctx.addCookies([
+      { name: 'sploot_qa_auth', value: token, url: base },
+      { name: 'sploot-theme', value: theme, url: base },
+    ]);
+
+    // find a real asset id via the authed API
+    const probe = await ctx.newPage();
+    await probe.goto(`${base}/app`, { waitUntil: 'networkidle' });
+    const assetId = await probe.evaluate(async () => {
+      const r = await fetch('/api/assets?limit=1');
+      if (!r.ok) return null;
+      const j = await r.json();
+      return j?.assets?.[0]?.id ?? j?.data?.[0]?.id ?? null;
+    });
+    await probe.close();
+    if (!assetId) problems.push(`${theme}: could not resolve an asset id from /api/assets`);
+
+    const routes: Array<[string, string]> = [
+      ['/app', 'feed'],
+      ...(assetId ? ([[`/app/meme/${assetId}`, 'detail']] as Array<[string, string]>) : []),
+      ['/app/upload', 'upload'],
+      ['/app/settings', 'settings'],
+    ];
+    for (const [route, name] of routes) {
+      const page = await ctx.newPage();
+      const errors: string[] = [];
+      page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+      page.on('pageerror', (e) => errors.push(String(e)));
+      await page.goto(`${base}${route}`, { waitUntil: 'networkidle' });
+      await page.evaluate((t) => {
+        document.documentElement.classList.toggle('dark', t === 'dark');
+      }, theme);
+      await page.waitForTimeout(600);
+      await page.screenshot({ path: `${out}/${name}-${theme}.png`, fullPage: false });
+      const hs = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+      if (hs > 6) problems.push(`${name}-${theme}: hscroll +${hs}px`);
+      // same exemption as qa-theme-walk: seeded broken-blob telemetry 400s
+      const realErrors = errors.filter((e) => !/favicon|manifest|apple-touch|400 \(Bad Request\)/i.test(e));
+      if (realErrors.length) problems.push(`${name}-${theme}: ${realErrors.slice(0, 2).join(' | ')}`);
+      await page.close();
+    }
+    await ctx.close();
+  }
+
+  await browser.close();
+  if (problems.length) {
+    console.error('PROBLEMS:\n' + problems.join('\n'));
+    process.exit(1);
+  }
+  console.log(`clean: shots in ${out}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/backlog.d/060-upload-redirect-hooks-crash.md
+++ b/backlog.d/060-upload-redirect-hooks-crash.md
@@ -1,0 +1,34 @@
+# 060 — /app/upload redirect crashes the library page (hooks-order violation)
+
+Status: todo
+Created: 2026-07-10
+
+## Goal
+
+Visiting `/app/upload` while authed (server redirect → `/app?upload=1`,
+i.e. library page mounting with the upload panel open) throws React's
+"Rendered more hooks than during the previous render" and the page
+recovers into the empty state instead of the user's pile. Reproduced
+identically on master (clean worktree rig, 2026-07-10) — pre-existing,
+NOT introduced by the spine convergence. Root-cause and fix the hook-order
+violation.
+
+## Acceptance oracle
+
+- Repro first: authed Playwright visit to `/app/upload` (QA rig:
+  pgvector + qa:seed + SPLOOT_QA_AUTH_MODE=enabled) captures the console
+  error before the fix and zero hooks errors after.
+- The library renders the user's assets (not the empty state) when
+  arriving via `/app/upload` / `?upload=1`.
+- The offending component's hooks are unconditional; no test or gate is
+  weakened.
+
+## Notes
+
+- Trigger is the upload-panel-open-on-mount path; plain `/app` is clean.
+- Evidence: session 31f4d9fa scratchpad spine-shots/master-shots runs
+  (branch and master both error on upload-light/upload-dark walks).
+- The `/app/upload` → `/app?upload=1` redirect dates to the original
+  subtree import; likely suspects are components mounted only when
+  `showUploadPanel` initializes true (UploadZone subtree) calling a hook
+  conditionally, or a suspense/remount seam in `AppPageClient`.

--- a/explorations/lab-035-spine/README.md
+++ b/explorations/lab-035-spine/README.md
@@ -55,3 +55,28 @@ Survivors + 18 mutations from their originating lanes: LAND drill-down
 around the live demo pile (HALL/IMPEC ×2 each), NAV (AFD/HALL ×2 each),
 DET head-to-head refinements (AFD/TASTE ×2 each), UP (AFD/HALL ×2 each),
 SET (AFD refine + blend, IMPEC ×2). FEED is locked and awaits convergence.
+
+### Round 2 verdicts (operator delegated the pick, 2026-07-10: "use your
+best judgment and ship it")
+
+- **LAND: IMPEC-LAND-3** — keeps both survivors' DNA (IMPEC copy tower ×
+  HALL console-crowned demo) with the searchable wall above the fold;
+  grafted HALL-LAND-3's honest reshuffle microcopy. Converged with
+  today's static starter-pile demo and honest copy; the 1,000-classic
+  live corpus is backlog 059.
+- **NAV: AFD-NAV-1** as endorsed in round 1 — mutations traded away
+  affordances (help control, visible sort chip) for marginal density.
+- **FEED: AFD-FEED-1** (operator lock). Convergence found production
+  already satisfies it: masonry, object-contain uncropped tiles, in-card
+  action rail, and pile chips already exist (PileFilterRail).
+- **DET: AFD-DET-3** — similar-saves with score pills living in the
+  sticky sidebar answers the related-memes defect most directly; grafted
+  TASTE-DET-4's "ranked by cosine similarity" microcopy. Action trio
+  unified to identical IconButton grammar (banger/share/delete).
+- **UP: AFD-UP-1** unchanged — both AFD mutations quietly demoted the
+  winning dropzone-dominant mouth into a cramped bar.
+- **SET: AFD-SET-4** (SET-1 calm column + SET-2 stat row) with
+  IMPEC-SET-3's token-scope-chip content graft. The typed-DELETE danger
+  gate was skipped honestly: no destructive account flow exists yet.
+
+Converged via branch feat/spine-convergence. Lab closed.

--- a/scripts/design-ratchet-baseline.json
+++ b/scripts/design-ratchet-baseline.json
@@ -24,7 +24,6 @@
     "apps/web/app/styleguide/page.tsx": 4
   },
   "tileActionGrammar": {
-    "apps/web/app/app/page.tsx": 5,
     "apps/web/components/library/share-button.tsx": 2
   },
   "legacyNames": {}


### PR DESCRIPTION
## Summary

Converges the lab-035 "spine" winners into the real pages, within the locked toybox system. Operator delegated the round-2 picks ("use your best judgment and ship it"); the full verdict ledger lives in `explorations/lab-035-spine/README.md`.

- **Landing = IMPEC-LAND-3**: sticky copy tower beside the meme-finder console crowning a scored demo wall; honest copy for today's static starter-pile demo (live 1,000-classic corpus is backlog 059). Yellow CTA band text pinned to the allowlisted `#1c1547` for dark AA.
- **Chrome = AFD-NAV-1**: two-row command bar — wide search pill + upload, then tabs/sort/shuffle with a mono "N in the pile · M cooking" readout; help (+`?` dialog) promoted to the global mast.
- **Feed = AFD-FEED-1 (operator lock)**: production already satisfied it (masonry, object-contain uncropped tiles, in-card rails, pile chips) — zero churn.
- **Detail = AFD-DET-3**: editorial split with sticky sidebar — identical-grammar banger/share/delete trio (fixes the mixed raised/flat defect), stat toys, and always-present "similar saves" with score pills ("ranked by cosine similarity").
- **Upload = AFD-UP-1**: "feed the pile" with a dominant dropzone and a stateful queue in the blue/yellow/mono/magenta grammar.
- **Settings = AFD-SET-4**: "the knobs" — three-stat candy row over the calm one-card-per-concern column; token scope chips grafted from IMPEC-SET-3.

## Evidence

- CI-parity gates green locally: lint, type-check, `lint:design` (ratchet shrank: tileActionGrammar page.tsx 5→0), 1088/1088 web tests against pgvector, extension build.
- `qa-theme-walk`: 16/16 walks clean both themes.
- New `qa-spine-shots.ts`: authed feed/detail/upload/settings both themes — clean after fixing a detail sidebar hscroll (+175px, long model name without break opportunity).
- Known pre-existing issue carded, not fixed here: `/app/upload` redirect crashes with a React hooks-order error — reproduced identically on a clean **master** worktree rig (`backlog.d/060-upload-redirect-hooks-crash.md`).

Backlog: backlog.d/032-adopt-design-system-and-landing-pass.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)