### PR TITLE
fix(web): follow protected route redirects in smoke

### DIFF
--- a/apps/web/docs/deployed-smoke-report.json
+++ b/apps/web/docs/deployed-smoke-report.json
@@ -2,31 +2,34 @@
   "base_url": "https://www.sploot.app",
   "extension_zip": "../extension/dist/extension-1.0.0-chrome.zip",
   "extension_dist": "../extension/dist/chrome-mv3",
-  "started_at": "2026-05-25T19:00:48.853Z",
-  "finished_at": "2026-05-25T19:00:50.803Z",
+  "started_at": "2026-07-15T05:07:16.412Z",
+  "finished_at": "2026-07-15T05:07:17.316Z",
   "status": "pass",
   "checks": [
     {
       "name": "production health",
       "status": "pass",
-      "duration_ms": 421,
+      "duration_ms": 235,
       "details": {
         "database": "up",
-        "redis": "up",
-        "database_latency_ms": 9,
+        "embedding_limiter": "up",
+        "share_slug_cache": "local",
+        "canary_configured": true,
+        "database_latency_ms": 42,
         "version": "0.1.0"
       }
     },
     {
       "name": "production service health",
       "status": "pass",
-      "duration_ms": 395,
+      "duration_ms": 153,
       "details": {
         "status": "degraded",
         "all_services_configured": true,
         "database": "healthy",
         "blob_storage": "healthy",
         "embeddings": "healthy",
+        "canary": "healthy",
         "can_upload": true,
         "can_search": true
       }
@@ -34,23 +37,51 @@
     {
       "name": "signed-out app route protection",
       "status": "pass",
-      "duration_ms": 370,
+      "duration_ms": 402,
       "details": {
         "redirects": [
           {
             "route": "/app",
-            "status": 307,
-            "location": "/sign-in"
+            "redirects": [
+              {
+                "from": "/app",
+                "status": 307,
+                "location": "/sign-in"
+              }
+            ],
+            "signIn": "/sign-in"
           },
           {
             "route": "/app/search",
-            "status": 307,
-            "location": "/sign-in"
+            "redirects": [
+              {
+                "from": "/app/search",
+                "status": 307,
+                "location": "/app"
+              },
+              {
+                "from": "/app",
+                "status": 307,
+                "location": "/sign-in"
+              }
+            ],
+            "signIn": "/sign-in"
           },
           {
             "route": "/app/upload",
-            "status": 307,
-            "location": "/sign-in"
+            "redirects": [
+              {
+                "from": "/app/upload",
+                "status": 307,
+                "location": "/app?upload=1"
+              },
+              {
+                "from": "/app?upload=1",
+                "status": 307,
+                "location": "/sign-in"
+              }
+            ],
+            "signIn": "/sign-in"
           }
         ]
       }
@@ -58,7 +89,7 @@
     {
       "name": "signed-out api auth contract",
       "status": "pass",
-      "duration_ms": 195,
+      "duration_ms": 71,
       "details": {
         "status": 401,
         "error": "Unauthorized"
@@ -67,7 +98,7 @@
     {
       "name": "production extension artifact",
       "status": "pass",
-      "duration_ms": 568,
+      "duration_ms": 41,
       "details": {
         "artifact": "../extension/dist/extension-1.0.0-chrome.zip",
         "artifact_type": "zip",

--- a/apps/web/scripts/smoke-deployed.mjs
+++ b/apps/web/scripts/smoke-deployed.mjs
@@ -6,6 +6,8 @@ import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
+import { assertSignedOutRedirectChain } from './smoke-redirects.mjs';
+
 const execFileAsync = promisify(execFile);
 const baseUrl = (process.env.DEPLOYED_SMOKE_URL ?? 'https://www.sploot.app').replace(/\/$/, '');
 const expectCanaryConfigured = process.env.EXPECT_CANARY_CONFIGURED === '1';
@@ -224,24 +226,12 @@ await record('signed-out app route protection', async () => {
   const redirects = [];
 
   for (const route of protectedRoutes) {
-    const response = await fetch(`${baseUrl}${route}`, {
-      method: 'GET',
-      redirect: 'manual',
-    });
-    const location = response.headers.get('location') ?? '';
-
-    if (![301, 302, 303, 307, 308].includes(response.status)) {
-      throw new Error(`${route}: expected redirect to sign-in, got HTTP ${response.status}`);
-    }
-    if (!location.includes('/sign-in')) {
-      throw new Error(`${route}: expected sign-in redirect, got ${location || '<missing location>'}`);
-    }
-
-    redirects.push({
+    const result = await assertSignedOutRedirectChain({
+      baseUrl,
       route,
-      status: response.status,
-      location,
+      fetchImpl: fetch,
     });
+    redirects.push({ route, ...result });
   }
 
   return { redirects };

--- a/apps/web/scripts/smoke-redirects.mjs
+++ b/apps/web/scripts/smoke-redirects.mjs
@@ -1,0 +1,67 @@
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function routeLabel(url) {
+  return `${url.pathname}${url.search}`;
+}
+
+/**
+ * Prove that a signed-out protected route reaches the deployment's sign-in
+ * page through a short, same-origin, acyclic redirect chain. Legacy route
+ * aliases are applied by Next before Clerk middleware, so requiring the first
+ * hop itself to be /sign-in would reject a correctly protected route.
+ */
+export async function assertSignedOutRedirectChain({
+  baseUrl,
+  route,
+  fetchImpl = fetch,
+  maxHops = 4,
+}) {
+  const deployment = new URL(baseUrl);
+  let current = new URL(route, deployment);
+  if (current.origin !== deployment.origin) {
+    throw new Error(`${route}: protected route is outside the deployment origin`);
+  }
+
+  const seen = new Set([current.href]);
+  const redirects = [];
+
+  for (let hop = 0; hop < maxHops; hop += 1) {
+    const response = await fetchImpl(current.href, {
+      method: 'GET',
+      redirect: 'manual',
+    });
+    const location = response.headers.get('location') ?? '';
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      throw new Error(`${routeLabel(current)}: expected redirect to sign-in, got HTTP ${response.status}`);
+    }
+    if (!location) {
+      throw new Error(`${routeLabel(current)}: redirect is missing location`);
+    }
+
+    const next = new URL(location, current);
+    if (next.origin !== deployment.origin) {
+      throw new Error(`${routeLabel(current)}: redirect left deployment origin for ${next.origin}`);
+    }
+
+    redirects.push({
+      from: routeLabel(current),
+      status: response.status,
+      location,
+    });
+
+    if (next.pathname === '/sign-in' || next.pathname.startsWith('/sign-in/')) {
+      return {
+        redirects,
+        signIn: routeLabel(next),
+      };
+    }
+    if (seen.has(next.href)) {
+      throw new Error(`${route}: redirect cycle detected at ${routeLabel(next)}`);
+    }
+
+    seen.add(next.href);
+    current = next;
+  }
+
+  throw new Error(`${route}: did not reach sign-in within ${maxHops} redirects`);
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "provider:test": "node --test scripts/check-provider-retirement.test.mjs",
     "deployment:check": "node scripts/check-web-deployment-runtime.mjs",
     "deployment:build": "node scripts/build-web-without-runtime-secrets.mjs",
-    "deployment:test": "node --test scripts/check-web-deployment-runtime.test.mjs",
+    "deployment:test": "node --test scripts/check-web-deployment-runtime.test.mjs scripts/smoke-deployed-redirect.test.mjs",
     "release": "semantic-release",
     "release:dry-run": "semantic-release --dry-run --no-ci",
     "clean": "turbo run clean && rm -rf node_modules"

--- a/scripts/smoke-deployed-redirect.test.mjs
+++ b/scripts/smoke-deployed-redirect.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { assertSignedOutRedirectChain } from '../apps/web/scripts/smoke-redirects.mjs';
+
+function redirect(status, location) {
+  return new Response(null, {
+    status,
+    headers: { location },
+  });
+}
+
+test('accepts a same-origin legacy redirect before the sign-in redirect', async () => {
+  const requests = [];
+  const responses = new Map([
+    ['https://sploot.app/app/search', redirect(307, '/app')],
+    ['https://sploot.app/app', redirect(307, '/sign-in')],
+  ]);
+  const fetchImpl = async (url) => {
+    requests.push(url);
+    return responses.get(url) ?? new Response(null, { status: 404 });
+  };
+
+  const result = await assertSignedOutRedirectChain({
+    baseUrl: 'https://sploot.app',
+    route: '/app/search',
+    fetchImpl,
+  });
+
+  assert.deepEqual(requests, [
+    'https://sploot.app/app/search',
+    'https://sploot.app/app',
+  ]);
+  assert.deepEqual(result.redirects.map(({ status, location }) => ({ status, location })), [
+    { status: 307, location: '/app' },
+    { status: 307, location: '/sign-in' },
+  ]);
+});
+
+test('rejects a redirect that escapes the deployment origin', async () => {
+  await assert.rejects(
+    assertSignedOutRedirectChain({
+      baseUrl: 'https://sploot.app',
+      route: '/app',
+      fetchImpl: async () => redirect(307, 'https://attacker.example/sign-in'),
+    }),
+    /left deployment origin/
+  );
+});
+
+test('rejects redirect cycles before exhausting the hop bound', async () => {
+  const responses = new Map([
+    ['https://sploot.app/app/search', redirect(307, '/app')],
+    ['https://sploot.app/app', redirect(307, '/app/search')],
+  ]);
+
+  await assert.rejects(
+    assertSignedOutRedirectChain({
+      baseUrl: 'https://sploot.app',
+      route: '/app/search',
+      fetchImpl: async (url) => responses.get(url),
+    }),
+    /redirect cycle/
+  );
+});
+
+test('rejects a protected route that returns content instead of redirecting', async () => {
+  await assert.rejects(
+    assertSignedOutRedirectChain({
+      baseUrl: 'https://sploot.app',
+      route: '/app',
+      fetchImpl: async () => new Response('private content', { status: 200 }),
+    }),
+    /expected redirect to sign-in, got HTTP 200/
+  );
+});
+
+test('rejects redirects without a location', async () => {
+  await assert.rejects(
+    assertSignedOutRedirectChain({
+      baseUrl: 'https://sploot.app',
+      route: '/app',
+      fetchImpl: async () => new Response(null, { status: 307 }),
+    }),
+    /redirect is missing location/
+  );
+});
+
+test('rejects a same-origin chain that never reaches sign-in within the hop bound', async () => {
+  let hop = 0;
+  await assert.rejects(
+    assertSignedOutRedirectChain({
+      baseUrl: 'https://sploot.app',
+      route: '/app',
+      maxHops: 2,
+      fetchImpl: async () => redirect(307, `/alias-${hop++}`),
+    }),
+    /did not reach sign-in within 2 redirects/
+  );
+});


### PR DESCRIPTION
## Summary

- follow bounded, same-origin redirect chains when proving signed-out app-route protection
- fail closed on content responses, missing locations, cross-origin escapes, cycles, and excessive hops
- ratchet the redirect oracle into the required deployment contract CI job
- refresh the deployed smoke report from the live production surface

## Why

Next applies the intentional legacy aliases for /app/search and /app/upload before Clerk middleware. The previous smoke required the first hop itself to be /sign-in, so it rejected a protected route whose chain was /app/search -> /app -> /sign-in.

## Verification

- red: deployed smoke failed /app/search because the first hop was /app
- pnpm deployment:test: 9/9, including aliases and every fail-closed case
- live deployed smoke: all five checks pass
- pnpm lint: 0 errors, 30 pre-existing warnings
- pnpm type-check
- pnpm lint:design
- pnpm secrets:check and gitleaks
- production remains closed on deployment ddebb4a5 at exact source 81505760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of signed-out access to protected routes, including multi-step redirects to sign-in.
  - Detects invalid redirect responses, missing locations, redirect loops, cross-origin redirects, and chains that do not reach sign-in.
  - Expanded deployment checks to include redirect behavior alongside runtime health checks.

- **Tests**
  - Added automated coverage for valid and invalid redirect scenarios.
  - Updated deployed smoke reports with refreshed health, authentication, routing, and artifact results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->