### PR TITLE
fix(web): repair production migration drift

### DIFF
--- a/apps/web/__tests__/lib/embedding-dimension-contract.test.ts
+++ b/apps/web/__tests__/lib/embedding-dimension-contract.test.ts
@@ -35,7 +35,13 @@ describe('embedding dimension contract', () => {
     );
     expect(migrationSql).toContain(`TYPE vector(${EMBEDDING_DIMENSION})`);
     expect(migrationSql).toContain(`"image_embedding"::vector(${EMBEDDING_DIMENSION})`);
-    expect(migrationSql).toContain(`current_dimensions <> ${EMBEDDING_DIMENSION}`);
+    expect(migrationSql).toContain('IF NOT FOUND THEN');
+    expect(migrationSql).toContain('ELSIF current_typmod = -1 THEN');
+    expect(migrationSql).toContain(
+      `vector_dims("image_embedding") <> ${EMBEDDING_DIMENSION}`
+    );
+    expect(migrationSql).toContain(`ELSIF current_typmod <> ${EMBEDDING_DIMENSION}`);
+    expect(migrationSql).toContain('Cannot constrain image_embedding to vector(768)');
     expect(migrationSql).toContain('Cannot automatically convert % existing image embeddings');
     expect(migrationSql).toContain('20260610195422_add_text_embedding_cache');
   });

--- a/apps/web/prisma/migrations/20260610195422_add_text_embedding_cache/migration.sql
+++ b/apps/web/prisma/migrations/20260610195422_add_text_embedding_cache/migration.sql
@@ -1,5 +1,11 @@
+-- This migration first reached production after several of its schema changes
+-- had already been applied out of band. Guard only those known pre-applied
+-- operations so `migrate resolve --rolled-back` can safely replay them; keep
+-- genuinely absent objects as plain CREATEs so incompatible partial state fails.
+BEGIN;
+
 -- DropIndex
-DROP INDEX "asset_embeddings_hnsw_idx";
+DROP INDEX IF EXISTS "asset_embeddings_hnsw_idx";
 
 -- AlterTable
 ALTER TABLE "asset_embeddings" ALTER COLUMN "updatedAt" DROP DEFAULT;
@@ -31,14 +37,120 @@ CREATE TABLE "text_embedding_cache" (
 -- CreateIndex
 CREATE INDEX "text_embedding_cache_expires_at_idx" ON "text_embedding_cache"("expires_at");
 
--- CreateIndex
-CREATE INDEX "asset_embeddings_status_createdAt_idx" ON "asset_embeddings"("status", "createdAt");
+-- CreateIndex. Production already has this exact index from an out-of-band
+-- schema sync; reject any same-named but incompatible object.
+DO $$
+DECLARE
+    existing_index_definition TEXT;
+    expected_index_definition TEXT := format(
+        'CREATE INDEX %I ON %I.%I USING btree (status, "createdAt")',
+        'asset_embeddings_status_createdAt_idx',
+        current_schema(),
+        'asset_embeddings'
+    );
+BEGIN
+    SELECT indexdef
+    INTO existing_index_definition
+    FROM pg_indexes
+    WHERE schemaname = current_schema()
+      AND tablename = 'asset_embeddings'
+      AND indexname = 'asset_embeddings_status_createdAt_idx';
+
+    IF existing_index_definition IS NULL THEN
+        CREATE INDEX "asset_embeddings_status_createdAt_idx"
+            ON "asset_embeddings"("status", "createdAt");
+    ELSIF existing_index_definition <> expected_index_definition THEN
+        RAISE EXCEPTION
+            'Existing asset_embeddings_status_createdAt_idx is incompatible: %',
+            existing_index_definition;
+    END IF;
+END $$;
 
 -- RenameIndex
-ALTER INDEX "unique_user_checksum" RENAME TO "assets_owner_user_id_checksum_sha256_key";
+DO $$
+DECLARE
+    old_exists BOOLEAN;
+    target_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relkind = 'i'
+          AND c.relname = 'unique_user_checksum'
+    ) INTO old_exists;
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relkind = 'i'
+          AND c.relname = 'assets_owner_user_id_checksum_sha256_key'
+    ) INTO target_exists;
+
+    IF old_exists AND target_exists THEN
+        RAISE EXCEPTION 'Both source and target checksum indexes exist';
+    ELSIF NOT target_exists THEN
+        ALTER INDEX "unique_user_checksum"
+            RENAME TO "assets_owner_user_id_checksum_sha256_key";
+    END IF;
+END $$;
 
 -- RenameIndex
-ALTER INDEX "unique_user_tag" RENAME TO "tags_owner_user_id_name_key";
+DO $$
+DECLARE
+    old_exists BOOLEAN;
+    target_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relkind = 'i'
+          AND c.relname = 'unique_user_tag'
+    ) INTO old_exists;
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relkind = 'i'
+          AND c.relname = 'tags_owner_user_id_name_key'
+    ) INTO target_exists;
+
+    IF old_exists AND target_exists THEN
+        RAISE EXCEPTION 'Both source and target tag indexes exist';
+    ELSIF NOT target_exists THEN
+        ALTER INDEX "unique_user_tag"
+            RENAME TO "tags_owner_user_id_name_key";
+    END IF;
+END $$;
 
 -- RenameIndex
-ALTER INDEX "unique_provider_subject" RENAME TO "user_identities_provider_provider_subject_key";
+DO $$
+DECLARE
+    old_exists BOOLEAN;
+    target_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relkind = 'i'
+          AND c.relname = 'unique_provider_subject'
+    ) INTO old_exists;
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relkind = 'i'
+          AND c.relname = 'user_identities_provider_provider_subject_key'
+    ) INTO target_exists;
+
+    IF old_exists AND target_exists THEN
+        RAISE EXCEPTION 'Both source and target provider indexes exist';
+    ELSIF NOT target_exists THEN
+        ALTER INDEX "unique_provider_subject"
+            RENAME TO "user_identities_provider_provider_subject_key";
+    END IF;
+END $$;
+
+COMMIT;

--- a/apps/web/prisma/migrations/20260610195422_add_text_embedding_cache/migration.sql
+++ b/apps/web/prisma/migrations/20260610195422_add_text_embedding_cache/migration.sql
@@ -69,88 +69,95 @@ END $$;
 -- RenameIndex
 DO $$
 DECLARE
-    old_exists BOOLEAN;
-    target_exists BOOLEAN;
+    old_names TEXT[] := ARRAY[
+        'unique_user_checksum',
+        'unique_user_tag',
+        'unique_provider_subject'
+    ];
+    target_names TEXT[] := ARRAY[
+        'assets_owner_user_id_checksum_sha256_key',
+        'tags_owner_user_id_name_key',
+        'user_identities_provider_provider_subject_key'
+    ];
+    table_names TEXT[] := ARRAY['assets', 'tags', 'user_identities'];
+    column_definitions TEXT[] := ARRAY[
+        'owner_user_id, checksum_sha256',
+        'owner_user_id, name',
+        'provider, provider_subject'
+    ];
+    position INTEGER;
+    old_definition TEXT;
+    target_definition TEXT;
+    expected_old_definition TEXT;
+    expected_target_definition TEXT;
 BEGIN
-    SELECT EXISTS (
-        SELECT 1 FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = current_schema()
-          AND c.relkind = 'i'
-          AND c.relname = 'unique_user_checksum'
-    ) INTO old_exists;
-    SELECT EXISTS (
-        SELECT 1 FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = current_schema()
-          AND c.relkind = 'i'
-          AND c.relname = 'assets_owner_user_id_checksum_sha256_key'
-    ) INTO target_exists;
+    FOR position IN 1..array_length(old_names, 1) LOOP
+        old_definition := NULL;
+        target_definition := NULL;
 
-    IF old_exists AND target_exists THEN
-        RAISE EXCEPTION 'Both source and target checksum indexes exist';
-    ELSIF NOT target_exists THEN
-        ALTER INDEX "unique_user_checksum"
-            RENAME TO "assets_owner_user_id_checksum_sha256_key";
-    END IF;
-END $$;
-
--- RenameIndex
-DO $$
-DECLARE
-    old_exists BOOLEAN;
-    target_exists BOOLEAN;
-BEGIN
-    SELECT EXISTS (
-        SELECT 1 FROM pg_class c
+        SELECT pg_get_indexdef(c.oid)
+        INTO old_definition
+        FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = current_schema()
           AND c.relkind = 'i'
-          AND c.relname = 'unique_user_tag'
-    ) INTO old_exists;
-    SELECT EXISTS (
-        SELECT 1 FROM pg_class c
+          AND c.relname = old_names[position];
+
+        SELECT pg_get_indexdef(c.oid)
+        INTO target_definition
+        FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = current_schema()
           AND c.relkind = 'i'
-          AND c.relname = 'tags_owner_user_id_name_key'
-    ) INTO target_exists;
+          AND c.relname = target_names[position];
 
-    IF old_exists AND target_exists THEN
-        RAISE EXCEPTION 'Both source and target tag indexes exist';
-    ELSIF NOT target_exists THEN
-        ALTER INDEX "unique_user_tag"
-            RENAME TO "tags_owner_user_id_name_key";
-    END IF;
-END $$;
+        expected_old_definition := format(
+            'CREATE UNIQUE INDEX %I ON %I.%I USING btree (%s)',
+            old_names[position],
+            current_schema(),
+            table_names[position],
+            column_definitions[position]
+        );
+        expected_target_definition := format(
+            'CREATE UNIQUE INDEX %I ON %I.%I USING btree (%s)',
+            target_names[position],
+            current_schema(),
+            table_names[position],
+            column_definitions[position]
+        );
 
--- RenameIndex
-DO $$
-DECLARE
-    old_exists BOOLEAN;
-    target_exists BOOLEAN;
-BEGIN
-    SELECT EXISTS (
-        SELECT 1 FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = current_schema()
-          AND c.relkind = 'i'
-          AND c.relname = 'unique_provider_subject'
-    ) INTO old_exists;
-    SELECT EXISTS (
-        SELECT 1 FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = current_schema()
-          AND c.relkind = 'i'
-          AND c.relname = 'user_identities_provider_provider_subject_key'
-    ) INTO target_exists;
+        IF old_definition IS NOT NULL AND target_definition IS NOT NULL THEN
+            RAISE EXCEPTION
+                'Both source % and target % indexes exist',
+                old_names[position],
+                target_names[position];
+        ELSIF target_definition IS NOT NULL THEN
+            IF target_definition <> expected_target_definition THEN
+                RAISE EXCEPTION
+                    'Existing target index % is incompatible: %',
+                    target_names[position],
+                    target_definition;
+            END IF;
+        ELSE
+            IF old_definition IS NULL THEN
+                RAISE EXCEPTION
+                    'Neither source % nor target % index exists',
+                    old_names[position],
+                    target_names[position];
+            ELSIF old_definition <> expected_old_definition THEN
+                RAISE EXCEPTION
+                    'Existing source index % is incompatible: %',
+                    old_names[position],
+                    old_definition;
+            END IF;
 
-    IF old_exists AND target_exists THEN
-        RAISE EXCEPTION 'Both source and target provider indexes exist';
-    ELSIF NOT target_exists THEN
-        ALTER INDEX "unique_provider_subject"
-            RENAME TO "user_identities_provider_provider_subject_key";
-    END IF;
+            EXECUTE format(
+                'ALTER INDEX %I RENAME TO %I',
+                old_names[position],
+                target_names[position]
+            );
+        END IF;
+    END LOOP;
 END $$;
 
 COMMIT;

--- a/apps/web/prisma/migrations/20260704000000_fix_embedding_vector_dimension/migration.sql
+++ b/apps/web/prisma/migrations/20260704000000_fix_embedding_vector_dimension/migration.sql
@@ -1,14 +1,16 @@
 -- Align the versioned schema with the active CLIP embedding width.
--- Production was already altered out-of-band to vector(768), so this migration
--- guards on pgvector's typmod and is a no-op there. Fresh or stale empty
--- databases that still have vector(512) are corrected through migrate deploy.
+-- Production may still carry an unbounded `vector` column even when every
+-- stored value is 768-dimensional. Distinguish that state from a missing
+-- column, prove the existing rows are compatible, and only then constrain it.
+-- Fresh or stale empty databases with another bounded width are also repaired.
 DO $$
 DECLARE
-  current_dimensions INTEGER;
-  non_null_embedding_count INTEGER;
+  current_typmod INTEGER;
+  incompatible_embedding_count BIGINT;
+  non_null_embedding_count BIGINT;
 BEGIN
-  SELECT NULLIF(a.atttypmod, -1)
-  INTO current_dimensions
+  SELECT a.atttypmod
+  INTO current_typmod
   FROM pg_attribute a
   INNER JOIN pg_class c ON c.oid = a.attrelid
   INNER JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -17,9 +19,28 @@ BEGIN
     AND a.attname = 'image_embedding'
     AND NOT a.attisdropped;
 
-  IF current_dimensions IS NULL THEN
+  IF NOT FOUND THEN
     RAISE EXCEPTION 'asset_embeddings.image_embedding column not found';
-  ELSIF current_dimensions <> 768 THEN
+  ELSIF current_typmod = -1 THEN
+    -- Unbounded `vector` columns may already contain correctly-sized data.
+    -- Prove every existing row is compatible before constraining the typmod.
+    SELECT COUNT(*)
+    INTO incompatible_embedding_count
+    FROM "asset_embeddings"
+    WHERE "image_embedding" IS NOT NULL
+      AND vector_dims("image_embedding") <> 768;
+
+    IF incompatible_embedding_count > 0 THEN
+      RAISE EXCEPTION
+        'Cannot constrain image_embedding to vector(768): % existing embeddings have a different dimension.',
+        incompatible_embedding_count;
+    END IF;
+
+    DROP INDEX IF EXISTS "asset_embeddings_hnsw_idx";
+    ALTER TABLE "asset_embeddings"
+      ALTER COLUMN "image_embedding" TYPE vector(768)
+      USING "image_embedding"::vector(768);
+  ELSIF current_typmod <> 768 THEN
     SELECT COUNT(*)
     INTO non_null_embedding_count
     FROM "asset_embeddings"
@@ -29,7 +50,7 @@ BEGIN
       RAISE EXCEPTION
         'Cannot automatically convert % existing image embeddings from vector(%) to vector(768); re-embed or backfill explicitly before this migration.',
         non_null_embedding_count,
-        current_dimensions;
+        current_typmod;
     END IF;
 
     -- The canonical migration history already dropped asset_embeddings_hnsw_idx


### PR DESCRIPTION
## Summary

- make the failed text-embedding-cache migration replay safely across the exact known production index drift
- distinguish an unbounded pgvector column from a missing column and constrain it only after all stored vectors prove 768-dimensional
- update the dimension contract test for the fail-closed branches

## Evidence

- fresh 11-migration replay: pass
- production-like drift replay: pass
- compatible non-null unbounded vector -> vector(768): pass
- incompatible vector remains unchanged and migration fails: pass
- lint, type-check, design gate: pass
- web: 111 files / 1,078 tests pass against pgvector
- extension build: pass
- two independent fresh critics: no blocking gap

## Production sequence

Merge durable source first, confirm the exact-SHA DigitalOcean build and old healthy release, then use Prisma `migrate resolve --rolled-back` (never `--applied`) before startup runs `migrate deploy`. The 14.3 MB vector rewrite is guarded by a long-transaction preflight and live post-schema checks.

Agent: sploot-cutover-implementer
Agent-Surface: Codex
Agent-Model: openai/gpt-5
Agent-Task: bastion-921