### PR TITLE
fix(web): isolate migration job build

### DIFF
--- a/apps/web/__tests__/scripts/enrollment-lifecycle.test.ts
+++ b/apps/web/__tests__/scripts/enrollment-lifecycle.test.ts
@@ -142,7 +142,11 @@ describe('strict DigitalOcean response contracts', () => {
     expect(job.run_command).toBe('pnpm --filter web exec node scripts/migrate-deploy.mjs');
     expect(job.github).toEqual(web.github);
     expect(job.source_dir).toBeNull();
-    expect(job.build_command).toBe(web.build_command);
+    expect(job.build_command).toBe(
+      'corepack enable && pnpm install --frozen-lockfile && pnpm --filter web exec prisma generate'
+    );
+    expect(job.build_command).not.toContain('web build');
+    expect(job.build_command).not.toContain('next build');
     expect(job.envs).toEqual([expect.objectContaining({ key: 'DATABASE_URL' })]);
     const lifted = deriveGaLiftSpec(staged);
     expect((lifted.services.find((service: { name?: unknown }) => service.name === 'web') as { envs?: Array<{ key: string; value: string }> }).envs?.find((entry) => entry.key === 'SPLOOT_ENROLLMENT_MODE')?.value).toBe('ga');

--- a/apps/web/scripts/deployment-provider-transaction.mjs
+++ b/apps/web/scripts/deployment-provider-transaction.mjs
@@ -6,6 +6,7 @@ const WEB_SERVICE_NAME = 'web';
 const MIGRATION_JOB_NAME = 'web-pre-deploy-migrate';
 const MIGRATION_JOB_KIND = 'PRE_DEPLOY';
 const SERVICE_RUN_COMMAND = 'pnpm --filter web start';
+const MIGRATION_BUILD_COMMAND = 'corepack enable && pnpm install --frozen-lockfile && pnpm --filter web exec prisma generate';
 const MIGRATION_RUN_COMMAND = 'pnpm --filter web exec node scripts/migrate-deploy.mjs';
 const SOURCE_KEYS = ['github', 'git', 'image'];
 const CLOSED_ALLOWLIST_BINDINGS = new Set([
@@ -437,6 +438,10 @@ export function deriveClosedStageSpec(liveSpec, operatorSpec = liveSpec) {
     job.kind = MIGRATION_JOB_KIND;
     job.run_command = MIGRATION_RUN_COMMAND;
     applySourceDescriptor(job, sourceDescriptor);
+    // App Platform builds jobs as independent components. The migrator needs
+    // dependencies and a generated Prisma client, never the Next.js artifact
+    // or web-only auth bindings.
+    job.build_command = MIGRATION_BUILD_COMMAND;
     if (!Array.isArray(job.envs)) job.envs = [];
     const existing = job.envs.filter((env) => env?.key === 'DATABASE_URL');
     if (existing.length > 1) throw new Error('migration job has duplicate DATABASE_URL bindings');
@@ -450,6 +455,7 @@ export function deriveClosedStageSpec(liveSpec, operatorSpec = liveSpec) {
       envs: [databaseBinding],
     };
     applySourceDescriptor(job, sourceDescriptor);
+    job.build_command = MIGRATION_BUILD_COMMAND;
     jobs.push(job);
   }
   web.run_command = SERVICE_RUN_COMMAND;

--- a/scripts/check-web-deployment-runtime.mjs
+++ b/scripts/check-web-deployment-runtime.mjs
@@ -45,8 +45,8 @@ export function validateWebDeploymentRuntime({
   if (!/merge-gate:[\s\S]*needs:\s*\[[^\]]*web-build/.test(workflow)) {
     failures.push('the production web build must be required by merge-gate');
   }
-  if (!/MIGRATION_JOB_NAME\s*=\s*['"]web-pre-deploy-migrate['"][\s\S]*MIGRATION_JOB_KIND\s*=\s*['"]PRE_DEPLOY['"][\s\S]*SERVICE_RUN_COMMAND\s*=\s*['"]pnpm --filter web start['"][\s\S]*MIGRATION_RUN_COMMAND\s*=\s*['"]pnpm --filter web exec node scripts\/migrate-deploy\.mjs['"]/.test(providerTransaction)) {
-    failures.push('the provider transaction must own one PRE_DEPLOY migrator and a start-only service');
+  if (!/MIGRATION_JOB_NAME\s*=\s*['"]web-pre-deploy-migrate['"][\s\S]*MIGRATION_JOB_KIND\s*=\s*['"]PRE_DEPLOY['"][\s\S]*SERVICE_RUN_COMMAND\s*=\s*['"]pnpm --filter web start['"][\s\S]*MIGRATION_BUILD_COMMAND\s*=\s*['"]corepack enable && pnpm install --frozen-lockfile && pnpm --filter web exec prisma generate['"][\s\S]*MIGRATION_RUN_COMMAND\s*=\s*['"]pnpm --filter web exec node scripts\/migrate-deploy\.mjs['"]/.test(providerTransaction)) {
+    failures.push('the provider transaction must own one migration-only PRE_DEPLOY component and a start-only service');
   }
   if (!/DENIED_RUNTIME_BINDINGS[\s\S]*createWebBuildEnvironment[\s\S]*spawnSync\(['"]pnpm['"],\s*\[['"]--filter['"],\s*['"]web['"],\s*['"]build['"]\]/.test(secretlessBuilder)) {
     failures.push('the CI builder must use an explicit runtime-secret-denied environment');

--- a/scripts/check-web-deployment-runtime.test.mjs
+++ b/scripts/check-web-deployment-runtime.test.mjs
@@ -46,6 +46,6 @@ test('the contract rejects migration at build time and mismatched standalone out
   assert.match(formatFailures(failures), /must not own a second production migration path/);
   assert.match(formatFailures(failures), /CI must execute the production web build/);
   assert.match(formatFailures(failures), /must be required by merge-gate/);
-  assert.match(formatFailures(failures), /provider transaction must own one PRE_DEPLOY migrator/);
+  assert.match(formatFailures(failures), /provider transaction must own one migration-only PRE_DEPLOY component/);
   assert.match(formatFailures(failures), /explicit runtime-secret-denied environment/);
 });


### PR DESCRIPTION
## Summary

- isolate the DigitalOcean PRE_DEPLOY migration component from the Next.js service build
- install locked dependencies and generate Prisma Client for the migration job without compiling web routes
- ratchet the deployment contract and lifecycle tests around the exact migration-only build command

## Production incident addressed

The first normalized closed-mode lifecycle attempt created the intended singleton PRE_DEPLOY job, but DigitalOcean builds each job as an independent source component. Reusing the web build command caused the migration component to execute a Next.js build with only DATABASE_URL bound, so it failed on Clerk-dependent routes before migration. The previously active deployment remained healthy and enrollment remained closed.

This change makes the migration component build only what its runtime needs. It does not broaden secret bindings, does not run migrations from GitHub Actions, and preserves the start-only web service contract.

## Verification

- red: lifecycle test failed while the job inherited the web build command
- green: lifecycle/provider suite: 48/48
- deployment contract suite: 3/3
- exact migration build command with non-DB production bindings blank: exit 0
- pnpm lint: 0 errors (30 pre-existing warnings)
- pnpm type-check
- pnpm lint:design
- secret scan and gitleaks
- pre-commit and pre-push hooks

## Rollout

After CI and independent review, merge while enrollment remains closed, then run the normal lifecycle against the exact merge commit. Acceptance requires the migration-only component build, successful PRE_DEPLOY migration, start-only web service, exact active source readback, healthy endpoints, and closed enrollment proof.