### PR TITLE
fix(extension): update open popup after web auth

### DIFF
--- a/apps/extension/CLAUDE.md
+++ b/apps/extension/CLAUDE.md
@@ -71,7 +71,9 @@ Every module exports a **simple interface** (1-4 functions) hiding complex imple
 - `logout(): Promise<void>`
 - `setupAuthListeners(): void`
 
-**Critical Detail:** Creates **fresh Clerk client on every call**. Caching clients breaks WebSSO cookie sync. This is intentional.
+**Critical Detail:** The background owns one long-lived Clerk client with its
+event-driven WebSSO cookie listener. It publishes sanitized auth metadata to
+the popup; tokens stay inside the Clerk client and never cross runtime messages.
 
 **`entrypoints/background/image-fetcher.ts`** - CORS-Aware Downloads
 - `fetchImage(url: string): Promise<{ blob: Blob, filename: string }>`
@@ -131,16 +133,17 @@ the full Clerk surface instead of a constrained extension popup.
 
 1. Signed-out popup and background prompts open `${VITE_API_BASE_URL}/sign-in`
    in a new tab
-2. Successful popup state checks still trigger an `AUTH_STATE_UPDATE` broadcast
-   to the background worker
-3. Background lazily calls `createClerkClient` for tokens whenever uploads need them
-4. Context menu prompts poll a fresh Clerk background client until WebSSO syncs
-   the web session into the extension
+2. The background starts one persistent Clerk sync listener and broadcasts
+   `AUTH_STATE_CHANGED` metadata when WebSSO changes
+3. An already-open popup requests the current state and refreshes its own Clerk
+   provider; it does not receive a token or need to be reopened
+4. Context-menu prompts wait on the same event boundary for up to 60 seconds;
+   they do not poll
 
 **Implementation constraints:**
 - Clerk domain must be in manifest `host_permissions`
 - Extension ID must be allowed in Clerk dashboard (via `pnpm setup:clerk`)
-- Fresh Clerk client per call (no caching)
+- One background Clerk client per service-worker lifecycle, recreated on worker restart
 - Web app URLs are centralized in `shared/app-url.ts`
 
 ### RPC Message Pattern
@@ -149,7 +152,7 @@ Cross-context communication now centers on auth state broadcasts:
 
 ```typescript
 chrome.runtime.sendMessage({
-  type: AUTH_MESSAGES.STATE_UPDATE,
+  type: AUTH_MESSAGES.STATE_CHANGED,
   payload: {
     status: 'signed-in',
     userId,
@@ -159,7 +162,9 @@ chrome.runtime.sendMessage({
 });
 ```
 
-Background listeners respond to `AUTH_STATE_UPDATE`, `AUTH_REQUEST_STATE`, and `RUN_AUTH_DIAGNOSTICS`.
+The background responds to `AUTH_REQUEST_STATE` and `RUN_AUTH_DIAGNOSTICS`.
+`AUTH_STATE_CHANGED` is a background-to-popup refresh signal; it contains only
+non-secret session metadata.
 
 ## Code Conventions
 

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -134,6 +134,42 @@ describe('auth-manager', () => {
     });
   });
 
+  it('reuses the listener-owned Clerk client for signed-out queue recovery after worker startup', async () => {
+    const listenerClient = {
+      session: null,
+      addListener: vi.fn((listener: (resources: unknown) => void) => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    };
+    const overwrittenClient = {
+      session: {
+        id: 'overwritten-session',
+        user: { id: 'overwritten-user' },
+        expireAt: null,
+      },
+      addListener: vi.fn(),
+    };
+    let latestClient: typeof listenerClient | typeof overwrittenClient | undefined;
+    createClerkClient.mockImplementation(async () => {
+      latestClient = createClerkClient.mock.calls.length === 1 ? listenerClient : overwrittenClient;
+      return latestClient;
+    });
+
+    const { getAuthAuthority, getAuthTokenForAuthority, setupAuthBridge } = await importAuthManager();
+    setupAuthBridge();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Context-menu startup recovery reads authority immediately after the
+    // bridge starts. A second create would overwrite Clerk's module-global
+    // client and detach the listener that owns the signed-in transition.
+    await expect(getAuthAuthority()).resolves.toBeNull();
+    await expect(getAuthTokenForAuthority({ userId: 'overwritten-user', sessionId: 'overwritten-session' })).resolves.toBeNull();
+    expect(createClerkClient).toHaveBeenCalledTimes(1);
+    expect(latestClient).toBe(listenerClient);
+    expect(clerkListeners).toHaveLength(1);
+  });
+
   it('treats a new session for the same account as the same durable owner', async () => {
     const { sameAccountAuthority } = await importAuthManager();
 

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -338,6 +338,31 @@ describe('auth-manager', () => {
     await expect(signInPromise).resolves.toBe(true)
   })
 
+  it('retries beyond the initial sync window during an active sign-in wait', async () => {
+    const clerk = {
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener)
+        return () => undefined
+      }),
+    }
+    createClerkClient
+      .mockRejectedValueOnce(new Error('sync host unavailable 1'))
+      .mockRejectedValueOnce(new Error('sync host unavailable 2'))
+      .mockRejectedValueOnce(new Error('sync host unavailable 3'))
+      .mockRejectedValueOnce(new Error('sync host unavailable 4'))
+      .mockRejectedValueOnce(new Error('sync host unavailable 5'))
+      .mockResolvedValue(clerk)
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const signInPromise = promptUserSignIn()
+    await vi.waitFor(() => expect(clerkListeners).toHaveLength(1), { timeout: 5000 })
+    clerkListeners[0]({ user: { id: 'late-user' }, session: { id: 'late-session', expireAt: null } })
+
+    await expect(signInPromise).resolves.toBe(true)
+  })
+
   it('resolves sign-in waiters when the persistent Clerk listener observes sign-in', async () => {
     const signedInState: AuthState = {
       status: 'signed-in',

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -132,6 +132,41 @@ describe('auth-manager', () => {
     });
   });
 
+  it('notifies worker subscribers when Clerk state changes', async () => {
+    createClerkClient.mockResolvedValue({
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener)
+        return () => undefined
+      }),
+    })
+
+    const { onAuthStateChanged, setupAuthBridge } = await importAuthManager()
+    const listener = vi.fn()
+    const remove = onAuthStateChanged(listener)
+    setupAuthBridge()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    clerkListeners[0]({
+      user: { id: 'user_subscriber' },
+      session: { id: 'session_subscriber', expireAt: null },
+    })
+    expect(listener).toHaveBeenLastCalledWith({
+      status: 'signed-in',
+      userId: 'user_subscriber',
+      sessionId: 'session_subscriber',
+      expiresAt: null,
+    })
+
+    const callsBeforeRemove = listener.mock.calls.length
+    remove()
+    clerkListeners[0]({
+      user: { id: 'user_after_remove' },
+      session: { id: 'session_after_remove', expireAt: null },
+    })
+    expect(listener).toHaveBeenCalledTimes(callsBeforeRemove)
+  })
+
   it('returns an explicit user/account/session authority for durable owner fencing', async () => {
     createClerkClient.mockResolvedValue({
       session: {

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -29,6 +29,8 @@ interface ChromeMock {
   };
   tabs: {
     create: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -64,6 +66,8 @@ beforeEach(() => {
     },
     tabs: {
       create: vi.fn(),
+      get: vi.fn(),
+      remove: vi.fn(),
     },
   };
 
@@ -236,6 +240,103 @@ describe('auth-manager', () => {
     expect(chromeMock.tabs.create).toHaveBeenCalledWith({ url: 'https://sploot.test/sign-in' });
     expect(chromeMock.action.openPopup).not.toHaveBeenCalled();
   });
+
+  it('closes its owned sign-in tab after successful auth', async () => {
+    createClerkClient.mockResolvedValue({
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener)
+        return () => undefined
+      }),
+    })
+    chromeMock.tabs.create.mockResolvedValue({ id: 77 })
+    chromeMock.tabs.get.mockResolvedValue({ id: 77, url: 'https://sploot.test/sign-in' })
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const signInPromise = promptUserSignIn()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    clerkListeners[0]({ user: { id: 'user_tab' }, session: { id: 'session_tab', expireAt: null } })
+
+    await expect(signInPromise).resolves.toBe(true)
+    expect(chromeMock.tabs.remove).toHaveBeenCalledWith(77)
+  })
+
+  it('does not close a sign-in tab after the user navigates it away', async () => {
+    createClerkClient.mockResolvedValue({
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener)
+        return () => undefined
+      }),
+    })
+    chromeMock.tabs.create.mockResolvedValue({ id: 78 })
+    chromeMock.tabs.get.mockResolvedValue({ id: 78, url: 'https://sploot.test/library' })
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const signInPromise = promptUserSignIn()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    clerkListeners[0]({ user: { id: 'user_tab' }, session: { id: 'session_tab', expireAt: null } })
+
+    await expect(signInPromise).resolves.toBe(true)
+    expect(chromeMock.tabs.remove).not.toHaveBeenCalled()
+  })
+
+  it('closes its owned sign-in tab after the wait aborts', async () => {
+    createClerkClient.mockResolvedValue({ session: null, addListener: vi.fn() })
+    chromeMock.tabs.create.mockResolvedValue({ id: 79 })
+    chromeMock.tabs.get.mockResolvedValue({ id: 79, url: 'https://sploot.test/sign-in' })
+    vi.useFakeTimers()
+    try {
+      const { promptUserSignIn } = await importAuthManager()
+      const signInPromise = promptUserSignIn()
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(60000)
+      await expect(signInPromise).resolves.toBe(false)
+      expect(chromeMock.tabs.remove).toHaveBeenCalledWith(79)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('closes its owned sign-in tab when the wait aborts', async () => {
+    createClerkClient.mockResolvedValue({ session: null, addListener: vi.fn() })
+    chromeMock.tabs.create.mockResolvedValue({ id: 80 })
+    chromeMock.tabs.get.mockResolvedValue({ id: 80, url: 'https://sploot.test/sign-in' })
+
+    const { promptUserSignIn } = await importAuthManager()
+    const controller = new AbortController()
+    const signInPromise = promptUserSignIn(controller.signal)
+    await Promise.resolve()
+    await Promise.resolve()
+    controller.abort()
+
+    await expect(signInPromise).resolves.toBe(false)
+    expect(chromeMock.tabs.remove).toHaveBeenCalledWith(80)
+  })
+
+  it('retries Clerk sync initialization and observes a later web sign-in', async () => {
+    const clerk = {
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener)
+        return () => undefined
+      }),
+    }
+    createClerkClient
+      .mockRejectedValueOnce(new Error('sync host unavailable'))
+      .mockResolvedValue(clerk)
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const signInPromise = promptUserSignIn()
+    await vi.waitFor(() => expect(clerkListeners).toHaveLength(1), { timeout: 1000 })
+    clerkListeners[0]({ user: { id: 'retry-user' }, session: { id: 'retry-session', expireAt: null } })
+
+    await expect(signInPromise).resolves.toBe(true)
+  })
 
   it('resolves sign-in waiters when the persistent Clerk listener observes sign-in', async () => {
     const signedInState: AuthState = {

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -20,8 +20,11 @@ interface ChromeMock {
   };
   runtime: {
     getURL: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+    id: string;
     onMessage: {
       addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
     };
   };
   tabs: {
@@ -31,6 +34,7 @@ interface ChromeMock {
 
 let messageListeners: Array<(message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => boolean>;
 let chromeMock: ChromeMock;
+let clerkListeners: Array<(resources: unknown) => void>;
 
 async function importAuthManager() {
   vi.resetModules();
@@ -49,10 +53,13 @@ beforeEach(() => {
     },
     runtime: {
       getURL: vi.fn(path => `chrome-extension://extension-id/${path}`),
+      sendMessage: vi.fn(async () => undefined),
+      id: 'extension-id',
       onMessage: {
         addListener: vi.fn(listener => {
           messageListeners.push(listener);
         }),
+        removeListener: vi.fn(),
       },
     },
     tabs: {
@@ -62,6 +69,7 @@ beforeEach(() => {
 
   vi.stubGlobal('chrome', chromeMock);
   createClerkClient.mockReset();
+  clerkListeners = [];
 });
 
 describe('auth-manager', () => {
@@ -73,6 +81,11 @@ describe('auth-manager', () => {
         expireAt: new Date('2026-05-18T12:00:00.000Z'),
         getToken: vi.fn(),
       },
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        listener({ session: null });
+        return () => undefined;
+      }),
     });
 
     const { isAuthenticated, setupAuthBridge } = await importAuthManager();
@@ -83,7 +96,7 @@ describe('auth-manager', () => {
     let response: unknown;
     messageListeners[0](
       { type: AUTH_MESSAGES.REQUEST_STATE },
-      {},
+      { id: chromeMock.runtime.id },
       nextResponse => {
         response = nextResponse;
       }
@@ -169,7 +182,7 @@ describe('auth-manager', () => {
   });
 
   it('returns null instead of requesting a token when there is no session', async () => {
-    createClerkClient.mockResolvedValue({ session: null });
+    createClerkClient.mockResolvedValue({ session: null, addListener: vi.fn() });
 
     const { getAuthToken } = await importAuthManager();
 
@@ -177,7 +190,13 @@ describe('auth-manager', () => {
   });
 
   it('opens the Sploot web sign-in page instead of the extension popup', async () => {
-    createClerkClient.mockResolvedValue({ session: null });
+    createClerkClient.mockResolvedValue({
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    });
 
     const { promptUserSignIn, setupAuthBridge } = await importAuthManager();
     setupAuthBridge();
@@ -188,16 +207,10 @@ describe('auth-manager', () => {
     expect(chromeMock.tabs.create).toHaveBeenCalledWith({ url: 'https://sploot.test/sign-in' });
     expect(chromeMock.action.openPopup).not.toHaveBeenCalled();
 
-    const signedInState: AuthState = {
-      status: 'signed-in',
-      userId: 'user_789',
-      sessionId: 'session_789',
-    };
-    messageListeners[0](
-      { type: AUTH_MESSAGES.STATE_UPDATE, payload: signedInState },
-      {},
-      () => undefined
-    );
+    clerkListeners[0]({
+      user: { id: 'user_789' },
+      session: { id: 'session_789', expireAt: null },
+    });
 
     await expect(signInPromise).resolves.toBe(true);
   });
@@ -210,6 +223,10 @@ describe('auth-manager', () => {
         expireAt: new Date('2026-05-18T12:00:00.000Z'),
         getToken: vi.fn(),
       },
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
     });
 
     const { promptUserSignIn } = await importAuthManager();
@@ -220,27 +237,161 @@ describe('auth-manager', () => {
     expect(chromeMock.action.openPopup).not.toHaveBeenCalled();
   });
 
-  it('resolves sign-in waiters when the popup sends a signed-in state update', async () => {
+  it('resolves sign-in waiters when the persistent Clerk listener observes sign-in', async () => {
     const signedInState: AuthState = {
       status: 'signed-in',
       userId: 'user_456',
       sessionId: 'session_456',
     };
+    createClerkClient.mockResolvedValue({
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    });
     const { setupAuthBridge, waitForSignIn } = await importAuthManager();
     setupAuthBridge();
 
     const waitPromise = waitForSignIn(1000);
-    let response: unknown;
-    messageListeners[0](
-      { type: AUTH_MESSAGES.STATE_UPDATE, payload: signedInState },
-      {},
-      nextResponse => {
-        response = nextResponse;
-      }
-    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+    clerkListeners[0]({
+      user: { id: signedInState.userId },
+      session: { id: signedInState.sessionId, expireAt: null },
+    });
 
     await expect(waitPromise).resolves.toBe(true);
-    expect(response).toEqual({ ok: true });
+  });
+
+  it('broadcasts a sanitized Clerk event so an open popup can refresh without polling', async () => {
+    const addListener = vi.fn((listener: (resources: unknown) => void) => {
+      clerkListeners.push(listener);
+      return () => undefined;
+    });
+    createClerkClient.mockResolvedValue({ session: null, addListener });
+
+    const { setupAuthBridge } = await importAuthManager();
+    setupAuthBridge();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    chromeMock.runtime.sendMessage.mockClear();
+
+    const signedInState: AuthState = {
+      status: 'signed-in',
+      userId: 'user_live',
+      sessionId: 'session_live',
+      expiresAt: 1780000000000,
+    };
+    clerkListeners[0]({
+      user: { id: signedInState.userId },
+      session: {
+        id: signedInState.sessionId,
+        expireAt: new Date(signedInState.expiresAt!),
+      },
+      token: 'must-never-cross-the-message-boundary',
+    });
+
+    expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({
+      type: AUTH_MESSAGES.STATE_CHANGED,
+      payload: signedInState,
+    });
+    expect(JSON.stringify(chromeMock.runtime.sendMessage.mock.calls)).not.toContain('must-never-cross');
+  });
+
+  it('does not use a polling interval and cleans up a timed-out waiter', async () => {
+    createClerkClient.mockResolvedValue({ session: null, addListener: vi.fn() });
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    const { waitForSignIn } = await importAuthManager();
+    await expect(waitForSignIn(1)).resolves.toBe(false);
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    setIntervalSpy.mockRestore();
+  });
+
+  it('recreates the event boundary after a service-worker restart', async () => {
+    const makeClerk = (sessionId: string) => ({
+      session: {
+        id: sessionId,
+        user: { id: 'restart-user' },
+        expireAt: null,
+        getToken: vi.fn(),
+      },
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    });
+    createClerkClient.mockResolvedValueOnce(makeClerk('session-before-restart'));
+    const firstWorker = await importAuthManager();
+    firstWorker.setupAuthBridge();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    createClerkClient.mockResolvedValueOnce(makeClerk('session-after-restart'));
+    const restartedWorker = await importAuthManager();
+    restartedWorker.setupAuthBridge();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(createClerkClient).toHaveBeenCalledTimes(2);
+    expect(messageListeners).toHaveLength(2);
+    let response: unknown;
+    messageListeners[1]({ type: AUTH_MESSAGES.REQUEST_STATE }, { id: chromeMock.runtime.id }, next => {
+      response = next;
+    });
+    expect(response).toEqual({
+      state: {
+        status: 'signed-in',
+        userId: 'restart-user',
+        sessionId: 'session-after-restart',
+        expiresAt: null,
+      },
+    });
+  });
+
+  it('ignores foreign senders and stale inbound state messages', async () => {
+    createClerkClient.mockResolvedValue({
+      session: null,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    });
+    const { setupAuthBridge } = await importAuthManager();
+    setupAuthBridge();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    clerkListeners[0]({
+      user: { id: 'current-user' },
+      session: { id: 'current-session', expireAt: null },
+    });
+
+    let foreignResponse: unknown;
+    expect(
+      messageListeners[0](
+        { type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'signed-in', userId: 'foreign' } },
+        { id: 'foreign-extension' },
+        response => {
+          foreignResponse = response;
+        }
+      )
+    ).toBe(false);
+    expect(foreignResponse).toBeUndefined();
+
+    messageListeners[0](
+      { type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'signed-out' } },
+      { id: chromeMock.runtime.id },
+      () => undefined
+    );
+    let stateResponse: unknown;
+    messageListeners[0]({ type: AUTH_MESSAGES.REQUEST_STATE }, { id: chromeMock.runtime.id }, response => {
+      stateResponse = response;
+    });
+    expect(stateResponse).toEqual({
+      state: {
+        status: 'signed-in',
+        userId: 'current-user',
+        sessionId: 'current-session',
+        expiresAt: null,
+      },
+    });
   });
 
   it('rejects diagnostics at the runtime message handler in production', async () => {
@@ -251,7 +402,6 @@ describe('auth-manager', () => {
 
     expect(messageListeners[0]({ type: AUTH_MESSAGES.RUN_DIAGNOSTICS }, {}, response)).toBe(false);
     expect(response).not.toHaveBeenCalled();
-    expect(createClerkClient).not.toHaveBeenCalled();
   });
 
   it('keeps diagnostics available through the runtime message handler in development', async () => {

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -317,6 +317,24 @@ describe('auth-manager', () => {
     expect(chromeMock.tabs.remove).toHaveBeenCalledWith(80)
   })
 
+  it('ignores an in-flight sync completion after the last waiter aborts', async () => {
+    let resolveClient: ((client: unknown) => void) | undefined
+    const addListener = vi.fn(() => () => undefined)
+    createClerkClient.mockImplementation(() => new Promise(resolve => { resolveClient = resolve }))
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const controller = new AbortController()
+    const signInPromise = promptUserSignIn(controller.signal)
+    await Promise.resolve()
+    controller.abort()
+    await expect(signInPromise).resolves.toBe(false)
+
+    resolveClient?.({ session: null, addListener })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(addListener).not.toHaveBeenCalled()
+  })
+
   it('retries Clerk sync initialization and observes a later web sign-in', async () => {
     const clerk = {
       session: null,

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -27,6 +27,12 @@ interface ChromeMock {
       removeListener: ReturnType<typeof vi.fn>;
     };
   };
+  cookies: {
+    onChanged: {
+      addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
+    };
+  };
   tabs: {
     create: ReturnType<typeof vi.fn>;
     get: ReturnType<typeof vi.fn>;
@@ -37,6 +43,7 @@ interface ChromeMock {
 let messageListeners: Array<(message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => boolean>;
 let chromeMock: ChromeMock;
 let clerkListeners: Array<(resources: unknown) => void>;
+let cookieListeners: Array<(changeInfo: chrome.cookies.CookieChangeInfo) => void>;
 
 async function importAuthManager() {
   vi.resetModules();
@@ -64,6 +71,14 @@ beforeEach(() => {
         removeListener: vi.fn(),
       },
     },
+    cookies: {
+      onChanged: {
+        addListener: vi.fn(listener => {
+          cookieListeners.push(listener);
+        }),
+        removeListener: vi.fn(),
+      },
+    },
     tabs: {
       create: vi.fn(),
       get: vi.fn(),
@@ -74,6 +89,7 @@ beforeEach(() => {
   vi.stubGlobal('chrome', chromeMock);
   createClerkClient.mockReset();
   clerkListeners = [];
+  cookieListeners = [];
 });
 
 describe('auth-manager', () => {
@@ -461,6 +477,138 @@ describe('auth-manager', () => {
 
     await expect(signInPromise).resolves.toBe(true)
   })
+
+  it('queues a cookie event during service-worker Clerk startup', async () => {
+    let resolveClient: ((client: unknown) => void) | undefined;
+    const signedInSession = { id: 'race-session', user: { id: 'race-user' }, expireAt: null };
+    const clerk = {
+      session: null as typeof signedInSession | null,
+      __internal_reloadInitialResources: vi.fn(async () => {
+        clerk.session = signedInSession;
+        clerkListeners[0]({ user: signedInSession.user, session: signedInSession });
+      }),
+      addListener: vi.fn((listener: (resources: unknown) => void) => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    };
+    createClerkClient.mockImplementation(() => new Promise(resolve => { resolveClient = resolve; }));
+
+    const { setupAuthBridge, waitForSignIn } = await importAuthManager();
+    setupAuthBridge();
+    // The worker registers the Chrome event synchronously, before Clerk awaits.
+    expect(cookieListeners).toHaveLength(1);
+    const waiter = waitForSignIn(1000);
+    cookieListeners[0]({
+      cause: 'explicit', removed: false, cookie: { domain: 'clerk.sploot.test' },
+    } as chrome.cookies.CookieChangeInfo);
+
+    resolveClient?.(clerk);
+    await expect(waiter).resolves.toBe(true);
+    expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce();
+    expect(cookieListeners).toHaveLength(1);
+  });
+
+  it('refreshes one Clerk authority from a scoped cookie event without a window', async () => {
+    const signedInSession = {
+      id: 'cookie-session',
+      user: { id: 'cookie-user' },
+      expireAt: null,
+      getToken: vi.fn(),
+    };
+    const reload = vi.fn(async () => {
+      clerk.session = signedInSession;
+      clerkListeners[0]({ user: signedInSession.user, session: signedInSession });
+    });
+    const clerk: {
+      session: typeof signedInSession | null;
+      __internal_reloadInitialResources: typeof reload;
+      addListener: ReturnType<typeof vi.fn>;
+    } = {
+      session: null,
+      __internal_reloadInitialResources: reload,
+      addListener: vi.fn(listener => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    };
+    createClerkClient.mockResolvedValue(clerk);
+
+    const { setupAuthBridge, waitForSignIn } = await importAuthManager();
+    setupAuthBridge();
+    await vi.waitFor(() => expect(cookieListeners).toHaveLength(1));
+    const waiter = waitForSignIn(1000);
+
+    cookieListeners[0]({
+      cause: 'explicit',
+      removed: false,
+      cookie: {
+        domain: '.clerk.sploot.test',
+        expirationDate: undefined,
+        hostOnly: false,
+        httpOnly: true,
+        name: '__clerk_db_jwt',
+        path: '/',
+        sameSite: 'no_restriction',
+        secure: true,
+        session: false,
+        storeId: '0',
+        value: 'opaque-cookie-value',
+      },
+    });
+
+    await expect(waiter).resolves.toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+    expect(createClerkClient).toHaveBeenCalledWith(expect.objectContaining({
+      syncHost: 'https://clerk.sploot.test',
+      __experimental_syncHostListener: false,
+    }));
+    expect(clerk.addListener).toHaveBeenCalledOnce();
+    expect(cookieListeners).toHaveLength(1);
+    expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({
+      type: AUTH_MESSAGES.STATE_CHANGED,
+      payload: {
+        status: 'signed-in',
+        userId: 'cookie-user',
+        sessionId: 'cookie-session',
+        expiresAt: null,
+      },
+    });
+    expect(JSON.stringify(chromeMock.runtime.sendMessage.mock.calls)).not.toContain('opaque-cookie-value');
+  });
+
+  it('ignores foreign cookie domains and serializes matching refreshes', async () => {
+    let resolveReload: (() => void) | undefined;
+    const clerk = {
+      session: null as { id: string; user: { id: string }; expireAt: null } | null,
+      __internal_reloadInitialResources: vi.fn(() => new Promise<void>(resolve => { resolveReload = resolve; })),
+      addListener: vi.fn((listener: (resources: unknown) => void) => {
+        clerkListeners.push(listener);
+        return () => undefined;
+      }),
+    };
+    createClerkClient.mockResolvedValue(clerk);
+    const { setupAuthBridge } = await importAuthManager();
+    setupAuthBridge();
+    await vi.waitFor(() => expect(cookieListeners).toHaveLength(1));
+
+    cookieListeners[0]({
+      cause: 'explicit', removed: false, cookie: { domain: 'foreign.test' },
+    } as chrome.cookies.CookieChangeInfo);
+    await Promise.resolve();
+    expect(clerk.__internal_reloadInitialResources).not.toHaveBeenCalled();
+
+    cookieListeners[0]({
+      cause: 'explicit', removed: false, cookie: { domain: 'clerk.sploot.test' },
+    } as chrome.cookies.CookieChangeInfo);
+    cookieListeners[0]({
+      cause: 'explicit', removed: false, cookie: { domain: '.clerk.sploot.test' },
+    } as chrome.cookies.CookieChangeInfo);
+    await vi.waitFor(() => expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce());
+    expect(resolveReload).toBeDefined();
+    resolveReload?.();
+    await vi.waitFor(() => expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledTimes(2));
+  });
 
   it('resolves sign-in waiters when the persistent Clerk listener observes sign-in', async () => {
     const signedInState: AuthState = {

--- a/apps/extension/entrypoints/background/auth-manager.test.ts
+++ b/apps/extension/entrypoints/background/auth-manager.test.ts
@@ -335,6 +335,51 @@ describe('auth-manager', () => {
     expect(addListener).not.toHaveBeenCalled()
   })
 
+  it('installs only the current generation listener after overlapping init', async () => {
+    let resolveClient: ((client: unknown) => void) | undefined
+    const addListener = vi.fn(listener => {
+      clerkListeners.push(listener)
+      return () => undefined
+    })
+    createClerkClient.mockImplementation(() => new Promise(resolve => { resolveClient = resolve }))
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const signInPromise = promptUserSignIn()
+    await Promise.resolve()
+    resolveClient?.({ session: null, addListener })
+    await vi.waitFor(() => expect(addListener).toHaveBeenCalledTimes(1))
+    clerkListeners[0]({ user: { id: 'current-user' }, session: { id: 'current-session', expireAt: null } })
+
+    await expect(signInPromise).resolves.toBe(true)
+    expect(addListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores stale init after abort before a new waiter starts', async () => {
+    let resolveClient: ((client: unknown) => void) | undefined
+    const addListener = vi.fn(listener => {
+      clerkListeners.push(listener)
+      return () => undefined
+    })
+    createClerkClient.mockImplementation(() => new Promise(resolve => { resolveClient = resolve }))
+
+    const { promptUserSignIn, setupAuthBridge } = await importAuthManager()
+    setupAuthBridge()
+    const firstController = new AbortController()
+    const first = promptUserSignIn(firstController.signal)
+    await Promise.resolve()
+    firstController.abort()
+    await expect(first).resolves.toBe(false)
+
+    const second = promptUserSignIn()
+    resolveClient?.({ session: null, addListener })
+    await vi.waitFor(() => expect(addListener).toHaveBeenCalledTimes(1))
+    clerkListeners[0]({ user: { id: 'current-user' }, session: { id: 'current-session', expireAt: null } })
+
+    await expect(second).resolves.toBe(true)
+    expect(addListener).toHaveBeenCalledTimes(1)
+  })
+
   it('retries Clerk sync initialization and observes a later web sign-in', async () => {
     const clerk = {
       session: null,

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -13,7 +13,8 @@ import { IS_DEV_BUILD } from '../../shared/build-mode'
 const PUBLISHABLE_KEY = CLERK_PUBLISHABLE_KEY
 const SIGN_IN_TIMEOUT_MS = 60000
 const E2E_AUTH_KEY = 'sploot:e2e-auth-authority'
-const AUTH_SYNC_RETRY_DELAYS_MS = [50, 100, 250, 500] as const
+const AUTH_SYNC_RETRY_DELAYS_MS = [50, 100, 250, 500, 1000, 2000, 5000, 10000, 15000, 15000] as const
+const AUTH_SYNC_INITIAL_RETRY_LIMIT = 4
 
 let cachedState: AuthState = { status: 'unknown' }
 const waiters = new Set<(state: AuthState) => void>()
@@ -170,7 +171,8 @@ function startAuthSyncWithRetry(): void {
 
   void startAuthSync().catch(error => {
     console.error('[Auth] Failed to initialize Clerk sync', error)
-    if (authSyncRetryAttempt >= AUTH_SYNC_RETRY_DELAYS_MS.length) {
+    const retryLimit = waiters.size > 0 ? AUTH_SYNC_RETRY_DELAYS_MS.length : AUTH_SYNC_INITIAL_RETRY_LIMIT
+    if (authSyncRetryAttempt >= retryLimit) {
       return
     }
     const delay = AUTH_SYNC_RETRY_DELAYS_MS[authSyncRetryAttempt++]
@@ -358,6 +360,11 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
       settled = true
       clearTimeout(timeoutId)
       waiters.delete(listener)
+      if (waiters.size === 0 && authSyncRetryTimer) {
+        clearTimeout(authSyncRetryTimer)
+        authSyncRetryTimer = undefined
+        authSyncRetryAttempt = 0
+      }
       signal?.removeEventListener('abort', abort)
       resolve(signedIn)
     }
@@ -385,6 +392,8 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
     }
 
     waiters.add(listener)
+    authSyncRetryAttempt = 0
+    startAuthSyncWithRetry()
   })
 }
 

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -124,18 +124,6 @@ function updateCachedState(next: AuthState) {
   }
 }
 
-async function createFreshClerkClient() {
-  assertExtensionConfig()
-  // CreateClerkClientOptions exposes no telemetry option and the SDK loads
-  // Clerk internally with fixed options, so there is no typed disable knob
-  // here. Clerk's telemetry collector no-ops for production publishable keys
-  // (instanceType gate); the ClerkProvider surfaces disable it explicitly.
-  return await createClerkClient({
-    publishableKey: PUBLISHABLE_KEY,
-    syncHost: CLERK_SYNC_HOST,
-    __experimental_syncHostListener: true,
-  })
-}
 
 async function getClerkClient() {
   assertExtensionConfig()
@@ -286,7 +274,7 @@ export async function readAuthAuthority(signal?: AbortSignal): Promise<AuthAutho
   if (E2E_AUTH_MODE) {
     return await getE2eAuthority(signal);
   }
-  const clerk = await withAbort(createFreshClerkClient(), signal)
+  const clerk = await withAbort(getClerkClient(), signal)
   const authority = sessionAuthority(clerk.session)
   if (authority) {
     updateCachedState({
@@ -324,7 +312,7 @@ export async function getAuthTokenForAuthority(expected: AuthAuthority, signal?:
         ? `e2e-token-${actual.userId}-${actual.sessionId}`
         : null;
     }
-    const clerk = await withAbort(createFreshClerkClient(), signal)
+    const clerk = await withAbort(getClerkClient(), signal)
     const actual = sessionAuthority(clerk.session)
     if (!sameAccountAuthority(actual, expected) || !clerk.session) {
       return null
@@ -491,7 +479,7 @@ export async function runAuthDiagnostics(): Promise<AuthDiagnosticsSnapshot> {
   }
 
   try {
-    const clerk = await createFreshClerkClient()
+    const clerk = await getClerkClient()
     snapshot.status = clerk.session ? 'signed-in' : 'signed-out'
     snapshot.userId = clerk.session?.user?.id
     snapshot.sessionId = clerk.session?.id

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -13,12 +13,15 @@ import { IS_DEV_BUILD } from '../../shared/build-mode'
 const PUBLISHABLE_KEY = CLERK_PUBLISHABLE_KEY
 const SIGN_IN_TIMEOUT_MS = 60000
 const E2E_AUTH_KEY = 'sploot:e2e-auth-authority'
+const AUTH_SYNC_RETRY_DELAYS_MS = [50, 100, 250, 500] as const
 
 let cachedState: AuthState = { status: 'unknown' }
 const waiters = new Set<(state: AuthState) => void>()
 let clerkClientPromise: ReturnType<typeof createClerkClient> | undefined
 let removeClerkListener: (() => void) | undefined
 let bridgeListener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] | undefined
+let authSyncRetryTimer: ReturnType<typeof setTimeout> | undefined
+let authSyncRetryAttempt = 0
 
 /**
  * The Clerk authority behind a durable save job.
@@ -149,10 +152,33 @@ async function startAuthSync(): Promise<void> {
   }
 
   const clerk = await getClerkClient()
-  removeClerkListener = clerk.addListener(resources => {
+  if (!clerk || typeof clerk.addListener !== 'function') {
+    throw new Error('Clerk sync listener is unavailable')
+  }
+  const removeListener = clerk.addListener(resources => {
     updateCachedState(authStateFromResources(resources))
   })
+  removeClerkListener = typeof removeListener === 'function' ? removeListener : () => undefined
+  authSyncRetryAttempt = 0
   updateCachedState(authStateFromResources(clerk))
+}
+
+function startAuthSyncWithRetry(): void {
+  if (E2E_AUTH_MODE || removeClerkListener || authSyncRetryTimer) {
+    return
+  }
+
+  void startAuthSync().catch(error => {
+    console.error('[Auth] Failed to initialize Clerk sync', error)
+    if (authSyncRetryAttempt >= AUTH_SYNC_RETRY_DELAYS_MS.length) {
+      return
+    }
+    const delay = AUTH_SYNC_RETRY_DELAYS_MS[authSyncRetryAttempt++]
+    authSyncRetryTimer = setTimeout(() => {
+      authSyncRetryTimer = undefined
+      startAuthSyncWithRetry()
+    }, delay)
+  })
 }
 
 export async function isAuthenticated(signal?: AbortSignal): Promise<boolean> {
@@ -322,6 +348,7 @@ function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSignal): Promise<boolean> {
   return new Promise(resolve => {
     let settled = false
+    let listener: (state: AuthState) => void
 
     const finish = (signedIn: boolean) => {
       if (settled) {
@@ -346,7 +373,7 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
     }
     signal?.addEventListener('abort', abort, { once: true })
 
-    const listener = (state: AuthState) => {
+    listener = (state: AuthState) => {
       if (state.status === 'signed-in') {
         finish(true)
       }
@@ -361,19 +388,41 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
   })
 }
 
-export async function promptUserSignIn(signal?: AbortSignal): Promise<boolean> {
+async function closeOwnedSignInTab(tabId: number | undefined, signInUrl: string): Promise<void> {
+  if (tabId === undefined) {
+    return
+  }
+
   try {
-    await chrome.tabs.create({ url: getSplootSignInUrl() })
+    const tab = await chrome.tabs.get(tabId)
+    if (tab.url === signInUrl) {
+      await chrome.tabs.remove(tabId)
+    }
+  } catch {
+    // The tab may have been closed or navigated away while auth completed.
+  }
+}
+
+export async function promptUserSignIn(signal?: AbortSignal): Promise<boolean> {
+  const signInUrl = getSplootSignInUrl()
+  let tabId: number | undefined
+  try {
+    const tab = await chrome.tabs.create({ url: signInUrl })
+    tabId = tab?.id
   } catch (error) {
     console.warn('[Auth] Unable to open Sploot sign-in tab', error)
     return false
   }
 
-  if (await isAuthenticated(signal)) {
-    return true
-  }
+  try {
+    if (await isAuthenticated(signal)) {
+      return true
+    }
 
-  return await waitForSignIn(SIGN_IN_TIMEOUT_MS, signal)
+    return await waitForSignIn(SIGN_IN_TIMEOUT_MS, signal)
+  } finally {
+    await closeOwnedSignInTab(tabId, signInUrl)
+  }
 }
 
 export interface AuthDiagnosticsSnapshot {
@@ -435,7 +484,5 @@ export function setupAuthBridge() {
   }
 
   chrome.runtime.onMessage.addListener(bridgeListener)
-  void startAuthSync().catch(error => {
-    console.error('[Auth] Failed to initialize Clerk sync', error)
-  })
+  startAuthSyncWithRetry()
 }

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -24,6 +24,8 @@ let bridgeListener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] |
 let authSyncRetryTimer: ReturnType<typeof setTimeout> | undefined
 let authSyncRetryAttempt = 0
 let authSyncGeneration = 0
+let authSyncInFlightGeneration: number | undefined
+let authSyncInFlightPromise: Promise<void> | undefined
 
 /**
  * The Clerk authority behind a durable save job.
@@ -148,13 +150,13 @@ async function getClerkClient() {
   return await clerkClientPromise
 }
 
-async function startAuthSync(generation = authSyncGeneration): Promise<void> {
+async function startAuthSyncImplementation(generation: number): Promise<void> {
   if (E2E_AUTH_MODE || removeClerkListener) {
     return
   }
 
   const clerk = await getClerkClient()
-  if (generation !== authSyncGeneration && waiters.size === 0) {
+  if (generation !== authSyncGeneration) {
     return
   }
   if (!clerk || typeof clerk.addListener !== 'function') {
@@ -166,6 +168,22 @@ async function startAuthSync(generation = authSyncGeneration): Promise<void> {
   removeClerkListener = typeof removeListener === 'function' ? removeListener : () => undefined
   authSyncRetryAttempt = 0
   updateCachedState(authStateFromResources(clerk))
+}
+
+function startAuthSync(generation = authSyncGeneration): Promise<void> {
+  if (authSyncInFlightGeneration === generation && authSyncInFlightPromise) {
+    return authSyncInFlightPromise
+  }
+
+  const promise = startAuthSyncImplementation(generation)
+  authSyncInFlightGeneration = generation
+  authSyncInFlightPromise = promise.finally(() => {
+    if (authSyncInFlightGeneration === generation) {
+      authSyncInFlightGeneration = undefined
+      authSyncInFlightPromise = undefined
+    }
+  })
+  return authSyncInFlightPromise
 }
 
 function startAuthSyncWithRetry(generation = authSyncGeneration): void {

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -23,6 +23,7 @@ let removeClerkListener: (() => void) | undefined
 let bridgeListener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] | undefined
 let authSyncRetryTimer: ReturnType<typeof setTimeout> | undefined
 let authSyncRetryAttempt = 0
+let authSyncGeneration = 0
 
 /**
  * The Clerk authority behind a durable save job.
@@ -147,12 +148,15 @@ async function getClerkClient() {
   return await clerkClientPromise
 }
 
-async function startAuthSync(): Promise<void> {
+async function startAuthSync(generation = authSyncGeneration): Promise<void> {
   if (E2E_AUTH_MODE || removeClerkListener) {
     return
   }
 
   const clerk = await getClerkClient()
+  if (generation !== authSyncGeneration && waiters.size === 0) {
+    return
+  }
   if (!clerk || typeof clerk.addListener !== 'function') {
     throw new Error('Clerk sync listener is unavailable')
   }
@@ -164,12 +168,15 @@ async function startAuthSync(): Promise<void> {
   updateCachedState(authStateFromResources(clerk))
 }
 
-function startAuthSyncWithRetry(): void {
-  if (E2E_AUTH_MODE || removeClerkListener || authSyncRetryTimer) {
+function startAuthSyncWithRetry(generation = authSyncGeneration): void {
+  if (E2E_AUTH_MODE || removeClerkListener || authSyncRetryTimer || generation !== authSyncGeneration) {
     return
   }
 
-  void startAuthSync().catch(error => {
+  void startAuthSync(generation).catch(error => {
+    if (generation !== authSyncGeneration) {
+      return
+    }
     console.error('[Auth] Failed to initialize Clerk sync', error)
     const retryLimit = waiters.size > 0 ? AUTH_SYNC_RETRY_DELAYS_MS.length : AUTH_SYNC_INITIAL_RETRY_LIMIT
     if (authSyncRetryAttempt >= retryLimit) {
@@ -178,7 +185,7 @@ function startAuthSyncWithRetry(): void {
     const delay = AUTH_SYNC_RETRY_DELAYS_MS[authSyncRetryAttempt++]
     authSyncRetryTimer = setTimeout(() => {
       authSyncRetryTimer = undefined
-      startAuthSyncWithRetry()
+      startAuthSyncWithRetry(generation)
     }, delay)
   })
 }
@@ -360,9 +367,12 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
       settled = true
       clearTimeout(timeoutId)
       waiters.delete(listener)
-      if (waiters.size === 0 && authSyncRetryTimer) {
-        clearTimeout(authSyncRetryTimer)
-        authSyncRetryTimer = undefined
+      if (waiters.size === 0) {
+        authSyncGeneration += 1
+        if (authSyncRetryTimer) {
+          clearTimeout(authSyncRetryTimer)
+          authSyncRetryTimer = undefined
+        }
         authSyncRetryAttempt = 0
       }
       signal?.removeEventListener('abort', abort)
@@ -391,9 +401,17 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
       return
     }
 
+    const hadActiveWaiter = waiters.size > 0
     waiters.add(listener)
-    authSyncRetryAttempt = 0
-    startAuthSyncWithRetry()
+    if (!hadActiveWaiter) {
+      authSyncGeneration += 1
+      if (authSyncRetryTimer) {
+        clearTimeout(authSyncRetryTimer)
+        authSyncRetryTimer = undefined
+      }
+      authSyncRetryAttempt = 0
+      startAuthSyncWithRetry(authSyncGeneration)
+    }
   })
 }
 

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -18,6 +18,7 @@ const AUTH_SYNC_INITIAL_RETRY_LIMIT = 4
 
 let cachedState: AuthState = { status: 'unknown' }
 const waiters = new Set<(state: AuthState) => void>()
+const authStateListeners = new Set<(state: AuthState) => void>()
 let clerkClientPromise: ReturnType<typeof createClerkClient> | undefined
 let removeClerkListener: (() => void) | undefined
 let bridgeListener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] | undefined
@@ -72,6 +73,15 @@ function notifyWaiters(state: AuthState) {
   for (const listener of waiters) {
     listener(state)
   }
+  for (const listener of authStateListeners) {
+    listener(state)
+  }
+}
+
+/** Subscribe to authoritative Clerk state transitions inside the worker. */
+export function onAuthStateChanged(listener: (state: AuthState) => void): () => void {
+  authStateListeners.add(listener)
+  return () => authStateListeners.delete(listener)
 }
 
 function authStateFromResources(resources: {

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -26,6 +26,8 @@ let authSyncRetryAttempt = 0
 let authSyncGeneration = 0
 let authSyncInFlightGeneration: number | undefined
 let authSyncInFlightPromise: Promise<void> | undefined
+let authCookieListener: ((changeInfo: chrome.cookies.CookieChangeInfo) => void) | undefined
+let authCookieRefreshPromise: Promise<void> | undefined
 
 /**
  * The Clerk authority behind a durable save job.
@@ -124,13 +126,74 @@ function updateCachedState(next: AuthState) {
   }
 }
 
+function normalizeCookieDomain(domain: string): string {
+  return domain.trim().replace(/^\.+/, '').toLowerCase()
+}
+
+function isClerkSyncCookieChange(changeInfo: chrome.cookies.CookieChangeInfo): boolean {
+  if (!changeInfo?.cookie?.domain || !CLERK_SYNC_HOST) {
+    return false
+  }
+
+  try {
+    const syncDomain = normalizeCookieDomain(new URL(CLERK_SYNC_HOST).hostname)
+    return syncDomain.length > 0 && normalizeCookieDomain(changeInfo.cookie.domain) === syncDomain
+  } catch {
+    return false
+  }
+}
+
+async function refreshAuthFromCookie(): Promise<void> {
+  const clerk = await getClerkClient()
+  await clerk.__internal_reloadInitialResources()
+  updateCachedState(authStateFromResources(clerk))
+}
+
+function queueAuthCookieRefresh(): void {
+  const previous = authCookieRefreshPromise ?? Promise.resolve()
+  const next = previous
+    .then(async () => {
+      await startAuthSync()
+      await refreshAuthFromCookie()
+    })
+    .catch(error => {
+      console.error('[Auth] Failed to refresh Clerk from cookie change', error)
+    })
+
+  const cleanup = next.finally(() => {
+    if (authCookieRefreshPromise === cleanup) {
+      authCookieRefreshPromise = undefined
+    }
+  })
+  authCookieRefreshPromise = cleanup
+}
+
+function installAuthCookieListener(): void {
+  if (E2E_AUTH_MODE || authCookieListener) {
+    return
+  }
+
+  const onChanged = chrome.cookies?.onChanged
+  if (!onChanged || typeof onChanged.addListener !== 'function') {
+    throw new Error('Chrome cookie change listener is unavailable')
+  }
+
+  const listener = (changeInfo: chrome.cookies.CookieChangeInfo) => {
+    if (isClerkSyncCookieChange(changeInfo)) {
+      queueAuthCookieRefresh()
+    }
+  }
+
+  onChanged.addListener(listener)
+  authCookieListener = listener
+}
 
 async function getClerkClient() {
   assertExtensionConfig()
   clerkClientPromise ??= Promise.resolve(createClerkClient({
     publishableKey: PUBLISHABLE_KEY,
     syncHost: CLERK_SYNC_HOST,
-    __experimental_syncHostListener: true,
+    __experimental_syncHostListener: false,
   })).catch(error => {
     clerkClientPromise = undefined
     throw error
@@ -517,5 +580,6 @@ export function setupAuthBridge() {
   }
 
   chrome.runtime.onMessage.addListener(bridgeListener)
+  installAuthCookieListener()
   startAuthSyncWithRetry()
 }

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -9,15 +9,16 @@ import {
 } from '../../shared/env'
 import { getSplootSignInUrl } from '../../shared/app-url'
 import { IS_DEV_BUILD } from '../../shared/build-mode'
-import { runBestEffort } from '../../shared/best-effort'
 
 const PUBLISHABLE_KEY = CLERK_PUBLISHABLE_KEY
 const SIGN_IN_TIMEOUT_MS = 60000
-const SIGN_IN_POLL_INTERVAL_MS = 1000
 const E2E_AUTH_KEY = 'sploot:e2e-auth-authority'
 
 let cachedState: AuthState = { status: 'unknown' }
 const waiters = new Set<(state: AuthState) => void>()
+let clerkClientPromise: ReturnType<typeof createClerkClient> | undefined
+let removeClerkListener: (() => void) | undefined
+let bridgeListener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] | undefined
 
 /**
  * The Clerk authority behind a durable save job.
@@ -64,10 +65,56 @@ function notifyWaiters(state: AuthState) {
   }
 }
 
+function authStateFromResources(resources: {
+  session?: { id: string; user?: { id: string } | null; expireAt?: Date | null } | null
+  user?: { id: string } | null
+}): AuthState {
+  if (!resources.session) {
+    return { status: 'signed-out', userId: null, sessionId: null, expiresAt: null }
+  }
+
+  return {
+    status: 'signed-in',
+    userId: resources.user?.id ?? resources.session.user?.id ?? null,
+    sessionId: resources.session.id,
+    expiresAt: resources.session.expireAt?.getTime() ?? null,
+  }
+}
+
+function sameAuthState(left: AuthState, right: AuthState): boolean {
+  return (
+    left.status === right.status &&
+    left.userId === right.userId &&
+    left.sessionId === right.sessionId &&
+    left.expiresAt === right.expiresAt
+  )
+}
+
 function updateCachedState(next: AuthState) {
+  if (sameAuthState(cachedState, next)) {
+    return
+  }
+
   cachedState = next
-  console.log('[Auth] State updated', next)
+  console.log('[Auth] State changed', {
+    status: next.status,
+    userId: next.userId,
+    sessionId: next.sessionId,
+    expiresAt: next.expiresAt,
+  })
   notifyWaiters(next)
+
+  try {
+    const result = chrome.runtime.sendMessage({
+      type: AUTH_MESSAGES.STATE_CHANGED,
+      payload: next,
+    })
+    if (result && typeof result.catch === 'function') {
+      void result.catch(() => undefined)
+    }
+  } catch {
+    // The popup may have closed between the state change and this broadcast.
+  }
 }
 
 async function createFreshClerkClient() {
@@ -83,12 +130,37 @@ async function createFreshClerkClient() {
   })
 }
 
+async function getClerkClient() {
+  assertExtensionConfig()
+  clerkClientPromise ??= Promise.resolve(createClerkClient({
+    publishableKey: PUBLISHABLE_KEY,
+    syncHost: CLERK_SYNC_HOST,
+    __experimental_syncHostListener: true,
+  })).catch(error => {
+    clerkClientPromise = undefined
+    throw error
+  })
+  return await clerkClientPromise
+}
+
+async function startAuthSync(): Promise<void> {
+  if (E2E_AUTH_MODE || removeClerkListener) {
+    return
+  }
+
+  const clerk = await getClerkClient()
+  removeClerkListener = clerk.addListener(resources => {
+    updateCachedState(authStateFromResources(resources))
+  })
+  updateCachedState(authStateFromResources(clerk))
+}
+
 export async function isAuthenticated(signal?: AbortSignal): Promise<boolean> {
   try {
     if (E2E_AUTH_MODE) {
       return Boolean(await getE2eAuthority(signal));
     }
-    const clerk = await withAbort(createFreshClerkClient(), signal)
+    const clerk = await withAbort(getClerkClient(), signal)
     const authority = sessionAuthority(clerk.session)
     const hasSession = Boolean(authority)
 
@@ -119,7 +191,7 @@ export async function getAuthToken(signal?: AbortSignal): Promise<string | null>
       const authority = await getE2eAuthority(signal);
       return authority ? `e2e-token-${authority.userId}-${authority.sessionId}` : null;
     }
-    const clerk = await withAbort(createFreshClerkClient(), signal)
+    const clerk = await withAbort(getClerkClient(), signal)
 
     if (!clerk.session) {
       console.warn('[Auth] No session available for token retrieval')
@@ -250,7 +322,6 @@ function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSignal): Promise<boolean> {
   return new Promise(resolve => {
     let settled = false
-    let intervalId: ReturnType<typeof setInterval> | undefined
 
     const finish = (signedIn: boolean) => {
       if (settled) {
@@ -259,9 +330,6 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
 
       settled = true
       clearTimeout(timeoutId)
-      if (intervalId) {
-        clearInterval(intervalId)
-      }
       waiters.delete(listener)
       signal?.removeEventListener('abort', abort)
       resolve(signedIn)
@@ -284,21 +352,12 @@ export function waitForSignIn(timeoutMs = SIGN_IN_TIMEOUT_MS, signal?: AbortSign
       }
     }
 
-    const pollForSyncedSession = async () => {
-      if (settled) {
-        return
-      }
-
-      if (await isAuthenticated()) {
-        finish(true)
-      }
+    if (cachedState.status === 'signed-in') {
+      finish(true)
+      return
     }
 
     waiters.add(listener)
-    intervalId = setInterval(() => {
-      runBestEffort('auth sign-in poll', pollForSyncedSession)
-    }, SIGN_IN_POLL_INTERVAL_MS)
-    runBestEffort('auth initial sign-in poll', pollForSyncedSession)
   })
 }
 
@@ -308,6 +367,10 @@ export async function promptUserSignIn(signal?: AbortSignal): Promise<boolean> {
   } catch (error) {
     console.warn('[Auth] Unable to open Sploot sign-in tab', error)
     return false
+  }
+
+  if (await isAuthenticated(signal)) {
+    return true
   }
 
   return await waitForSignIn(SIGN_IN_TIMEOUT_MS, signal)
@@ -348,13 +411,11 @@ export async function runAuthDiagnostics(): Promise<AuthDiagnosticsSnapshot> {
 }
 
 export function setupAuthBridge() {
-  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-    if (message?.type === AUTH_MESSAGES.STATE_UPDATE) {
-      updateCachedState(message.payload)
-      sendResponse({ ok: true })
-      return true
-    }
+  if (bridgeListener) {
+    return
+  }
 
+  bridgeListener = (message, _sender, sendResponse) => {
     if (message?.type === AUTH_MESSAGES.REQUEST_STATE) {
       sendResponse({ state: cachedState })
       return true
@@ -371,5 +432,10 @@ export function setupAuthBridge() {
     }
 
     return false
+  }
+
+  chrome.runtime.onMessage.addListener(bridgeListener)
+  void startAuthSync().catch(error => {
+    console.error('[Auth] Failed to initialize Clerk sync', error)
   })
 }

--- a/apps/extension/entrypoints/background/auth-manager.ts
+++ b/apps/extension/entrypoints/background/auth-manager.ts
@@ -200,6 +200,10 @@ function installAuthCookieListener(): void {
 
 async function getClerkClient() {
   assertExtensionConfig()
+  // CreateClerkClientOptions exposes no telemetry option and the SDK loads
+  // Clerk internally with fixed options, so there is no typed disable knob
+  // here. Clerk's telemetry collector no-ops for production publishable keys
+  // (instanceType gate); the ClerkProvider surfaces disable it explicitly.
   clerkClientPromise ??= Promise.resolve(createClerkClient({
     publishableKey: PUBLISHABLE_KEY,
     syncHost: CLERK_SYNC_HOST,

--- a/apps/extension/entrypoints/background/context-menu-save-queue.test.ts
+++ b/apps/extension/entrypoints/background/context-menu-save-queue.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   saveToSploot: vi.fn(),
   showErrorNotification: vi.fn(),
   getAuthAuthority: vi.fn(),
+  promptUserSignIn: vi.fn(),
   readAuthAuthority: vi.fn(),
 }));
 
@@ -19,6 +20,7 @@ vi.mock('./save-flow', () => ({ saveToSploot: mocks.saveToSploot }));
 vi.mock('./notifications', () => ({ showErrorNotification: mocks.showErrorNotification }));
 vi.mock('./auth-manager', () => ({
   getAuthAuthority: mocks.getAuthAuthority,
+  promptUserSignIn: mocks.promptUserSignIn,
   readAuthAuthority: mocks.readAuthAuthority,
   // Mirrors the production contract proven in auth-manager.test.ts: durable
   // ownership is the stable account identity; sessionId never participates.
@@ -54,7 +56,7 @@ interface StoredJob {
   id: string;
   imageUrl: string;
   filename: string;
-  state: 'pending' | 'processing' | 'failed' | 'paused';
+  state: 'pending' | 'processing' | 'failed' | 'paused' | 'awaiting-auth';
   createdAt: number;
   attempts?: number;
   nextAttemptAt?: number;
@@ -88,7 +90,7 @@ beforeEach(() => {
         get: vi.fn(async () => ({
           [CONTEXT_MENU_QUEUE_KEY]: storedQueue.map(job => ({
             ...job,
-            owner: job.owner ?? OWNER,
+            owner: job.owner ?? (job.state === 'awaiting-auth' ? undefined : OWNER),
             sourceBytes: job.sourceBytes ?? btoa('image'),
             sourceType: job.sourceType ?? 'image/png',
           })),
@@ -112,6 +114,7 @@ beforeEach(() => {
   });
   setupContextMenuSaveQueue();
   mocks.getAuthAuthority.mockResolvedValue(OWNER);
+  mocks.promptUserSignIn.mockResolvedValue(true);
   // readAuthAuthority is the throwing variant of getAuthAuthority; by default
   // mirror it so owner-fencing tests drive both through one seam.
   mocks.readAuthAuthority.mockImplementation((signal?: AbortSignal) => mocks.getAuthAuthority(signal));
@@ -127,6 +130,20 @@ describe.sequential('durable context-menu save queue', () => {
       expect.any(Function), 'image', { owner: OWNER, signal: expect.any(AbortSignal) },
     ));
     await vi.waitFor(() => expect(storedQueue).toEqual([]));
+  });
+
+  it('waits for signed-in cookie state and continues the original prepared save', async () => {
+    mocks.getAuthAuthority
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(OWNER);
+
+    await enqueueCapturedSave(new Blob(['prepared-original'], { type: 'image/png' }), 'cat.png', 'https://x.test/cat.png');
+
+    expect(mocks.promptUserSignIn).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(mocks.saveToSploot).toHaveBeenCalledWith(
+      expect.any(Function), 'image', { owner: OWNER, signal: expect.any(AbortSignal) },
+    ));
+    expect(storedQueue).toEqual([]);
   });
 
   it('keeps failed payloads and schedules the next attempt with bounded backoff', async () => {

--- a/apps/extension/entrypoints/background/context-menu-save-queue.test.ts
+++ b/apps/extension/entrypoints/background/context-menu-save-queue.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   saveToSploot: vi.fn(),
   showErrorNotification: vi.fn(),
   getAuthAuthority: vi.fn(),
+  onAuthStateChanged: vi.fn(),
   promptUserSignIn: vi.fn(),
   readAuthAuthority: vi.fn(),
 }));
@@ -20,6 +21,7 @@ vi.mock('./save-flow', () => ({ saveToSploot: mocks.saveToSploot }));
 vi.mock('./notifications', () => ({ showErrorNotification: mocks.showErrorNotification }));
 vi.mock('./auth-manager', () => ({
   getAuthAuthority: mocks.getAuthAuthority,
+  onAuthStateChanged: mocks.onAuthStateChanged,
   promptUserSignIn: mocks.promptUserSignIn,
   readAuthAuthority: mocks.readAuthAuthority,
   // Mirrors the production contract proven in auth-manager.test.ts: durable
@@ -72,6 +74,7 @@ interface StoredJob {
 
 let storedQueue: StoredJob[];
 let alarmListener: ((alarm: { name: string }) => void) | undefined;
+let authStateListener: ((state: { status: string }) => void) | undefined;
 let alarmCreate: ReturnType<typeof vi.fn>;
 let alarmClear: ReturnType<typeof vi.fn>;
 const OWNER = { userId: 'user-1', sessionId: 'session-1' };
@@ -82,6 +85,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   storedQueue = [];
   alarmListener = undefined;
+  authStateListener = undefined;
   alarmCreate = vi.fn(async () => undefined);
   alarmClear = vi.fn(async () => true);
   vi.stubGlobal('chrome', {
@@ -112,6 +116,10 @@ beforeEach(() => {
       },
     },
   });
+  mocks.onAuthStateChanged.mockImplementation((listener: (state: { status: string }) => void) => {
+    authStateListener = listener;
+    return () => undefined;
+  });
   setupContextMenuSaveQueue();
   mocks.getAuthAuthority.mockResolvedValue(OWNER);
   mocks.promptUserSignIn.mockResolvedValue(true);
@@ -132,17 +140,23 @@ describe.sequential('durable context-menu save queue', () => {
     await vi.waitFor(() => expect(storedQueue).toEqual([]));
   });
 
-  it('waits for signed-in cookie state and continues the original prepared save', async () => {
+  it('continues a signed-out prepared save from the worker auth event', async () => {
     mocks.getAuthAuthority
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(OWNER);
+    let finishPrompt!: (signedIn: boolean) => void;
+    mocks.promptUserSignIn.mockReturnValueOnce(new Promise(resolve => { finishPrompt = resolve; }));
 
-    await enqueueCapturedSave(new Blob(['prepared-original'], { type: 'image/png' }), 'cat.png', 'https://x.test/cat.png');
-
+    const enqueue = enqueueCapturedSave(new Blob(['prepared-original'], { type: 'image/png' }), 'cat.png', 'https://x.test/cat.png');
+    await vi.waitFor(() => expect(storedQueue).toEqual([expect.objectContaining({ state: 'awaiting-auth' })]));
     expect(mocks.promptUserSignIn).toHaveBeenCalledOnce();
+
+    authStateListener?.({ status: 'signed-in' });
     await vi.waitFor(() => expect(mocks.saveToSploot).toHaveBeenCalledWith(
       expect.any(Function), 'image', { owner: OWNER, signal: expect.any(AbortSignal) },
     ));
+    finishPrompt(false);
+    await enqueue;
     expect(storedQueue).toEqual([]);
   });
 

--- a/apps/extension/entrypoints/background/context-menu-save-queue.ts
+++ b/apps/extension/entrypoints/background/context-menu-save-queue.ts
@@ -1,7 +1,6 @@
 import { UPLOAD } from '@sploot/common';
-import { AUTH_MESSAGES } from '../../shared/auth-messages';
 import { setSaveStatus } from '../../shared/save-status';
-import { getAuthAuthority, promptUserSignIn, readAuthAuthority, sameAccountAuthority, type AuthAuthority } from './auth-manager';
+import { getAuthAuthority, onAuthStateChanged, promptUserSignIn, readAuthAuthority, sameAccountAuthority, type AuthAuthority } from './auth-manager';
 import { fetchImage } from './image-fetcher';
 import { showErrorNotification } from './notifications';
 import { saveToSploot } from './save-flow';
@@ -770,6 +769,8 @@ async function recoverPendingSavesLocked(
   await scheduleContextMenuSaveQueueWakeup();
 }
 
+let removeAuthStateListener: (() => void) | undefined
+
 export function setupContextMenuSaveQueue(): void {
   chrome.alarms.onAlarm.addListener(alarm => {
     if (alarm.name !== CONTEXT_MENU_SAVE_ALARM_NAME) {
@@ -780,17 +781,17 @@ export function setupContextMenuSaveQueue(): void {
     });
   });
 
-  // A new worker can be revived by Clerk's cookie event after the original
-  // context-menu event was terminated. Re-run recovery on the signed-in state
-  // broadcast so ownerless prepared bytes cross that worker boundary.
-  chrome.runtime?.onMessage?.addListener(message => {
-    if (message?.type !== AUTH_MESSAGES.STATE_CHANGED || message.payload?.status !== 'signed-in') {
-      return false;
+  // The auth bridge and queue share this worker, so a signed-in Clerk resource
+  // transition is the reliable wakeup for an ownerless prepared save. Runtime
+  // messages are popup-facing and never loop back to their background sender.
+  removeAuthStateListener?.();
+  removeAuthStateListener = onAuthStateChanged(state => {
+    if (state.status !== 'signed-in') {
+      return;
     }
     void recoverPendingContextMenuSaves('startup').catch(error => {
       console.error('[Background][ContextMenu] Auth recovery failed', error);
     });
-    return false;
   });
 }
 

--- a/apps/extension/entrypoints/background/context-menu-save-queue.ts
+++ b/apps/extension/entrypoints/background/context-menu-save-queue.ts
@@ -1,6 +1,7 @@
 import { UPLOAD } from '@sploot/common';
+import { AUTH_MESSAGES } from '../../shared/auth-messages';
 import { setSaveStatus } from '../../shared/save-status';
-import { getAuthAuthority, readAuthAuthority, sameAccountAuthority, type AuthAuthority } from './auth-manager';
+import { getAuthAuthority, promptUserSignIn, readAuthAuthority, sameAccountAuthority, type AuthAuthority } from './auth-manager';
 import { fetchImage } from './image-fetcher';
 import { showErrorNotification } from './notifications';
 import { saveToSploot } from './save-flow';
@@ -26,7 +27,7 @@ export const MAX_CONTEXT_MENU_SAVE_STORAGE_BYTES = 8 * 1024 * 1024;
 /** Fetch, conversion, and upload each have a finite worker deadline. */
 export const CONTEXT_MENU_SAVE_DEADLINE_MS = UPLOAD.timeout;
 
-export type ContextMenuSaveJobState = 'pending' | 'processing' | 'failed' | 'paused';
+export type ContextMenuSaveJobState = 'pending' | 'processing' | 'failed' | 'paused' | 'awaiting-auth';
 
 export interface ContextMenuSaveJob {
   id: string;
@@ -150,7 +151,7 @@ function normalizeJob(job: unknown): ContextMenuSaveJob | null {
     typeof candidate.id !== 'string'
     || typeof candidate.imageUrl !== 'string'
     || typeof candidate.filename !== 'string'
-    || !['pending', 'processing', 'failed', 'paused'].includes(candidate.state ?? '')
+    || !['pending', 'processing', 'failed', 'paused', 'awaiting-auth'].includes(candidate.state ?? '')
     || typeof candidate.createdAt !== 'number'
     || !Number.isFinite(candidate.createdAt)
   ) {
@@ -716,6 +717,17 @@ async function recoverPendingSavesLocked(
           nextAttemptAt: Math.max(job.nextAttemptAt, now),
         };
       }
+      // A signed-out right-click is durably retained without an owner while the
+      // web sign-in tab is open. The first signed-in authority claims it before
+      // the job becomes eligible for upload; this is the restart boundary.
+      if (job.state === 'awaiting-auth' && !job.owner && currentAuthority) {
+        return {
+          ...job,
+          owner: currentAuthority,
+          state: 'pending' as const,
+          nextAttemptAt: now,
+        };
+      }
       // Same-account adoption: a new session of the owning account resumes its
       // paused saves — sign-out/re-auth must never orphan durable work.
       if (job.state === 'paused' && job.owner && sameAccountAuthority(currentAuthority, job.owner)) {
@@ -767,6 +779,19 @@ export function setupContextMenuSaveQueue(): void {
       console.error('[Background][ContextMenu] Alarm recovery failed', error);
     });
   });
+
+  // A new worker can be revived by Clerk's cookie event after the original
+  // context-menu event was terminated. Re-run recovery on the signed-in state
+  // broadcast so ownerless prepared bytes cross that worker boundary.
+  chrome.runtime?.onMessage?.addListener(message => {
+    if (message?.type !== AUTH_MESSAGES.STATE_CHANGED || message.payload?.status !== 'signed-in') {
+      return false;
+    }
+    void recoverPendingContextMenuSaves('startup').catch(error => {
+      console.error('[Background][ContextMenu] Auth recovery failed', error);
+    });
+    return false;
+  });
 }
 
 interface QueueAdmission {
@@ -815,7 +840,7 @@ function evictionCandidateIndex(jobs: ContextMenuSaveJob[], owner: AuthAuthority
  */
 function reclaimQueueCapacity(
   jobs: ContextMenuSaveJob[],
-  owner: AuthAuthority,
+  owner: AuthAuthority | null,
   incomingSourceBytes: number,
   now: number,
 ): QueueAdmission {
@@ -826,7 +851,9 @@ function reclaimQueueCapacity(
     || retainedSourceBytes(retained) + incomingSourceBytes > MAX_CONTEXT_MENU_SAVE_STORAGE_BYTES
   );
   while (overCapacity()) {
-    const candidateIndex = evictionCandidateIndex(retained, owner);
+    // An unaffiliated save cannot evict another account's retained work before
+    // authentication establishes the admission owner.
+    const candidateIndex = owner ? evictionCandidateIndex(retained, owner) : -1;
     if (candidateIndex < 0) {
       return { admitted: false, jobs, evictedCount: 0 };
     }
@@ -836,51 +863,60 @@ function reclaimQueueCapacity(
   return { admitted: true, jobs: retained, evictedCount };
 }
 
-/** Persist captured bytes and owner in one authoritative storage transition. */
+/** Persist captured bytes before any potentially long web sign-in wait. */
 export function enqueueCapturedSave(blob: Blob, filename: string, imageUrl = 'captured://visible-tab'): Promise<void> {
   return withDeadline(() => blobToStoredSource(blob), 'Image preparation timed out; save was not queued.')
-    .then(retained => exclusively(async () => {
-      // Throwing read: a transient auth failure surfaces as its own error
-      // instead of masquerading as "signed out".
+    .then(async retained => {
+      // Throwing read: a transient auth failure surfaces as its own error instead
+      // of masquerading as "signed out". Signed-out admission is deliberately
+      // ownerless and durable; it must not hold the image only in worker memory
+      // while promptUserSignIn waits for a cookie transition.
       const owner = await withDeadline(
         signal => readAuthAuthority(signal),
         'Auth check timed out; save was not queued.',
       );
-      if (!owner) {
-        throw new ContextMenuSaveQueueError('Sign in to Sploot before saving this image.', 'owner-unavailable');
-      }
+      return exclusively(async () => {
+        const jobs = await readJobs();
+        const now = Date.now();
+        const admission = reclaimQueueCapacity(jobs, owner, retained.sourceBytes.length, now);
+        if (!admission.admitted) {
+          throw new ContextMenuSaveQueueError(
+            'Save queue is full. Open the extension popup to retry or discard a failed save, then try again.',
+            'queue-full',
+          );
+        }
+        if (admission.evictedCount > 0) {
+          // Count only: evicted jobs belong to other accounts and their
+          // filenames/URLs must not leak into this profile's logs.
+          console.log(`[Background][ContextMenu] Reclaimed ${admission.evictedCount} expired or inactive retained save(s) to admit a new save`);
+        }
 
-      const jobs = await readJobs();
-      const now = Date.now();
-      const admission = reclaimQueueCapacity(jobs, owner, retained.sourceBytes.length, now);
-      if (!admission.admitted) {
-        throw new ContextMenuSaveQueueError(
-          'Save queue is full. Open the extension popup to retry or discard a failed save, then try again.',
-          'queue-full',
-        );
+        const job: ContextMenuSaveJob = {
+          id: crypto.randomUUID(),
+          imageUrl,
+          filename,
+          ...(owner ? { owner } : {}),
+          ...retained,
+          state: owner ? 'pending' : 'awaiting-auth',
+          createdAt: now,
+          attempts: 0,
+          nextAttemptAt: now,
+        };
+        await writeJobs([...admission.jobs, job]);
+        setQueuedStatus(filename);
+        return { id: job.id, awaitingAuth: !owner };
+      });
+    })
+    .then(async ({ id: jobId, awaitingAuth }) => {
+      if (awaitingAuth) {
+        // The bytes are already durable. If this worker is terminated while the
+        // tab is open, a new worker claims the ownerless job on the signed-in
+        // auth broadcast and resumes it without another right-click.
+        const signedIn = await promptUserSignIn();
+        if (!signedIn) {
+          return;
+        }
       }
-      if (admission.evictedCount > 0) {
-        // Count only: evicted jobs belong to other accounts and their
-        // filenames/URLs must not leak into this profile's logs.
-        console.log(`[Background][ContextMenu] Reclaimed ${admission.evictedCount} expired or inactive retained save(s) to admit a new save`);
-      }
-
-      const job: ContextMenuSaveJob = {
-        id: crypto.randomUUID(),
-        imageUrl,
-        filename,
-        owner,
-        ...retained,
-        state: 'pending',
-        createdAt: now,
-        attempts: 0,
-        nextAttemptAt: now,
-      };
-      await writeJobs([...admission.jobs, job]);
-      setQueuedStatus(filename);
-      return job.id;
-    }))
-    .then(async jobId => {
       // Start recovery before acknowledging the durable write. The attempt
       // remains detached and bounded, but is scoped to this exact durable job;
       // a late event cannot process a later job after a worker boundary.

--- a/apps/extension/entrypoints/background/context-menu.test.ts
+++ b/apps/extension/entrypoints/background/context-menu.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUTH_MESSAGES } from '../../shared/auth-messages';
 import { CONTEXT_MENU_SAVE_MESSAGES } from '../../shared/context-menu-save-messages';
 
 const mocks = vi.hoisted(() => ({
@@ -52,6 +53,7 @@ type MessageHandler = (
 let onClicked: ClickHandler;
 let onStartup: (() => Promise<void>) | undefined;
 let onMessage: MessageHandler;
+let runtimeMessageListeners: Array<(message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => unknown> = [];
 let contextMenusCreate: ReturnType<typeof vi.fn>;
 let contextMenusRemove: ReturnType<typeof vi.fn>;
 let storedQueue: unknown[] = [];
@@ -63,6 +65,7 @@ beforeEach(() => {
   contextMenusCreate = vi.fn();
   contextMenusRemove = vi.fn();
   storedQueue = [];
+  runtimeMessageListeners = [];
   vi.stubGlobal('chrome', {
     contextMenus: {
       create: contextMenusCreate,
@@ -72,7 +75,7 @@ beforeEach(() => {
     runtime: {
       onInstalled: { addListener: vi.fn() },
       onStartup: { addListener: vi.fn((fn: () => Promise<void>) => { onStartup = fn; }) },
-      onMessage: { addListener: vi.fn((fn: MessageHandler) => { onMessage = fn; }) },
+      onMessage: { addListener: vi.fn((fn: MessageHandler) => { runtimeMessageListeners.push(fn as unknown as (message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => unknown); onMessage = fn; }) },
     },
     alarms: {
       create: vi.fn(async () => undefined),
@@ -84,7 +87,7 @@ beforeEach(() => {
         get: vi.fn().mockImplementation(async () => ({
           'sploot:context-menu-queue': storedQueue.map(job => ({
             ...(job as Record<string, unknown>),
-            owner: (job as Record<string, unknown>).owner ?? OWNER,
+            owner: (job as Record<string, unknown>).owner ?? ((job as Record<string, unknown>).state === 'awaiting-auth' ? undefined : OWNER),
             sourceBytes: (job as Record<string, unknown>).sourceBytes ?? btoa('x'),
             sourceType: (job as Record<string, unknown>).sourceType ?? 'image/png',
           })),
@@ -126,6 +129,36 @@ describe('context menu save', () => {
       expect.any(Blob), 'cat.png', expect.anything(), expect.any(AbortSignal),
     ));
     await vi.waitFor(() => expect(mocks.showSuccessNotification).toHaveBeenCalled());
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+
+  it('continues the original right-click from the signed-in runtime event after a worker boundary', async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    mocks.getAuthAuthority.mockClear();
+    mocks.getAuthAuthority
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(OWNER);
+    let finishPrompt!: (signedIn: boolean) => void;
+    mocks.promptUserSignIn.mockReturnValueOnce(new Promise(resolve => { finishPrompt = resolve; }));
+
+    const click = onClicked({ menuItemId: 'save-to-sploot', srcUrl: 'https://x.test/cat.png' }, { title: 'Cat' });
+    await vi.waitFor(() => expect(mocks.promptUserSignIn).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(storedQueue).toEqual([expect.objectContaining({ state: 'awaiting-auth' })]));
+
+    for (const listener of runtimeMessageListeners) {
+      listener({
+        type: AUTH_MESSAGES.STATE_CHANGED,
+        payload: { status: 'signed-in', userId: OWNER.userId, sessionId: OWNER.sessionId },
+      }, {}, vi.fn());
+    }
+
+    await vi.waitFor(() => expect(mocks.uploadImage).toHaveBeenCalledWith(
+      expect.any(Blob), 'cat.png', expect.anything(), expect.any(AbortSignal),
+    ));
+    finishPrompt(false);
+    await click;
+
+    expect(mocks.showSuccessNotification).toHaveBeenCalled();
     expect(mocks.showErrorNotification).not.toHaveBeenCalled();
   });
 

--- a/apps/extension/entrypoints/background/context-menu.test.ts
+++ b/apps/extension/entrypoints/background/context-menu.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AUTH_MESSAGES } from '../../shared/auth-messages';
 import { CONTEXT_MENU_SAVE_MESSAGES } from '../../shared/context-menu-save-messages';
 
 const mocks = vi.hoisted(() => ({
@@ -7,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   isAuthenticated: vi.fn(),
   promptUserSignIn: vi.fn(),
   getAuthAuthority: vi.fn(),
+  onAuthStateChanged: vi.fn(),
   readAuthAuthority: vi.fn(),
   getAuthTokenForAuthority: vi.fn(),
   sameAccountAuthority: vi.fn(),
@@ -29,6 +29,7 @@ vi.mock('./auth-manager', () => ({
   isAuthenticated: mocks.isAuthenticated,
   promptUserSignIn: mocks.promptUserSignIn,
   getAuthAuthority: mocks.getAuthAuthority,
+  onAuthStateChanged: mocks.onAuthStateChanged,
   readAuthAuthority: mocks.readAuthAuthority,
   getAuthTokenForAuthority: mocks.getAuthTokenForAuthority,
   sameAccountAuthority: mocks.sameAccountAuthority,
@@ -53,7 +54,7 @@ type MessageHandler = (
 let onClicked: ClickHandler;
 let onStartup: (() => Promise<void>) | undefined;
 let onMessage: MessageHandler;
-let runtimeMessageListeners: Array<(message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => unknown> = [];
+let authStateListeners: Array<(state: { status: string }) => void> = [];
 let contextMenusCreate: ReturnType<typeof vi.fn>;
 let contextMenusRemove: ReturnType<typeof vi.fn>;
 let storedQueue: unknown[] = [];
@@ -65,7 +66,7 @@ beforeEach(() => {
   contextMenusCreate = vi.fn();
   contextMenusRemove = vi.fn();
   storedQueue = [];
-  runtimeMessageListeners = [];
+  authStateListeners = [];
   vi.stubGlobal('chrome', {
     contextMenus: {
       create: contextMenusCreate,
@@ -75,7 +76,7 @@ beforeEach(() => {
     runtime: {
       onInstalled: { addListener: vi.fn() },
       onStartup: { addListener: vi.fn((fn: () => Promise<void>) => { onStartup = fn; }) },
-      onMessage: { addListener: vi.fn((fn: MessageHandler) => { runtimeMessageListeners.push(fn as unknown as (message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => unknown); onMessage = fn; }) },
+      onMessage: { addListener: vi.fn((fn: MessageHandler) => { onMessage = fn; }) },
     },
     alarms: {
       create: vi.fn(async () => undefined),
@@ -117,6 +118,10 @@ beforeEach(() => {
     thumbnailUrl: 't',
     isDuplicate: false,
   });
+  mocks.onAuthStateChanged.mockImplementation((listener: (state: { status: string }) => void) => {
+    authStateListeners.push(listener);
+    return () => undefined;
+  });
   setupContextMenu();
 });
 
@@ -145,11 +150,8 @@ describe('context menu save', () => {
     await vi.waitFor(() => expect(mocks.promptUserSignIn).toHaveBeenCalledOnce());
     await vi.waitFor(() => expect(storedQueue).toEqual([expect.objectContaining({ state: 'awaiting-auth' })]));
 
-    for (const listener of runtimeMessageListeners) {
-      listener({
-        type: AUTH_MESSAGES.STATE_CHANGED,
-        payload: { status: 'signed-in', userId: OWNER.userId, sessionId: OWNER.sessionId },
-      }, {}, vi.fn());
+    for (const listener of authStateListeners) {
+      listener({ status: 'signed-in' });
     }
 
     await vi.waitFor(() => expect(mocks.uploadImage).toHaveBeenCalledWith(

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -12,7 +12,7 @@ import {
 } from '@clerk/chrome-extension'
 import type { SplootEnrollmentPublicState } from '@sploot/common'
 import { installPopupAuthSync } from '../../shared/auth-sync'
-import { AUTH_MESSAGES, type AuthState } from '../../shared/auth-messages'
+import { AUTH_MESSAGES } from '../../shared/auth-messages'
 import { IS_DEV_BUILD } from '../../shared/build-mode'
 import { requestVisibleTabCapture } from '../../shared/capture-messages'
 import { CONTEXT_MENU_SAVE_MESSAGES, type ContextMenuSaveJobSummary } from '../../shared/context-menu-save-messages'

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -50,7 +50,6 @@ function App() {
       telemetry={{ disabled: true }}
       __experimental_syncHostListener
     >
-      <AuthStatusReporter />
       <AuthStateSync />
       <PopupContent>
         <SignedOut>

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -491,3 +491,9 @@ function AuthStateSync() {
 
   return null
 }
+
+// Render app
+const root = document.getElementById('root')
+if (root) {
+  ReactDOM.createRoot(root).render(<App />)
+}

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -5,11 +5,12 @@ import {
   SignedIn,
   SignedOut,
   SignOutButton,
-  useAuth,
+  useClerk,
   useSession,
   useUser,
 } from '@clerk/chrome-extension'
 import type { SplootEnrollmentPublicState } from '@sploot/common'
+import { installPopupAuthSync } from '../../shared/auth-sync'
 import { AUTH_MESSAGES, type AuthState } from '../../shared/auth-messages'
 import { IS_DEV_BUILD } from '../../shared/build-mode'
 import { requestVisibleTabCapture } from '../../shared/capture-messages'
@@ -49,6 +50,7 @@ function App() {
       __experimental_syncHostListener
     >
       <AuthStatusReporter />
+      <AuthStateSync />
       <PopupContent>
         <SignedOut>
           <SignedOutPanel />
@@ -480,29 +482,12 @@ function SaveStatusStrip({ status }: { status: SaveStatus }) {
   )
 }
 
-function AuthStatusReporter() {
-  const { isSignedIn } = useAuth()
-  const { user } = useUser()
-  const { session } = useSession()
+function AuthStateSync() {
+  const clerk = useClerk()
 
   useEffect(() => {
-    const payload: AuthState = {
-      status: isSignedIn ? 'signed-in' : 'signed-out',
-      userId: user?.id ?? null,
-      sessionId: session?.id ?? null,
-      expiresAt: session?.expireAt?.getTime() ?? null,
-    }
-
-    chrome.runtime
-      .sendMessage({ type: AUTH_MESSAGES.STATE_UPDATE, payload })
-      .catch(error => console.error('[Popup] Failed to publish auth state', error))
-  }, [isSignedIn, user?.id, session?.id, session?.expireAt])
+    return installPopupAuthSync(clerk)
+  }, [clerk])
 
   return null
-}
-
-// Render app
-const root = document.getElementById('root')
-if (root) {
-  ReactDOM.createRoot(root).render(<App />)
 }

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -5,6 +5,7 @@ import {
   SignedIn,
   SignedOut,
   SignOutButton,
+  useAuth,
   useClerk,
   useSession,
   useUser,
@@ -483,11 +484,15 @@ function SaveStatusStrip({ status }: { status: SaveStatus }) {
 }
 
 function AuthStateSync() {
+  const { isLoaded } = useAuth()
   const clerk = useClerk()
 
   useEffect(() => {
+    if (!isLoaded) {
+      return
+    }
     return installPopupAuthSync(clerk)
-  }, [clerk])
+  }, [clerk, isLoaded])
 
   return null
 }

--- a/apps/extension/shared/api-client.test.ts
+++ b/apps/extension/shared/api-client.test.ts
@@ -60,4 +60,20 @@ describe('SplootApiClient token provider', () => {
       })
     );
   });
+
+  it('makes an expired-session notification actionable with the web sign-in route', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 401 })));
+
+    const { createSplootApiClient } = await import('./api-client');
+    const client = createSplootApiClient({
+      getToken: vi.fn(async () => 'injected-token'),
+    });
+
+    await expect(
+      client.uploadImage(new Blob(['image'], { type: 'image/jpeg' }), 'asset.jpg')
+    ).rejects.toMatchObject({
+      code: 'unauthorized',
+      actionHref: '/sign-in',
+    });
+  });
 });

--- a/apps/extension/shared/api-client.ts
+++ b/apps/extension/shared/api-client.ts
@@ -92,7 +92,13 @@ async function parseErrorResponse(
   }
 
   if (response.status === 401) {
-    return new SplootApiClientError('Session expired. Please login again.', response.status, 'unauthorized');
+    return new SplootApiClientError(
+      'Session expired. Please login again.',
+      response.status,
+      'unauthorized',
+      false,
+      '/sign-in'
+    );
   }
 
   if (response.status === 413) {

--- a/apps/extension/shared/auth-messages.ts
+++ b/apps/extension/shared/auth-messages.ts
@@ -8,13 +8,13 @@ export interface AuthState {
 }
 
 export const AUTH_MESSAGES = {
-  STATE_UPDATE: 'AUTH_STATE_UPDATE',
+  STATE_CHANGED: 'AUTH_STATE_CHANGED',
   REQUEST_STATE: 'AUTH_REQUEST_STATE',
   RUN_DIAGNOSTICS: 'RUN_AUTH_DIAGNOSTICS',
 } as const
 
-export interface AuthStateUpdateMessage {
-  type: typeof AUTH_MESSAGES.STATE_UPDATE
+export interface AuthStateChangedMessage {
+  type: typeof AUTH_MESSAGES.STATE_CHANGED
   payload: AuthState
 }
 
@@ -27,6 +27,6 @@ export interface AuthDiagnosticsRequestMessage {
 }
 
 export type AuthMessage =
-  | AuthStateUpdateMessage
+  | AuthStateChangedMessage
   | AuthStateRequestMessage
   | AuthDiagnosticsRequestMessage

--- a/apps/extension/shared/auth-sync.test.ts
+++ b/apps/extension/shared/auth-sync.test.ts
@@ -39,7 +39,7 @@ describe('popup auth sync', () => {
     expect(reloadPopup).not.toHaveBeenCalled()
   })
 
-  it('does not reload before the popup Clerk client hydrates', async () => {
+  it('converges once for a loaded stale signed-in popup', async () => {
     runtime.sendMessage.mockResolvedValue({
       state: { status: 'signed-in', userId: 'user_1', sessionId: 'session_1' },
     })
@@ -59,7 +59,57 @@ describe('popup auth sync', () => {
     )
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(reloadPopup).not.toHaveBeenCalled()
+    expect(reloadPopup).toHaveBeenCalledTimes(1)
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+      reloadGuardStorage,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(reloadPopup).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads once when a stale local user conflicts with signed-out state', async () => {
+    const clerk = { user: { reload: vi.fn(async () => undefined) } }
+    const reloadPopup = vi.fn()
+    const storage = new Map<string, string>()
+    runtime.sendMessage.mockResolvedValue({ state: { status: 'signed-out' } })
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+      {
+        getItem: key => storage.get(key) ?? null,
+        setItem: (key, value) => { storage.set(key, value) },
+      },
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(reloadPopup).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to memory when session storage rejects access', async () => {
+    runtime.sendMessage.mockResolvedValue({
+      state: { status: 'signed-in', userId: 'user_throw', sessionId: 'session_throw' },
+    })
+    const clerk = { user: null }
+    const reloadPopup = vi.fn()
+    const throwingStorage = {
+      getItem: () => { throw new Error('storage unavailable') },
+      setItem: () => { throw new Error('storage unavailable') },
+    }
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+      throwingStorage,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(reloadPopup).toHaveBeenCalledTimes(1)
   })
 
   it('refreshes an open popup from a worker state event without receiving a token', async () => {

--- a/apps/extension/shared/auth-sync.test.ts
+++ b/apps/extension/shared/auth-sync.test.ts
@@ -39,6 +39,29 @@ describe('popup auth sync', () => {
     expect(reloadPopup).not.toHaveBeenCalled()
   })
 
+  it('does not reload before the popup Clerk client hydrates', async () => {
+    runtime.sendMessage.mockResolvedValue({
+      state: { status: 'signed-in', userId: 'user_1', sessionId: 'session_1' },
+    })
+    const clerk = { user: null }
+    const reloadPopup = vi.fn()
+    const storage = new Map<string, string>()
+    const reloadGuardStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => { storage.set(key, value) },
+    }
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+      reloadGuardStorage,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(reloadPopup).not.toHaveBeenCalled()
+  })
+
   it('refreshes an open popup from a worker state event without receiving a token', async () => {
     const clerk = { user: null }
     const reloadPopup = vi.fn()

--- a/apps/extension/shared/auth-sync.test.ts
+++ b/apps/extension/shared/auth-sync.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AUTH_MESSAGES, type AuthState } from './auth-messages'
+import { installPopupAuthSync } from './auth-sync'
+
+describe('popup auth sync', () => {
+  let listeners: Array<(message: unknown, sender: { id?: string }) => void>
+  let runtime: {
+    id: string
+    onMessage: {
+      addListener: ReturnType<typeof vi.fn>
+      removeListener: ReturnType<typeof vi.fn>
+    }
+    sendMessage: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    listeners = []
+    runtime = {
+      id: 'extension-id',
+      onMessage: {
+        addListener: vi.fn(listener => listeners.push(listener)),
+        removeListener: vi.fn(),
+      },
+      sendMessage: vi.fn(async () => ({ state: { status: 'signed-out' } })),
+    }
+  })
+
+  it('does not reload repeatedly for the initial signed-out state', async () => {
+    const clerk = { user: null }
+    const reloadPopup = vi.fn()
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(reloadPopup).not.toHaveBeenCalled()
+  })
+
+  it('refreshes an open popup from a worker state event without receiving a token', async () => {
+    const clerk = { user: null }
+    const reloadPopup = vi.fn()
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+    reloadPopup.mockClear()
+
+    const signedInState: AuthState = {
+      status: 'signed-in',
+      userId: 'user_123',
+      sessionId: 'session_123',
+      expiresAt: 1780000000000,
+    }
+    listeners[0](
+      {
+        type: AUTH_MESSAGES.STATE_CHANGED,
+        payload: signedInState,
+        token: 'must-never-cross-the-message-boundary',
+      },
+      { id: runtime.id }
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(reloadPopup).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(reloadPopup.mock.calls)).not.toContain('must-never-cross')
+  })
+
+  it('ignores foreign or malformed messages and removes its listener on cleanup', async () => {
+    const clerk = { user: null }
+    const reloadPopup = vi.fn()
+    const cleanup = installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+    reloadPopup.mockClear()
+
+    listeners[0]({ type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'signed-in' } }, { id: 'foreign' })
+    listeners[0]({ type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'not-a-state' } }, { id: runtime.id })
+    expect(reloadPopup).not.toHaveBeenCalled()
+
+    cleanup()
+    expect(runtime.onMessage.removeListener).toHaveBeenCalledWith(listeners[0])
+    listeners[0]({ type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'signed-out' } }, { id: runtime.id })
+    expect(reloadPopup).not.toHaveBeenCalled()
+  })
+})

--- a/apps/extension/shared/auth-sync.test.ts
+++ b/apps/extension/shared/auth-sync.test.ts
@@ -91,7 +91,7 @@ describe('popup auth sync', () => {
     expect(reloadPopup).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to memory when session storage rejects access', async () => {
+  it('fails safe across remounts when session storage rejects access', async () => {
     runtime.sendMessage.mockResolvedValue({
       state: { status: 'signed-in', userId: 'user_throw', sessionId: 'session_throw' },
     })
@@ -109,16 +109,31 @@ describe('popup auth sync', () => {
       throwingStorage,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
-    expect(reloadPopup).toHaveBeenCalledTimes(1)
+    expect(reloadPopup).not.toHaveBeenCalled()
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+      reloadPopup,
+      throwingStorage,
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(reloadPopup).not.toHaveBeenCalled()
   })
 
   it('refreshes an open popup from a worker state event without receiving a token', async () => {
     const clerk = { user: null }
     const reloadPopup = vi.fn()
+    const storage = new Map<string, string>()
+    const reloadGuardStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => { storage.set(key, value) },
+    }
     installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
       reloadPopup,
+      reloadGuardStorage,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
     reloadPopup.mockClear()

--- a/apps/extension/shared/auth-sync.test.ts
+++ b/apps/extension/shared/auth-sync.test.ts
@@ -25,118 +25,118 @@ describe('popup auth sync', () => {
     }
   })
 
-  it('does not reload repeatedly for the initial signed-out state', async () => {
-    const clerk = { user: null }
-    const reloadPopup = vi.fn()
-
-    installPopupAuthSync(
-      clerk,
-      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-    )
-    await new Promise(resolve => setTimeout(resolve, 0))
-
-    expect(reloadPopup).not.toHaveBeenCalled()
-  })
-
-  it('converges once for a loaded stale signed-in popup', async () => {
-    runtime.sendMessage.mockResolvedValue({
-      state: { status: 'signed-in', userId: 'user_1', sessionId: 'session_1' },
-    })
-    const clerk = { user: null }
-    const reloadPopup = vi.fn()
-    const storage = new Map<string, string>()
-    const reloadGuardStorage = {
-      getItem: (key: string) => storage.get(key) ?? null,
-      setItem: (key: string, value: string) => { storage.set(key, value) },
+  it('does not rehydrate repeatedly for the initial signed-out state', async () => {
+    const clerk = {
+      user: null,
+      __internal_reloadInitialResources: vi.fn(async () => undefined),
     }
 
     installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-      reloadGuardStorage,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(reloadPopup).toHaveBeenCalledTimes(1)
+    expect(clerk.__internal_reloadInitialResources).not.toHaveBeenCalled()
+  })
+
+  it('rehydrates once for a loaded stale signed-in popup without reloading its window', async () => {
+    runtime.sendMessage.mockResolvedValue({
+      state: { status: 'signed-in', userId: 'user_1', sessionId: 'session_1' },
+    })
+    const clerk = {
+      user: null,
+      __internal_reloadInitialResources: vi.fn(async () => undefined),
+    }
 
     installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-      reloadGuardStorage,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
-    expect(reloadPopup).toHaveBeenCalledTimes(1)
+
+    expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce()
   })
 
-  it('reloads once when a stale local user conflicts with signed-out state', async () => {
-    const clerk = { user: { reload: vi.fn(async () => undefined) } }
-    const reloadPopup = vi.fn()
-    const storage = new Map<string, string>()
+  it('replays the latest auth state after an earlier refresh settles', async () => {
+    runtime.sendMessage.mockResolvedValue({
+      state: { status: 'signed-in', userId: 'user_1', sessionId: 'session_1' },
+    })
+    let resolveFirst!: () => void
+    const firstRefresh = new Promise<void>(resolve => { resolveFirst = resolve })
+    const clerk = {
+      user: null,
+      __internal_reloadInitialResources: vi.fn()
+        .mockReturnValueOnce(firstRefresh)
+        .mockResolvedValue(undefined),
+    }
+
+    installPopupAuthSync(
+      clerk,
+      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
+    )
+    await vi.waitFor(() => expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce())
+
+    listeners[0](
+      {
+        type: AUTH_MESSAGES.STATE_CHANGED,
+        payload: { status: 'signed-in', userId: 'user_2', sessionId: 'session_2' },
+      },
+      { id: runtime.id },
+    )
+    resolveFirst()
+
+    await vi.waitFor(() => expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledTimes(2))
+  })
+
+  it('rehydrates when a stale local user conflicts with signed-out state', async () => {
+    const clerk = {
+      user: { reload: vi.fn(async () => undefined) },
+      __internal_reloadInitialResources: vi.fn(async () => undefined),
+    }
     runtime.sendMessage.mockResolvedValue({ state: { status: 'signed-out' } })
 
     installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-      {
-        getItem: key => storage.get(key) ?? null,
-        setItem: (key, value) => { storage.set(key, value) },
-      },
     )
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(reloadPopup).toHaveBeenCalledTimes(1)
+    expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce()
+    expect(clerk.user.reload).not.toHaveBeenCalled()
   })
 
-  it('fails safe across remounts when session storage rejects access', async () => {
+  it('reports a Clerk rehydration failure without falling back to window reload', async () => {
     runtime.sendMessage.mockResolvedValue({
       state: { status: 'signed-in', userId: 'user_throw', sessionId: 'session_throw' },
     })
-    const clerk = { user: null }
-    const reloadPopup = vi.fn()
-    const throwingStorage = {
-      getItem: () => { throw new Error('storage unavailable') },
-      setItem: () => { throw new Error('storage unavailable') },
+    const clerk = {
+      user: null,
+      __internal_reloadInitialResources: vi.fn(async () => { throw new Error('resource refresh failed') }),
     }
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-      throwingStorage,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
-    expect(reloadPopup).not.toHaveBeenCalled()
 
-    installPopupAuthSync(
-      clerk,
-      runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-      throwingStorage,
-    )
-    await new Promise(resolve => setTimeout(resolve, 0))
-    expect(reloadPopup).not.toHaveBeenCalled()
+    expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce()
+    expect(errorSpy).toHaveBeenCalledWith('[Popup] Failed to refresh auth state', expect.any(Error))
+    errorSpy.mockRestore()
   })
 
-  it('refreshes an open popup from a worker state event without receiving a token', async () => {
-    const clerk = { user: null }
-    const reloadPopup = vi.fn()
-    const storage = new Map<string, string>()
-    const reloadGuardStorage = {
-      getItem: (key: string) => storage.get(key) ?? null,
-      setItem: (key: string, value: string) => { storage.set(key, value) },
+  it('rehydrates an open popup from a worker state event without receiving a token', async () => {
+    const clerk = {
+      user: null,
+      __internal_reloadInitialResources: vi.fn(async () => undefined),
     }
     installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
-      reloadGuardStorage,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
-    reloadPopup.mockClear()
 
     const signedInState: AuthState = {
       status: 'signed-in',
@@ -154,28 +154,28 @@ describe('popup auth sync', () => {
     )
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(reloadPopup).toHaveBeenCalledTimes(1)
-    expect(JSON.stringify(reloadPopup.mock.calls)).not.toContain('must-never-cross')
+    expect(clerk.__internal_reloadInitialResources).toHaveBeenCalledOnce()
+    expect(JSON.stringify(clerk.__internal_reloadInitialResources.mock.calls)).not.toContain('must-never-cross')
   })
 
   it('ignores foreign or malformed messages and removes its listener on cleanup', async () => {
-    const clerk = { user: null }
-    const reloadPopup = vi.fn()
+    const clerk = {
+      user: null,
+      __internal_reloadInitialResources: vi.fn(async () => undefined),
+    }
     const cleanup = installPopupAuthSync(
       clerk,
       runtime as unknown as NonNullable<Parameters<typeof installPopupAuthSync>[1]>,
-      reloadPopup,
     )
     await new Promise(resolve => setTimeout(resolve, 0))
-    reloadPopup.mockClear()
 
     listeners[0]({ type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'signed-in' } }, { id: 'foreign' })
     listeners[0]({ type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'not-a-state' } }, { id: runtime.id })
-    expect(reloadPopup).not.toHaveBeenCalled()
+    expect(clerk.__internal_reloadInitialResources).not.toHaveBeenCalled()
 
     cleanup()
     expect(runtime.onMessage.removeListener).toHaveBeenCalledWith(listeners[0])
     listeners[0]({ type: AUTH_MESSAGES.STATE_CHANGED, payload: { status: 'signed-out' } }, { id: runtime.id })
-    expect(reloadPopup).not.toHaveBeenCalled()
+    expect(clerk.__internal_reloadInitialResources).not.toHaveBeenCalled()
   })
 })

--- a/apps/extension/shared/auth-sync.ts
+++ b/apps/extension/shared/auth-sync.ts
@@ -17,6 +17,24 @@ interface ClerkRefreshClient {
   user?: { reload(): Promise<unknown> } | null
 }
 
+interface ReloadGuardStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+const memoryReloadGuard = new Map<string, string>()
+
+function getReloadGuardStorage(): ReloadGuardStorage {
+  try {
+    return window.sessionStorage
+  } catch {
+    return {
+      getItem: key => memoryReloadGuard.get(key) ?? null,
+      setItem: (key, value) => { memoryReloadGuard.set(key, value) },
+    }
+  }
+}
+
 function isAuthState(value: unknown): value is AuthState {
   if (!value || typeof value !== 'object') {
     return false
@@ -40,10 +58,11 @@ export function installPopupAuthSync(
   clerk: ClerkRefreshClient,
   runtime: AuthSyncRuntime = chrome.runtime,
   reloadPopup: () => void = () => window.location.reload(),
+  reloadGuardStorage: ReloadGuardStorage | null = getReloadGuardStorage(),
 ): () => void {
   let disposed = false
 
-  const refresh = (state: AuthState) => {
+  const refresh = (state: AuthState, allowReload: boolean) => {
     if (disposed) {
       return
     }
@@ -55,11 +74,33 @@ export function installPopupAuthSync(
       return
     }
 
-    const refreshPromise = state.status === 'signed-in' && clerk.user
-      ? clerk.user.reload()
-      : Promise.resolve().then(reloadPopup)
-    void refreshPromise.catch(error => {
-      console.error('[Popup] Failed to refresh auth state', error)
+    if (state.status === 'signed-in' && clerk.user) {
+      void clerk.user.reload().catch(error => {
+        console.error('[Popup] Failed to refresh auth state', error)
+      })
+      return
+    }
+
+    if (!allowReload) {
+      return
+    }
+
+    // A reload is only a bootstrap fallback while Clerk hydrates from the
+    // synced web session. Persist the guard so a remount cannot reload forever.
+    if (!reloadGuardStorage) {
+      return
+    }
+    const reloadKey = `sploot-auth-refresh:${state.status}:${state.sessionId ?? state.userId ?? 'none'}`
+    try {
+      if (reloadGuardStorage.getItem(reloadKey)) {
+        return
+      }
+      reloadGuardStorage.setItem(reloadKey, '1')
+    } catch {
+      return
+    }
+    void Promise.resolve().then(reloadPopup).catch(error => {
+      console.error('[Popup] Failed to reload auth state', error)
     })
   }
 
@@ -70,7 +111,7 @@ export function installPopupAuthSync(
 
     const candidate = message as { type?: unknown; payload?: unknown }
     if (candidate.type === AUTH_MESSAGES.STATE_CHANGED && shouldRefresh(candidate.payload)) {
-      refresh(candidate.payload)
+      refresh(candidate.payload, true)
     }
   }
 
@@ -84,7 +125,7 @@ export function installPopupAuthSync(
 
       const state = (response as { state?: unknown }).state
       if (shouldRefresh(state)) {
-        refresh(state)
+        refresh(state, false)
       }
     })
     .catch(error => {

--- a/apps/extension/shared/auth-sync.ts
+++ b/apps/extension/shared/auth-sync.ts
@@ -15,19 +15,7 @@ interface AuthSyncRuntime {
 
 interface ClerkRefreshClient {
   user?: { reload(): Promise<unknown> } | null
-}
-
-interface ReloadGuardStorage {
-  getItem(key: string): string | null
-  setItem(key: string, value: string): void
-}
-
-function getReloadGuardStorage(): ReloadGuardStorage | null {
-  try {
-    return window.sessionStorage
-  } catch {
-    return null
-  }
+  __internal_reloadInitialResources(): Promise<void>
 }
 
 function isAuthState(value: unknown): value is AuthState {
@@ -47,54 +35,77 @@ function shouldRefresh(value: unknown): value is AuthState {
  * Connect the popup's Clerk provider to the background auth authority.
  *
  * The message carries state metadata only. The popup asks its own Clerk client
- * to reload so session tokens never cross the runtime message boundary.
+ * to rehydrate resources so session tokens never cross the runtime message boundary
+ * and the MV3 service worker never needs a window API.
  */
 export function installPopupAuthSync(
   clerk: ClerkRefreshClient,
   runtime: AuthSyncRuntime = chrome.runtime,
-  reloadPopup: () => void = () => window.location.reload(),
-  reloadGuardStorage: ReloadGuardStorage | null = getReloadGuardStorage(),
 ): () => void {
   let disposed = false
+
+  let lastRefreshKey: string | undefined
+  let pendingState: AuthState | undefined
+  let refreshInFlight: Promise<void> | undefined
+
+  const refreshKey = (state: AuthState) => (
+    state.status + ':' + (state.sessionId ?? state.userId ?? 'none')
+  )
+
+  const drainRefresh = () => {
+    if (disposed || refreshInFlight) {
+      return
+    }
+
+    const state = pendingState
+    pendingState = undefined
+    if (!state) {
+      return
+    }
+
+    // A signed-out popup is already in the correct Clerk state. Do not turn the
+    // initial REQUEST_STATE response into a refresh loop.
+    if (state.status === 'signed-out' && !clerk.user) {
+      return
+    }
+
+    // Coalesce bursts while Clerk rehydrates, but always process the latest
+    // state after the current operation settles. This preserves sign-out and
+    // account-switch transitions instead of dropping them at the in-flight
+    // boundary.
+    const key = refreshKey(state)
+    if (lastRefreshKey === key) {
+      return
+    }
+    lastRefreshKey = key
+
+    refreshInFlight = Promise.resolve()
+      .then(() => {
+        if (state.status === 'signed-in' && clerk.user) {
+          return clerk.user.reload().then(() => undefined)
+        }
+        // The background state is metadata only; a popup never crosses the
+        // token boundary and never reloads its window.
+        return clerk.__internal_reloadInitialResources()
+      })
+      .catch(error => {
+        if (lastRefreshKey === key) {
+          lastRefreshKey = undefined
+        }
+        console.error('[Popup] Failed to refresh auth state', error)
+      })
+      .finally(() => {
+        refreshInFlight = undefined
+        drainRefresh()
+      })
+  }
 
   const refresh = (state: AuthState) => {
     if (disposed) {
       return
     }
-
-    // A signed-out popup is already in the correct Clerk state. Reload only
-    // when transitioning an existing signed-in popup, otherwise the initial
-    // signed-out REQUEST_STATE response would reload the popup forever.
-    if (state.status === 'signed-out' && !clerk.user) {
-      return
-    }
-
-    if (state.status === 'signed-in' && clerk.user) {
-      void clerk.user.reload().catch(error => {
-        console.error('[Popup] Failed to refresh auth state', error)
-      })
-      return
-    }
-
-
-    // A reload is only a bootstrap fallback while Clerk hydrates from the
-    // synced web session. Persist the guard so a remount cannot reload forever.
-    if (!reloadGuardStorage) {
-      return
-    }
-    const reloadKey = `sploot-auth-refresh:${state.status}:${state.sessionId ?? state.userId ?? 'none'}`
-    try {
-      if (reloadGuardStorage.getItem(reloadKey)) {
-        return
-      }
-      reloadGuardStorage.setItem(reloadKey, '1')
-    } catch {
-      // Never hard-reload without a persistent guard that survives remounts.
-      return
-    }
-    void Promise.resolve().then(reloadPopup).catch(error => {
-      console.error('[Popup] Failed to reload auth state', error)
-    })
+    pendingState = state
+    drainRefresh()
   }
 
   const onMessage = (message: unknown, sender: RuntimeMessageSender) => {

--- a/apps/extension/shared/auth-sync.ts
+++ b/apps/extension/shared/auth-sync.ts
@@ -1,0 +1,103 @@
+import { AUTH_MESSAGES, type AuthState } from './auth-messages'
+
+interface RuntimeMessageSender {
+  id?: string
+}
+
+interface AuthSyncRuntime {
+  id: string
+  onMessage: {
+    addListener(listener: (message: unknown, sender: RuntimeMessageSender) => void): void
+    removeListener(listener: (message: unknown, sender: RuntimeMessageSender) => void): void
+  }
+  sendMessage(message: unknown): Promise<unknown>
+}
+
+interface ClerkRefreshClient {
+  user?: { reload(): Promise<unknown> } | null
+}
+
+function isAuthState(value: unknown): value is AuthState {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const state = value as Partial<AuthState>
+  return state.status === 'unknown' || state.status === 'signed-in' || state.status === 'signed-out'
+}
+
+function shouldRefresh(value: unknown): value is AuthState {
+  return isAuthState(value) && value.status !== 'unknown'
+}
+
+/**
+ * Connect the popup's Clerk provider to the background auth authority.
+ *
+ * The message carries state metadata only. The popup asks its own Clerk client
+ * to reload so session tokens never cross the runtime message boundary.
+ */
+export function installPopupAuthSync(
+  clerk: ClerkRefreshClient,
+  runtime: AuthSyncRuntime = chrome.runtime,
+  reloadPopup: () => void = () => window.location.reload(),
+): () => void {
+  let disposed = false
+
+  const refresh = (state: AuthState) => {
+    if (disposed) {
+      return
+    }
+
+    // A signed-out popup is already in the correct Clerk state. Reload only
+    // when transitioning an existing signed-in popup, otherwise the initial
+    // signed-out REQUEST_STATE response would reload the popup forever.
+    if (state.status === 'signed-out' && !clerk.user) {
+      return
+    }
+
+    const refreshPromise = state.status === 'signed-in' && clerk.user
+      ? clerk.user.reload()
+      : Promise.resolve().then(reloadPopup)
+    void refreshPromise.catch(error => {
+      console.error('[Popup] Failed to refresh auth state', error)
+    })
+  }
+
+  const onMessage = (message: unknown, sender: RuntimeMessageSender) => {
+    if (sender.id !== runtime.id || !message || typeof message !== 'object') {
+      return
+    }
+
+    const candidate = message as { type?: unknown; payload?: unknown }
+    if (candidate.type === AUTH_MESSAGES.STATE_CHANGED && shouldRefresh(candidate.payload)) {
+      refresh(candidate.payload)
+    }
+  }
+
+  runtime.onMessage.addListener(onMessage)
+  void runtime
+    .sendMessage({ type: AUTH_MESSAGES.REQUEST_STATE })
+    .then(response => {
+      if (disposed || !response || typeof response !== 'object') {
+        return
+      }
+
+      const state = (response as { state?: unknown }).state
+      if (shouldRefresh(state)) {
+        refresh(state)
+      }
+    })
+    .catch(error => {
+      if (!disposed) {
+        console.error('[Popup] Failed to request auth state', error)
+      }
+    })
+
+  return () => {
+    if (disposed) {
+      return
+    }
+    disposed = true
+    runtime.onMessage.removeListener(onMessage)
+  }
+}

--- a/apps/extension/shared/auth-sync.ts
+++ b/apps/extension/shared/auth-sync.ts
@@ -62,7 +62,7 @@ export function installPopupAuthSync(
 ): () => void {
   let disposed = false
 
-  const refresh = (state: AuthState, allowReload: boolean) => {
+  const refresh = (state: AuthState) => {
     if (disposed) {
       return
     }
@@ -81,9 +81,6 @@ export function installPopupAuthSync(
       return
     }
 
-    if (!allowReload) {
-      return
-    }
 
     // A reload is only a bootstrap fallback while Clerk hydrates from the
     // synced web session. Persist the guard so a remount cannot reload forever.
@@ -95,9 +92,18 @@ export function installPopupAuthSync(
       if (reloadGuardStorage.getItem(reloadKey)) {
         return
       }
+    } catch {
+      if (memoryReloadGuard.get(reloadKey)) {
+        return
+      }
+    }
+    try {
       reloadGuardStorage.setItem(reloadKey, '1')
     } catch {
-      return
+      if (memoryReloadGuard.get(reloadKey)) {
+        return
+      }
+      memoryReloadGuard.set(reloadKey, '1')
     }
     void Promise.resolve().then(reloadPopup).catch(error => {
       console.error('[Popup] Failed to reload auth state', error)
@@ -111,7 +117,7 @@ export function installPopupAuthSync(
 
     const candidate = message as { type?: unknown; payload?: unknown }
     if (candidate.type === AUTH_MESSAGES.STATE_CHANGED && shouldRefresh(candidate.payload)) {
-      refresh(candidate.payload, true)
+      refresh(candidate.payload)
     }
   }
 
@@ -125,7 +131,7 @@ export function installPopupAuthSync(
 
       const state = (response as { state?: unknown }).state
       if (shouldRefresh(state)) {
-        refresh(state, false)
+        refresh(state)
       }
     })
     .catch(error => {

--- a/apps/extension/shared/auth-sync.ts
+++ b/apps/extension/shared/auth-sync.ts
@@ -22,16 +22,11 @@ interface ReloadGuardStorage {
   setItem(key: string, value: string): void
 }
 
-const memoryReloadGuard = new Map<string, string>()
-
-function getReloadGuardStorage(): ReloadGuardStorage {
+function getReloadGuardStorage(): ReloadGuardStorage | null {
   try {
     return window.sessionStorage
   } catch {
-    return {
-      getItem: key => memoryReloadGuard.get(key) ?? null,
-      setItem: (key, value) => { memoryReloadGuard.set(key, value) },
-    }
+    return null
   }
 }
 
@@ -92,18 +87,10 @@ export function installPopupAuthSync(
       if (reloadGuardStorage.getItem(reloadKey)) {
         return
       }
-    } catch {
-      if (memoryReloadGuard.get(reloadKey)) {
-        return
-      }
-    }
-    try {
       reloadGuardStorage.setItem(reloadKey, '1')
     } catch {
-      if (memoryReloadGuard.get(reloadKey)) {
-        return
-      }
-      memoryReloadGuard.set(reloadKey, '1')
+      // Never hard-reload without a persistent guard that survives remounts.
+      return
     }
     void Promise.resolve().then(reloadPopup).catch(error => {
       console.error('[Popup] Failed to reload auth state', error)

--- a/apps/extension/shared/context-menu-save-messages.ts
+++ b/apps/extension/shared/context-menu-save-messages.ts
@@ -7,7 +7,7 @@ export const CONTEXT_MENU_SAVE_MESSAGES = {
   E2E_SAVE: 'sploot:e2e:context-menu-save',
 } as const;
 
-export type ContextMenuSaveJobState = 'pending' | 'processing' | 'failed' | 'paused';
+export type ContextMenuSaveJobState = 'pending' | 'processing' | 'failed' | 'paused' | 'awaiting-auth';
 
 export interface ContextMenuSaveJobSummary {
   id: string;


### PR DESCRIPTION
## Summary
- replace popup-originated auth state polling with a persistent background Clerk sync listener
- broadcast sanitized `AUTH_STATE_CHANGED` metadata and let the open popup refresh its own Clerk provider
- preserve web-tab sign-in, auto-continue copy, actionable 401 sign-in notifications, and capture queue behavior
- add lifecycle regressions for worker restart, foreign/stale messages, cleanup, timeout, no polling, and token non-leakage

## Evidence
- `pnpm --filter extension test`: 10 files, 41 tests passed
- `pnpm --filter extension lint`: passed
- `pnpm --filter extension type-check`: passed
- `pnpm lint`: passed (existing web warnings only)
- `pnpm type-check`: passed
- `pnpm lint:design`: passed
- `VITE_CLERK_PUBLISHABLE_KEY=pk_live_local-verification-placeholder pnpm --filter extension build:prod`: passed; production MV3 bundle generated
- commit: `15a63bfa`

## Residual verification
- `pnpm --filter web test` was attempted but DB-backed tests cannot connect to PostgreSQL at `localhost:5432`; Docker was intentionally not used.
- Headed Chrome/unpacked extension E2E is not available in this runner: no Chrome/Chromium executable and no test Clerk credentials were present. No device proof is claimed.
- No deploy, store submission, production mutation, or credential exposure performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-driven authentication synchronization between the extension background service and popup.
  * Context-menu saves can now wait for sign-in and automatically resume afterward.
  * Added automatic recovery when authentication changes or the extension restarts.

* **Bug Fixes**
  * Improved handling of expired sessions with clearer sign-in guidance.
  * Prevented authentication tokens from being exposed through extension messages.
  * Removed polling-based sign-in detection for more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->