### PR TITLE
fix(web): make mobile gallery and navbar touch-safe

### DIFF
--- a/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
+++ b/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import sharp from 'sharp';
+import { GET } from '@/app/api/cron/regenerate-thumbnails/route';
+import { NextRequest } from 'next/server';
+
+// Mock next/headers
+const mockHeaders = vi.fn();
+vi.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+}));
+
+// Mock lib/db
+const mockPrisma = {
+  asset: {
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+};
+
+let mockDatabaseAvailable = true;
+
+vi.mock('@/lib/db', () => ({
+  get prisma() {
+    return mockDatabaseAvailable ? mockPrisma : null;
+  },
+  get databaseAvailable() {
+    return mockDatabaseAvailable;
+  },
+}));
+
+// Mock @vercel/blob — uploads must not hit the network
+const mockPut = vi.fn();
+const mockDel = vi.fn();
+vi.mock('@vercel/blob', () => ({
+  put: (...args: unknown[]) => mockPut(...args),
+  del: (...args: unknown[]) => mockDel(...args),
+}));
+
+global.fetch = vi.fn();
+
+interface FetchMock {
+  mockResolvedValueOnce(value: unknown): FetchMock;
+}
+
+const fetchMock = global.fetch as unknown as FetchMock;
+
+function makeRequest(query = '') {
+  return new NextRequest(`http://localhost/api/cron/regenerate-thumbnails${query}`);
+}
+
+async function png(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: { width, height, channels: 3, background: { r: 40, g: 80, b: 200 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+function fetchResponse(buffer: Buffer) {
+  return {
+    ok: true,
+    arrayBuffer: async () => buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+  };
+}
+
+describe('/api/cron/regenerate-thumbnails', () => {
+  const CRON_SECRET = 'test-cron-secret';
+
+  const baseAsset = {
+    id: 'asset-1',
+    blobUrl: 'https://blob.example/original.png',
+    thumbnailUrl: 'https://blob.example/original-thumb.png',
+    pathname: 'user/original.png',
+    mime: 'image/png',
+    width: 800,
+    height: 1000,
+  };
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = CRON_SECRET;
+    mockDatabaseAvailable = true;
+    vi.clearAllMocks();
+    mockHeaders.mockReturnValue({
+      get: vi.fn((key: string) =>
+        key === 'authorization' ? `Bearer ${CRON_SECRET}` : null
+      ),
+    });
+    mockPut.mockResolvedValue({
+      url: 'https://blob.example/original-thumb-new.png',
+      pathname: 'user/original-thumb-new.png',
+    });
+    mockDel.mockResolvedValue(undefined);
+    mockPrisma.asset.update.mockResolvedValue({});
+  });
+
+  it('rejects requests without the cron secret', async () => {
+    mockHeaders.mockReturnValue({ get: vi.fn(() => null) });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('regenerates a legacy square-cropped thumbnail from the original', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const legacySquareThumb = await png(256, 256); // the pre-fix crop
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce(fetchResponse(legacySquareThumb))
+      .mockResolvedValueOnce(fetchResponse(original));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.regenerated).toBe(1);
+    expect(body.failed).toBe(0);
+
+    // the uploaded replacement preserves the original's aspect
+    const uploadedBuffer = mockPut.mock.calls[0][1] as Buffer;
+    const meta = await sharp(uploadedBuffer).metadata();
+    expect(Math.abs(meta.width! / meta.height! - 800 / 1000)).toBeLessThan(0.02);
+
+    expect(mockPrisma.asset.update).toHaveBeenCalledWith({
+      where: { id: 'asset-1' },
+      data: {
+        thumbnailUrl: 'https://blob.example/original-thumb-new.png',
+        thumbnailPath: 'user/original-thumb-new.png',
+      },
+    });
+    expect(mockDel).toHaveBeenCalledWith('https://blob.example/original-thumb.png');
+  });
+
+  it('regenerates when the stored thumbnail has disappeared', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce(fetchResponse(original));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.regenerated).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(mockPrisma.asset.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips thumbnails whose aspect already matches the original', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const correctThumb = await png(205, 256); // 800/1000 aspect at 256 edge
+    fetchMock.mockResolvedValueOnce(fetchResponse(correctThumb));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(body.alreadyCorrect).toBe(1);
+    expect(body.regenerated).toBe(0);
+    expect(mockPut).not.toHaveBeenCalled();
+    expect(mockPrisma.asset.update).not.toHaveBeenCalled();
+  });
+
+  it('reports failures without aborting the batch and pages via cursor', async () => {
+    const second = { ...baseAsset, id: 'asset-2' };
+    const third = { ...baseAsset, id: 'asset-3' };
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset, second, third]);
+    const correctThumb = await png(205, 256);
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 404 }) // asset-1 thumb gone
+      .mockResolvedValueOnce({ ok: false, status: 503 }) // asset-1 original unavailable
+      .mockResolvedValueOnce(fetchResponse(correctThumb)); // asset-2 fine
+
+    const res = await GET(makeRequest('?limit=2'));
+    const body = await res.json();
+
+    expect(body.scanned).toBe(2);
+    expect(body.failed).toBe(1);
+    expect(body.failures[0].id).toBe('asset-1');
+    expect(body.alreadyCorrect).toBe(1);
+    expect(body.nextCursor).toBe('asset-2'); // third candidate signals more work
+  });
+});

--- a/apps/web/__tests__/components/chrome/navbar.test.tsx
+++ b/apps/web/__tests__/components/chrome/navbar.test.tsx
@@ -5,8 +5,19 @@ import React from 'react';
 
 // Mock child components
 vi.mock('@/components/chrome/user-avatar', () => ({
-  UserAvatar: ({ onSignOut }: { onSignOut?: () => void }) => (
-    <button data-testid="user-avatar" onClick={onSignOut}>
+  UserAvatar: ({
+    onSignOut,
+    className,
+  }: {
+    onSignOut?: () => void;
+    className?: string;
+  }) => (
+    <button
+      aria-label="User menu"
+      data-testid="user-avatar"
+      className={`${className ?? ''} max-sm:size-[var(--sploot-touch-target)]`}
+      onClick={onSignOut}
+    >
       User Avatar
     </button>
   ),
@@ -69,11 +80,15 @@ describe('Navbar', () => {
       expect(nav).toHaveClass('fixed', 'top-0', 'left-0', 'right-0');
     });
 
-    it('should have correct height (48px mobile, 64px desktop)', () => {
+    it('reserves a touch-safe rail instead of clipping compact controls', () => {
       render(<Navbar />);
 
       const nav = screen.getByRole('navigation');
-      expect(nav).toHaveClass('h-12', 'md:h-16');
+      expect(nav).toHaveClass(
+        'h-auto',
+        'min-h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)]',
+        'md:min-h-[calc(4rem+env(safe-area-inset-top)+3px)]'
+      );
     });
 
     it('should have correct z-index for layering', () => {
@@ -103,6 +118,24 @@ describe('Navbar', () => {
       const nav = screen.getByRole('navigation');
       expect(nav).toHaveClass('custom-navbar-class');
     });
+
+    it('keeps all navbar controls centered inside a touch-safe mobile chrome rail', () => {
+      render(<Navbar />);
+
+      const nav = screen.getByRole('navigation');
+      const help = screen.getByRole('button', { name: 'keyboard shortcuts' });
+      const theme = screen.getByRole('button', { name: 'switch theme' });
+      const auth = screen.getByRole('button', { name: 'User menu' });
+
+      expect(nav).toHaveClass(
+        'min-h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)]',
+        'md:min-h-[calc(4rem+env(safe-area-inset-top)+3px)]',
+        'items-center'
+      );
+      for (const control of [help, theme, auth]) {
+        expect(control).toHaveClass('max-sm:size-[var(--sploot-touch-target)]');
+      }
+    });
   });
 
   describe('Callbacks', () => {
@@ -124,18 +157,26 @@ describe('NavbarSpacer', () => {
 
     const spacer = container.firstChild as HTMLElement;
     expect(spacer).toBeInTheDocument();
-    expect(spacer).toHaveClass('h-[calc(3rem+env(safe-area-inset-top))]', 'md:h-[calc(4rem+env(safe-area-inset-top))]');
+    expect(spacer).toHaveClass(
+      'h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)]',
+      'md:h-[calc(4rem+env(safe-area-inset-top)+3px)]'
+    );
   });
 
-  it('should match navbar height (48px mobile, 64px desktop)', () => {
+  it('keeps the spacer aligned with the touch-safe navbar rail', () => {
     const { container: navbarContainer } = render(<Navbar />);
     const { container: spacerContainer } = render(<NavbarSpacer />);
 
     const navbar = navbarContainer.querySelector('nav');
     const spacer = spacerContainer.firstChild as HTMLElement;
 
-    // Navbar has responsive height, spacer includes safe area inset
-    expect(navbar).toHaveClass('h-12', 'md:h-16');
-    expect(spacer).toHaveClass('h-[calc(3rem+env(safe-area-inset-top))]', 'md:h-[calc(4rem+env(safe-area-inset-top))]');
+    expect(navbar).toHaveClass(
+      'min-h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)]',
+      'md:min-h-[calc(4rem+env(safe-area-inset-top)+3px)]'
+    );
+    expect(spacer).toHaveClass(
+      'h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)]',
+      'md:h-[calc(4rem+env(safe-area-inset-top)+3px)]'
+    );
   });
 });

--- a/apps/web/__tests__/components/library/image-tile-aspect.test.tsx
+++ b/apps/web/__tests__/components/library/image-tile-aspect.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ImgHTMLAttributes } from 'react';
+import { BlobCircuitBreakerProvider } from '@/contexts/blob-circuit-breaker-context';
+import { ImageTile } from '@/components/library/image-tile';
+import type { Asset } from '@/lib/types';
+
+type MockImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fill?: boolean;
+  sizes?: string;
+  unoptimized?: boolean;
+};
+
+vi.mock('next/image', () => ({
+  default: ({ fill: _fill, sizes: _sizes, unoptimized: _unoptimized, ...props }: MockImageProps) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt ?? ''} />
+  ),
+}));
+
+const landscapeAsset: Asset = {
+  id: 'asset-landscape',
+  ownerUserId: 'user-1',
+  blobUrl: 'https://example.com/original-landscape.jpg',
+  thumbnailUrl: 'https://example.com/cropped-landscape-thumb.jpg',
+  pathname: 'landscape.jpg',
+  filename: 'landscape.jpg',
+  mime: 'image/jpeg',
+  size: 42_000,
+  checksumSha256: 'checksum-landscape',
+  width: 1600,
+  height: 900,
+  favorite: false,
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  deletedAt: null,
+  tags: [],
+};
+
+describe('uncropped gallery media contract', () => {
+  it('falls back to the original when a stored thumbnail has the wrong aspect ratio', () => {
+    render(
+      <BlobCircuitBreakerProvider>
+        <ImageTile asset={landscapeAsset} />
+      </BlobCircuitBreakerProvider>
+    );
+
+    const image = screen.getByAltText('landscape.jpg');
+    Object.defineProperties(image, {
+      naturalWidth: { configurable: true, value: 256 },
+      naturalHeight: { configurable: true, value: 256 },
+    });
+
+    fireEvent.load(image);
+
+    expect(screen.getByAltText('landscape.jpg')).toHaveAttribute(
+      'src',
+      landscapeAsset.blobUrl
+    );
+  });
+
+  it('keeps a thumbnail when its natural aspect matches the source', () => {
+    render(
+      <BlobCircuitBreakerProvider>
+        <ImageTile asset={landscapeAsset} />
+      </BlobCircuitBreakerProvider>
+    );
+
+    const image = screen.getByAltText('landscape.jpg');
+    Object.defineProperties(image, {
+      naturalWidth: { configurable: true, value: 1600 },
+      naturalHeight: { configurable: true, value: 900 },
+    });
+
+    fireEvent.load(image);
+
+    expect(screen.getByAltText('landscape.jpg')).toHaveAttribute(
+      'src',
+      landscapeAsset.thumbnailUrl
+    );
+  });
+
+  it('uses the original blob when source dimensions are unavailable', () => {
+    const assetWithoutDimensions = { ...landscapeAsset, width: null, height: null };
+
+    render(
+      <BlobCircuitBreakerProvider>
+        <ImageTile asset={assetWithoutDimensions} />
+      </BlobCircuitBreakerProvider>
+    );
+
+    expect(screen.getByAltText('landscape.jpg')).toHaveAttribute(
+      'src',
+      assetWithoutDimensions.blobUrl
+    );
+  });
+});

--- a/apps/web/app/api/cron/regenerate-thumbnails/route.ts
+++ b/apps/web/app/api/cron/regenerate-thumbnails/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { headers } from 'next/headers';
+import { put, del } from '@vercel/blob';
+import sharp from 'sharp';
+import { prisma } from '@/lib/db';
+import { generateThumbnail } from '@/lib/image-processing';
+import { withObservability } from '@/lib/with-observability';
+import { logger } from '@/lib/observability-logger';
+
+/**
+ * GET /api/cron/regenerate-thumbnails?limit=25&cursor=<assetId>
+ *
+ * Backfill for backlog 058: thumbnails generated before the fit:'inside'
+ * fix (2026-07-10, d27ffad) are square center-crops — the grid shows those
+ * memes cropped forever until their stored thumbnail file is regenerated
+ * from the original. CSS cannot uncrop a cropped file.
+ *
+ * For each candidate asset the stored thumbnail's real aspect is compared
+ * against the original's stored width/height; on mismatch (>2%) the
+ * thumbnail is regenerated from the original blob, uploaded under a fresh
+ * pathname (cache-safe), the asset row updated, and the old blob deleted
+ * best-effort. Idempotent: already-correct thumbnails are skipped, so
+ * repeated runs converge to all-skips.
+ *
+ * Authorization: Bearer token from CRON_SECRET (same contract as the other
+ * cron routes; triggerable as a DigitalOcean job where $CRON_SECRET
+ * resolves). Batched via limit/cursor so a driver loops until done.
+ */
+
+const ASPECT_TOLERANCE = 0.02;
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const SUPPORTED_THUMBNAIL_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+
+type OutputFormat = 'jpeg' | 'webp' | 'png';
+
+function formatForMime(mime: string): OutputFormat {
+  if (mime === 'image/webp') return 'webp';
+  if (mime === 'image/png') return 'png';
+  return 'jpeg';
+}
+
+function thumbPathname(pathname: string, format: OutputFormat): string {
+  const extension = format === 'jpeg' ? 'jpg' : format;
+  if (/\.[^/.]+$/.test(pathname)) {
+    return pathname.replace(/\.[^/.]+$/, `-thumb.${extension}`);
+  }
+  return `${pathname}-thumb.${extension}`;
+}
+
+async function getHandler(request: NextRequest) {
+  const authHeader = (await headers()).get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) {
+    return NextResponse.json({ error: 'CRON_SECRET not configured' }, { status: 500 });
+  }
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!prisma) {
+    return NextResponse.json({ error: 'Database unavailable' }, { status: 503 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  const limit = Math.min(
+    Math.max(Number(params.get('limit')) || DEFAULT_LIMIT, 1),
+    MAX_LIMIT
+  );
+  const cursor = params.get('cursor');
+
+  const candidates = await prisma.asset.findMany({
+    where: {
+      deletedAt: null,
+      thumbnailUrl: { not: null },
+      width: { gt: 0 },
+      height: { gt: 0 },
+      mime: { in: SUPPORTED_THUMBNAIL_MIMES },
+    },
+    orderBy: { id: 'asc' },
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    select: {
+      id: true,
+      blobUrl: true,
+      thumbnailUrl: true,
+      pathname: true,
+      mime: true,
+      width: true,
+      height: true,
+    },
+  });
+
+  const hasMore = candidates.length > limit;
+  const batch = candidates.slice(0, limit);
+
+  let regenerated = 0;
+  let alreadyCorrect = 0;
+  let failed = 0;
+  const failures: Array<{ id: string; reason: string }> = [];
+
+  for (const asset of batch) {
+    try {
+      const originalAspect = asset.width! / asset.height!;
+
+      const thumbRes = await fetch(asset.thumbnailUrl!);
+      if (thumbRes.ok) {
+        const thumbBuffer = Buffer.from(await thumbRes.arrayBuffer());
+        const thumbMeta = await sharp(thumbBuffer).metadata();
+        if (!thumbMeta.width || !thumbMeta.height) throw new Error('thumbnail unreadable');
+
+        const thumbAspect = thumbMeta.width / thumbMeta.height;
+        if (Math.abs(thumbAspect - originalAspect) / originalAspect <= ASPECT_TOLERANCE) {
+          alreadyCorrect++;
+          continue;
+        }
+      } else if (thumbRes.status !== 404) {
+        throw new Error(`thumbnail fetch ${thumbRes.status}`);
+      }
+
+      // Legacy crop confirmed — regenerate from the original.
+      const originalRes = await fetch(asset.blobUrl);
+      if (!originalRes.ok) throw new Error(`original fetch ${originalRes.status}`);
+      const originalBuffer = Buffer.from(await originalRes.arrayBuffer());
+
+      const format = formatForMime(asset.mime);
+      const newThumb = await generateThumbnail(originalBuffer, format);
+      const blob = await put(thumbPathname(asset.pathname, format), newThumb, {
+        access: 'public',
+        // fresh pathname per run — old CDN entries can't shadow the fix
+        addRandomSuffix: true,
+        contentType: `image/${format === 'jpeg' ? 'jpeg' : format}`,
+      });
+
+      const oldThumbUrl = asset.thumbnailUrl!;
+      await prisma.asset.update({
+        where: { id: asset.id },
+        data: { thumbnailUrl: blob.url, thumbnailPath: blob.pathname },
+      });
+
+      // best-effort: drop the orphaned cropped thumbnail
+      try {
+        await del(oldThumbUrl);
+      } catch {
+        // orphan cleanup is non-critical; audit-assets sweeps blobs daily
+      }
+
+      regenerated++;
+    } catch (error) {
+      failed++;
+      failures.push({
+        id: asset.id,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const summary = {
+    scanned: batch.length,
+    regenerated,
+    alreadyCorrect,
+    failed,
+    failures: failures.slice(0, 10),
+    nextCursor: hasMore ? batch[batch.length - 1].id : null,
+  };
+
+  logger.logInfo('regenerate-thumbnails batch complete', summary);
+  return NextResponse.json(summary);
+}
+
+export const GET = withObservability(getHandler, {
+  operation: 'cron:regenerate-thumbnails',
+});

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -729,7 +729,7 @@ select:focus-visible {
 }
 
 .sploot-ctl:active {
-  transform: translate(1px, 1px) scale(0.92, 0.88);
+  transform: translate(1px, 1px) scale(0.96);
   background: var(--sploot-magenta);
   color: #1c1547;
   box-shadow: none;

--- a/apps/web/components/chrome/chrome-spacers.tsx
+++ b/apps/web/components/chrome/chrome-spacers.tsx
@@ -1,10 +1,5 @@
 /**
- * Spacer component to account for fixed navbar height
+ * Backward-compatible import path for the canonical navbar spacer.
+ * Keeping one height contract prevents the fixed chrome from covering the feed.
  */
-
-/**
- * Spacer for navbar height (56px)
- */
-export function NavbarSpacer() {
-  return <div className="h-12 md:h-14" />;
-}
+export { NavbarSpacer } from './navbar';

--- a/apps/web/components/chrome/navbar.tsx
+++ b/apps/web/components/chrome/navbar.tsx
@@ -2,7 +2,6 @@
 
 import { ReactNode } from 'react';
 import Link from 'next/link';
-import { HelpCircle } from 'lucide-react';
 import { UserAvatar } from './user-avatar';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { PileMark, IconButton } from '@/components/sploot';
@@ -19,10 +18,9 @@ interface NavbarProps {
 }
 
 /**
- * Fixed navbar component for the new architecture
- * Height: 64px (16 * 4px base unit)
- * Position: Fixed top
- * Z-index: 50 (stays above main content)
+ * Fixed navbar component for the new architecture.
+ * The row always reserves the mobile touch-target height plus breathing room
+ * so compact controls stay centered instead of fighting the bottom rule.
  */
 export function Navbar({
   children,
@@ -44,10 +42,10 @@ export function Navbar({
         'fixed top-0 left-0 right-0',
         // Z-index to stay above content
         'z-50',
-        // Height: 48px mobile, 64px desktop
-        'h-12 md:h-16',
+        // Height: touch-safe mobile rail + breathing room; 64px desktop rail
+        'h-auto min-h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)] md:min-h-[calc(4rem+env(safe-area-inset-top)+3px)]',
         // iOS PWA safe area support - push navbar below status bar/notch
-        'pt-[env(safe-area-inset-top)]',
+        'pt-[env(safe-area-inset-top)] pb-1.5 md:py-2',
         'pl-[env(safe-area-inset-left)]',
         'pr-[env(safe-area-inset-right)]',
         // Background and border — toybox chrome: opaque paper shelf with a
@@ -62,7 +60,7 @@ export function Navbar({
       )}
     >
       {/* Container for navbar content - max-width for ultra-wide screens */}
-      <div className="flex items-center justify-between w-full max-w-screen-2xl 2xl:max-w-[1920px] mx-auto">
+      <div className="flex min-h-[var(--sploot-touch-target)] w-full max-w-screen-2xl items-center justify-between mx-auto 2xl:max-w-[1920px]">
         {/* Left section: SPLOOT branding with pile mark */}
         <Link
           href="/app"
@@ -86,23 +84,31 @@ export function Navbar({
 
         {/* Right section: Status line, help, theme toggle, and user menu —
             compact ink-mini icon buttons share identical grammar. */}
-        <div className="flex items-center gap-2 md:gap-3">
+        <div className="flex min-h-[var(--sploot-touch-target)] items-center gap-2 md:gap-3">
           {/* Terminal-style status line */}
           {statusLine}
 
-          {/* Help control */}
-          <IconButton label="keyboard shortcuts" onClick={openHelp}>
-            <HelpCircle />
+          {/* Help control — bare glyph in a circular ink-mini: the circled
+              HelpCircle icon inside a squared shell read as a frame-in-a-
+              frame, and the square shells fought the round avatar. The mast
+              family is circles. */}
+          <IconButton label="keyboard shortcuts" onClick={openHelp} className="!rounded-full">
+            <span aria-hidden="true" className="font-mono text-[15px] font-black leading-none">
+              ?
+            </span>
           </IconButton>
 
           {/* Theme toggle */}
-          <ThemeToggle />
+          <ThemeToggle className="!rounded-full" />
 
-          {/* User avatar - 32px circle with 8px margin from right edge */}
+          {/* User avatar — joins the mast family: same diameter as the
+              ink-mini controls, same 2px ink ring, instead of the bare
+              Clerk disc that read as a foreign object. */}
           {showUserAvatar && (
             <UserAvatar
-              className="mr-2"  // 8px margin from right edge
-              avatarSize="md"   // 32px size
+              className="mr-2"
+              avatarClassName="size-[34px] max-sm:size-[var(--sploot-touch-target)] border-2 border-sploot-ink"
+              avatarSize="md"
               showDropdown={true}
               onSignOut={onSignOut}
             />
@@ -124,5 +130,7 @@ export function Navbar({
  * Accounts for both navbar height (64px/4rem) and iOS safe area inset
  */
 export function NavbarSpacer() {
-  return <div className="h-[calc(3rem+env(safe-area-inset-top))] md:h-[calc(4rem+env(safe-area-inset-top))]" />;
+  return (
+    <div className="h-[calc(var(--sploot-touch-target)+0.75rem+env(safe-area-inset-top)+3px)] md:h-[calc(4rem+env(safe-area-inset-top)+3px)]" />
+  );
 }

--- a/apps/web/components/chrome/user-avatar.tsx
+++ b/apps/web/components/chrome/user-avatar.tsx
@@ -19,6 +19,8 @@ import { cn } from '@/lib/utils';
 
 interface UserAvatarProps {
   className?: string;
+  /** Extra classes for the avatar disc itself (e.g. the navbar's ink ring). */
+  avatarClassName?: string;
   avatarSize?: 'sm' | 'md' | 'lg';
   showDropdown?: boolean;
   onSignOut?: () => void;
@@ -30,6 +32,7 @@ interface UserAvatarProps {
  */
 export function UserAvatar({
   className,
+  avatarClassName,
   avatarSize = 'md',
   showDropdown = true,
   onSignOut,
@@ -82,14 +85,15 @@ export function UserAvatar({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
+          type="button"
           className={cn(
             // 44px hit area on phones regardless of the avatar's visual size
-            'inline-grid cursor-pointer place-items-center focus-visible:outline-none max-sm:size-[var(--sploot-touch-target)]',
+            'inline-grid cursor-pointer place-items-center focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-[3px] focus-visible:outline-sploot-focus max-sm:size-[var(--sploot-touch-target)]',
             className
           )}
           aria-label="User menu"
         >
-          <Avatar className={sizeClasses[avatarSize]}>
+          <Avatar className={cn(sizeClasses[avatarSize], avatarClassName)}>
             <AvatarImage
               src={user?.imageUrl}
               alt={getUserDisplay()}

--- a/apps/web/components/library/image-tile.tsx
+++ b/apps/web/components/library/image-tile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState, useEffect, memo } from 'react';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, SyntheticEvent } from 'react';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { error as logError } from '@/lib/logger';
@@ -17,6 +17,8 @@ import { isAnimatedImageMimeType, isVideoMimeType } from '@sploot/common';
 import { resolveQaSeedSrc } from '@/lib/qa/qa-image-loader';
 import { SIMILARITY_MATCH_BOUNDARY, SIMILARITY_NEAR_BOUNDARY } from '@/lib/search-config';
 import { postBlobLoadFailure } from '@/lib/telemetry-client';
+
+const THUMBNAIL_ASPECT_TOLERANCE = 0.02;
 
 interface ImageTileProps {
   asset: Asset;
@@ -45,12 +47,16 @@ function ImageTileComponent({
 }: ImageTileProps) {
   const isVideo = isVideoMimeType(asset.mime);
   const isAnimatedImage = isAnimatedImageMimeType(asset.mime);
+  const originalSrc = resolveQaSeedSrc(asset.blobUrl);
+  const thumbnailSrc = asset.thumbnailUrl ? resolveQaSeedSrc(asset.thumbnailUrl) : null;
+  const hasSourceDimensions = (asset.width ?? 0) > 0 && (asset.height ?? 0) > 0;
+  const initialImageSrc = hasSourceDimensions
+    ? getTileImageSrc(asset.mime, asset.blobUrl, asset.thumbnailUrl)
+    : originalSrc;
   const [isLoading, setIsLoading] = useState(false);
   const [imageError, setImageError] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
-  const [imageSrc, setImageSrc] = useState(() =>
-    getTileImageSrc(asset.mime, asset.blobUrl, asset.thumbnailUrl)
-  );
+  const [imageSrc, setImageSrc] = useState(initialImageSrc);
   const [hasTriedFallback, setHasTriedFallback] = useState(false);
   const [isGeneratingEmbedding, setIsGeneratingEmbedding] = useState(false);
   const [hasEmbedding, setHasEmbedding] = useState(!!asset.embedding);
@@ -79,12 +85,21 @@ function ImageTileComponent({
   // Reset image src when asset changes (e.g., component reused)
   useEffect(() => {
     queueMicrotask(() => {
-      setImageSrc(getTileImageSrc(asset.mime, asset.blobUrl, asset.thumbnailUrl));
+      setImageSrc(initialImageSrc);
       setHasTriedFallback(false);
       setImageError(false);
       setImageLoaded(false);
     });
-  }, [asset.id, asset.blobUrl, asset.thumbnailUrl, asset.mime]);
+  }, [
+    asset.id,
+    asset.blobUrl,
+    asset.thumbnailUrl,
+    asset.mime,
+    asset.width,
+    asset.height,
+    preserveAspectRatio,
+    initialImageSrc,
+  ]);
 
   // Simulate queue position in debug mode
   useEffect(() => {
@@ -360,6 +375,35 @@ function ImageTileComponent({
     void postBlobLoadFailure(hasTriedFallback).catch(() => {});
   };
 
+  const handleImageLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    const image = event.currentTarget;
+    const sourceAspect = asset.width && asset.height ? asset.width / asset.height : null;
+    const thumbnailAspect = image.naturalWidth && image.naturalHeight
+      ? image.naturalWidth / image.naturalHeight
+      : null;
+    const thumbnailIsCropped =
+      imageSrc === thumbnailSrc &&
+      !!originalSrc &&
+      !hasTriedFallback &&
+      sourceAspect !== null &&
+      thumbnailAspect !== null &&
+      Math.abs(thumbnailAspect - sourceAspect) / sourceAspect > THUMBNAIL_ASPECT_TOLERANCE;
+
+    if (thumbnailIsCropped) {
+      logger.logInfo('image-tile.thumbnail-aspect-fallback', {
+        assetId: asset.id,
+        sourceAspect,
+        thumbnailAspect,
+      });
+      setHasTriedFallback(true);
+      setImageSrc(originalSrc);
+      return;
+    }
+
+    setImageLoaded(true);
+    recordBlobSuccess();
+  };
+
   return (
     <>
       <div
@@ -459,18 +503,15 @@ function ImageTileComponent({
                   // for no benefit — serve it directly. The detail/share pages
                   // stay optimized. See ADR-008.
                   unoptimized
-                  onLoad={() => {
-                    setImageLoaded(true);
-                    recordBlobSuccess();
-                  }}
+                  onLoad={handleImageLoad}
                   onError={() => {
                     // If thumbnail failed and we haven't tried the main blob yet
-                    if (imageSrc === asset.thumbnailUrl && asset.blobUrl && !hasTriedFallback) {
+                    if (imageSrc === thumbnailSrc && originalSrc && !hasTriedFallback) {
                       logger.logInfo('image-tile.thumbnail-fallback', {
                         assetId: asset.id,
                       });
                       setHasTriedFallback(true);
-                      setImageSrc(asset.blobUrl);
+                      setImageSrc(originalSrc);
                       // Don't set imageError yet - give the fallback a chance
                       return;
                     }
@@ -608,10 +649,15 @@ function arePropsEqual(prevProps: ImageTileProps, nextProps: ImageTileProps) {
   // Always re-render if asset ID changed (different image)
   if (prevProps.asset.id !== nextProps.asset.id) return false;
 
-  // Re-render if URLs changed
+  // Re-render if URLs, metadata, or media dimensions changed
   if (prevProps.asset.blobUrl !== nextProps.asset.blobUrl) return false;
   if (prevProps.asset.thumbnailUrl !== nextProps.asset.thumbnailUrl) return false;
   if (prevProps.asset.mime !== nextProps.asset.mime) return false;
+  if (prevProps.asset.filename !== nextProps.asset.filename) return false;
+  if (prevProps.asset.pathname !== nextProps.asset.pathname) return false;
+  if (prevProps.asset.size !== nextProps.asset.size) return false;
+  if (prevProps.asset.width !== nextProps.asset.width) return false;
+  if (prevProps.asset.height !== nextProps.asset.height) return false;
 
   // Re-render if favorite status changed
   if (prevProps.asset.favorite !== nextProps.asset.favorite) return false;
@@ -630,8 +676,8 @@ function arePropsEqual(prevProps: ImageTileProps, nextProps: ImageTileProps) {
   if (prevProps.showSimilarityScore !== nextProps.showSimilarityScore) return false;
 
   // Re-render if similarity score changed (for search results)
-  const prevSimilarity = (prevProps.asset as any).similarity;
-  const nextSimilarity = (nextProps.asset as any).similarity;
+  const prevSimilarity = prevProps.asset.similarity;
+  const nextSimilarity = nextProps.asset.similarity;
   if (prevSimilarity !== nextSimilarity) return false;
 
   // Ignore function prop changes - they're stable via useCallback (see JSDoc above)

--- a/apps/web/components/sploot/icon-button.tsx
+++ b/apps/web/components/sploot/icon-button.tsx
@@ -47,7 +47,10 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
             : 'size-[34px] max-sm:size-[var(--sploot-touch-target)]',
           chip &&
             'rounded-[var(--sploot-radius-pill)] bg-sploot-panel shadow-[0_2px_0_var(--sploot-shadow-color)] hover:shadow-[2px_4px_0_var(--sploot-shadow-color)] active:shadow-none',
-          pressed && 'bg-sploot-yellow text-[#1c1547]',
+          // !important: .sploot-ctl's own background is declared later in the
+          // sheet and silently wins otherwise (the tile rails already work
+          // around this with ! overrides)
+          pressed && '!bg-sploot-yellow !text-[#1c1547]',
           className
         )}
         {...props}

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -6,7 +6,7 @@ import { useTheme } from 'next-themes';
 
 import { IconButton } from '@/components/sploot';
 
-export function ThemeToggle() {
+export function ThemeToggle({ className }: { className?: string }) {
   // resolvedTheme, not theme: with the default "system" preference, `theme`
   // stays "system" while the page actually renders dark — the control must
   // reflect the resolved state or it misreports on dark-OS machines.
@@ -19,7 +19,7 @@ export function ThemeToggle() {
   }, []);
 
   if (!mounted) {
-    return <IconButton label="switch theme" disabled />;
+    return <IconButton label="switch theme" disabled className={className} />;
   }
 
   const isDark = resolvedTheme === 'dark';
@@ -28,6 +28,7 @@ export function ThemeToggle() {
     <IconButton
       label="switch theme"
       pressed={isDark}
+      className={className}
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >
       {isDark ? <Moon /> : <Sun />}

--- a/apps/web/lib/image-processing.ts
+++ b/apps/web/lib/image-processing.ts
@@ -5,13 +5,12 @@ import sharp from 'sharp';
  * Images larger than this will be resized (longest edge)
  */
 export const MAX_IMAGE_DIMENSION = 2048;
-
 /**
- * Thumbnail dimensions for grid view
- * Square thumbnails for consistent grid layout
+ * Maximum edge for grid thumbnails.
+ * The generated thumbnail keeps the source aspect ratio; only its longest
+ * edge is bounded so the gallery never receives a square crop.
  */
 export const THUMBNAIL_SIZE = 256;
-
 /**
  * Quality settings for processed images
  */
@@ -38,7 +37,7 @@ export interface ImageProcessingResult {
  * Process an uploaded image to create optimized versions.
  * Generates:
  * 1. Main image (resized if > 2048px)
- * 2. Thumbnail (256x256 square for grid view)
+ * 2. Thumbnail (longest edge 256px, source aspect preserved for grid view)
  *
  * @param buffer - Raw image buffer
  * @param mimeType - Original file mime type
@@ -166,7 +165,7 @@ async function processMainImage(
  * shows the complete image, so the thumbnail must carry the full frame.
  * fit: 'inside' bounds the longest edge at THUMBNAIL_SIZE without cropping.
  */
-async function generateThumbnail(
+export async function generateThumbnail(
   buffer: Buffer,
   format: 'jpeg' | 'webp' | 'png'
 ): Promise<Buffer> {


### PR DESCRIPTION
## Summary
- Keep gallery media complete for portrait and landscape memes with aspect-preserving frames, original-blob fallback for cropped or metadata-free thumbnails, and a cursor-paged legacy thumbnail backfill.
- Give help, theme, and Clerk auth controls one touch-safe navbar rail with stable pressed-theme geometry and visible keyboard focus.

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm lint:design`
- `CI=1 pnpm --filter web test` — 113 files, 1088 tests passed
- `pnpm --filter extension build`
- Seeded browser QA at 390x844: portrait and landscape assets used `object-fit: contain`; source/frame ratio delta <= 0.016; help/theme/auth controls were 44x44 at top 3/bottom 47 inside a 59px navbar in light and pressed dark themes.

## Backlog
- Powder: `mobile-gallery-header-fixes`.
- `backlog.d/058-regenerate-cropped-thumbnails.md` remains open (`todo`) because production backfill execution and proof are still required; the implementation is isolated in its own commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Images now preserve their original aspect ratio during thumbnail generation.
  - Image tiles automatically fall back to the original image when a thumbnail is missing or incorrectly cropped.
  - Navigation controls and user avatars better support touch-friendly sizing and safe-area spacing.

- **Bug Fixes**
  - Corrected pressed-button styling for more reliable visual feedback.
  - Improved alignment and spacing across mobile and desktop navigation layouts.
  - Added automatic repair of legacy incorrectly cropped thumbnails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->