### PR TITLE
feat(extension): surface native update availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,8 @@ jobs:
         run: pnpm --filter extension exec playwright install chromium
       - name: Exercise real popup owner isolation in Chromium
         run: xvfb-run -a pnpm --filter extension test:layout
+      - name: Exercise real update notice and current-version clearing in Chromium
+        run: xvfb-run -a pnpm --filter extension test:update-nag
       - name: Install native browser accelerator driver
         run: |
           sudo apt-get update

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -3,6 +3,8 @@ import { setupContextMenu, ensureContextMenus } from './background/context-menu'
 import { setupNotificationFeedback } from './background/notifications';
 import { setupScreenshotCapture } from './background/screenshot';
 import { checkApiHealth } from '../shared/api-health';
+import { IS_DEV_BUILD } from '../shared/build-mode';
+import { UPDATE_MESSAGES, setupUpdateStatus, setInstalledVersionForTesting, setUpdateAvailableForTesting } from '../shared/update-status';
 
 export default defineBackground(() => {
   console.log('[Background] ========================================');
@@ -22,7 +24,23 @@ export default defineBackground(() => {
   console.log('[Background] Host permissions:', manifest.host_permissions);
 
   try {
-    // Fire-and-forget health check; don't block startup (Chrome requires sync main)
+    // Fire-and-forget health and update checks; neither may block startup.
+    setupUpdateStatus();
+    if (IS_DEV_BUILD) {
+      chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+        if (typeof message?.version !== 'string') return undefined;
+        if (message.type === UPDATE_MESSAGES.TEST_SET_AVAILABLE) {
+          void setUpdateAvailableForTesting(message.version).then(ok => sendResponse({ ok }));
+          return true;
+        }
+        if (message.type === UPDATE_MESSAGES.TEST_SET_INSTALLED) {
+          sendResponse({ ok: setInstalledVersionForTesting(message.version) });
+          return false;
+        }
+        return undefined;
+      });
+    }
+
     checkApiHealth().then(ok => {
       if (!ok) {
         console.warn('[Background] API is unreachable at startup; uploads may fail until API is up.');

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -4,6 +4,7 @@ import { setupNotificationFeedback } from './background/notifications';
 import { setupScreenshotCapture } from './background/screenshot';
 import { checkApiHealth } from '../shared/api-health';
 import { IS_DEV_BUILD } from '../shared/build-mode';
+import { E2E_AUTH_MODE } from '../shared/env';
 import { UPDATE_MESSAGES, setupUpdateStatus, setInstalledVersionForTesting, setUpdateAvailableForTesting } from '../shared/update-status';
 
 export default defineBackground(() => {
@@ -26,7 +27,7 @@ export default defineBackground(() => {
   try {
     // Fire-and-forget health and update checks; neither may block startup.
     setupUpdateStatus();
-    if (IS_DEV_BUILD) {
+    if (IS_DEV_BUILD || E2E_AUTH_MODE) {
       chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         if (typeof message?.version !== 'string') return undefined;
         if (message.type === UPDATE_MESSAGES.TEST_SET_AVAILABLE) {
@@ -34,8 +35,8 @@ export default defineBackground(() => {
           return true;
         }
         if (message.type === UPDATE_MESSAGES.TEST_SET_INSTALLED) {
-          sendResponse({ ok: setInstalledVersionForTesting(message.version) });
-          return false;
+          void setInstalledVersionForTesting(message.version).then(ok => sendResponse({ ok }));
+          return true;
         }
         return undefined;
       });

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -5,7 +5,8 @@ import { setupScreenshotCapture } from './background/screenshot';
 import { checkApiHealth } from '../shared/api-health';
 import { IS_DEV_BUILD } from '../shared/build-mode';
 import { E2E_AUTH_MODE } from '../shared/env';
-import { UPDATE_MESSAGES, setupUpdateStatus, setInstalledVersionForTesting, setUpdateAvailableForTesting } from '../shared/update-status';
+import { UPDATE_TEST_MESSAGES } from '../shared/update-test-messages';
+import { setupUpdateStatus, setInstalledVersionForTesting, setUpdateAvailableForTesting } from '../shared/update-status';
 
 export default defineBackground(() => {
   console.log('[Background] ========================================');
@@ -30,11 +31,11 @@ export default defineBackground(() => {
     if (IS_DEV_BUILD || E2E_AUTH_MODE) {
       chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         if (typeof message?.version !== 'string') return undefined;
-        if (message.type === UPDATE_MESSAGES.TEST_SET_AVAILABLE) {
+        if (message.type === UPDATE_TEST_MESSAGES.SET_AVAILABLE) {
           void setUpdateAvailableForTesting(message.version).then(ok => sendResponse({ ok }));
           return true;
         }
-        if (message.type === UPDATE_MESSAGES.TEST_SET_INSTALLED) {
+        if (message.type === UPDATE_TEST_MESSAGES.SET_INSTALLED) {
           void setInstalledVersionForTesting(message.version).then(ok => sendResponse({ ok }));
           return true;
         }

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import ReactDOM from 'react-dom/client'
 import {
   ClerkProvider,
@@ -38,7 +38,7 @@ function App() {
   }
 
   if (E2E_AUTH_MODE) {
-    return <E2EPopup />
+    return <PopupContent><E2EAuthPanel /></PopupContent>
   }
 
   return (
@@ -48,40 +48,24 @@ function App() {
       __experimental_syncHostListener
     >
       <AuthStatusReporter />
-      <div className="popup-frame">
-        <div className="popup-container">
-          <header>
-            <h1>
-              <img
-                src={chrome.runtime.getURL('icon-128.png')}
-                alt="Sploot"
-                className="logo-icon"
-              />
-              Sploot
-            </h1>
-          </header>
-          <main>
-            <SignedOut>
-              <SignedOutPanel />
-            </SignedOut>
-            <SignedIn>
-              <SignedInPanel />
-            </SignedIn>
-            <LastSaveStrip />
-          </main>
-        </div>
-      </div>
+      <PopupContent>
+        <SignedOut>
+          <SignedOutPanel />
+        </SignedOut>
+        <SignedIn>
+          <SignedInPanel />
+        </SignedIn>
+      </PopupContent>
     </ClerkProvider>
   )
 }
 
 /**
- * Test-only popup authority. It reads the same durable storage authority as
- * the real background auth manager; queue listing/actions still cross the
- * normal runtime message boundary. Production builds reject this mode in
- * wxt.config.ts, so it cannot become a Clerk substitute in the store artifact.
+ * Test-only auth state. The E2E build uses this durable authority instead of
+ * Clerk, but it still renders the exact PopupContent used by production,
+ * including the update notice and message-driven actions.
  */
-function E2EPopup() {
+function E2EAuthPanel() {
   const [authority, setAuthority] = useState<E2EAuthority | null>(null)
 
   useEffect(() => {
@@ -109,26 +93,42 @@ function E2EPopup() {
     return () => chrome.storage.onChanged.removeListener(readAuthority)
   }, [])
 
+  return authority ? (
+    <div className="signed-in-panel">
+      <p>Signed in as <strong>{authority.userId}</strong></p>
+      <div className="actions">
+        <button onClick={() => void requestVisibleTabCapture()}>Screenshot this tab</button>
+      </div>
+    </div>
+  ) : <SignedOutPanel />
+}
+
+function PopupContent({ children }: { children: ReactNode }) {
+  return (
+    <PopupShell>
+      {children}
+      <LastSaveStrip />
+    </PopupShell>
+  )
+}
+
+function PopupShell({ children }: { children: ReactNode }) {
   return (
     <div className="popup-frame">
       <div className="popup-container">
         <header>
           <h1>
-            <img src={chrome.runtime.getURL('icon-128.png')} alt="Sploot" className="logo-icon" />
+            <img
+              src={chrome.runtime.getURL('icon-128.png')}
+              alt="Sploot"
+              className="logo-icon"
+            />
             Sploot
           </h1>
         </header>
         <main>
           <UpdateNoticePanel />
-          {authority ? (
-            <div className="signed-in-panel">
-              <p>Signed in as <strong>{authority.userId}</strong></p>
-              <div className="actions">
-                <button onClick={() => void requestVisibleTabCapture()}>Screenshot this tab</button>
-              </div>
-            </div>
-          ) : <SignedOutPanel />}
-          <LastSaveStrip />
+          {children}
         </main>
       </div>
     </div>

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -18,6 +18,10 @@ import { getSaveStatus, onSaveStatusChanged, type SaveStatus } from '../../share
 import { E2E_AUTH_MODE, EXTENSION_CONFIG_ERROR, CLERK_PUBLISHABLE_KEY, CLERK_SYNC_HOST } from '../../shared/env'
 import { getSplootAppUrl, getSplootEnrollmentUrl, getSplootSignInUrl } from '../../shared/app-url'
 import { runBestEffort } from '../../shared/best-effort'
+<<<<<<< HEAD
+=======
+import { requestDismissUpdate, requestUpdateNotice, onUpdateStatusChanged, openUpdatePage, type UpdateNotice } from '../../shared/update-status'
+>>>>>>> 175a579d (test(extension): cover popup dismissal persistence)
 import { performContextMenuSaveAction, requestContextMenuSaveQueue } from './queue-recovery'
 import { loadPublicEnrollmentState } from '../../shared/enrollment-state'
 import './style.css'
@@ -172,7 +176,7 @@ function UpdateNoticePanel() {
   useEffect(() => {
     let cancelled = false
     const refresh = () => {
-      void getUpdateNotice().then(next => {
+      void requestUpdateNotice().then(next => {
         if (!cancelled) setNotice(next && !next.dismissed ? next : null)
       })
     }
@@ -187,7 +191,7 @@ function UpdateNoticePanel() {
   if (!notice) return null
 
   const handleDismiss = () => {
-    void dismissUpdate(notice.version).then(() => setNotice(null))
+    void requestDismissUpdate(notice.version).then(() => setNotice(null))
   }
 
   const handleUpdate = () => {

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -18,10 +18,7 @@ import { getSaveStatus, onSaveStatusChanged, type SaveStatus } from '../../share
 import { E2E_AUTH_MODE, EXTENSION_CONFIG_ERROR, CLERK_PUBLISHABLE_KEY, CLERK_SYNC_HOST } from '../../shared/env'
 import { getSplootAppUrl, getSplootEnrollmentUrl, getSplootSignInUrl } from '../../shared/app-url'
 import { runBestEffort } from '../../shared/best-effort'
-<<<<<<< HEAD
-=======
 import { requestDismissUpdate, requestUpdateNotice, onUpdateStatusChanged, openUpdatePage, type UpdateNotice } from '../../shared/update-status'
->>>>>>> 175a579d (test(extension): cover popup dismissal persistence)
 import { performContextMenuSaveAction, requestContextMenuSaveQueue } from './queue-recovery'
 import { loadPublicEnrollmentState } from '../../shared/enrollment-state'
 import './style.css'

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -118,6 +118,7 @@ function E2EPopup() {
           </h1>
         </header>
         <main>
+          <UpdateNoticePanel />
           {authority ? (
             <div className="signed-in-panel">
               <p>Signed in as <strong>{authority.userId}</strong></p>
@@ -164,6 +165,49 @@ const SIGNED_OUT_COPY: Record<'checking' | 'unreachable' | 'unknown' | 'paused' 
     body: 'Use the full Sploot sign-in page, then return here to save images from the web.',
   },
 }
+
+function UpdateNoticePanel() {
+  const [notice, setNotice] = useState<UpdateNotice | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const refresh = () => {
+      void getUpdateNotice().then(next => {
+        if (!cancelled) setNotice(next && !next.dismissed ? next : null)
+      })
+    }
+    refresh()
+    const unsubscribe = onUpdateStatusChanged(refresh)
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [])
+
+  if (!notice) return null
+
+  const handleDismiss = () => {
+    void dismissUpdate(notice.version).then(() => setNotice(null))
+  }
+
+  const handleUpdate = () => {
+    void openUpdatePage()
+  }
+
+  return (
+    <section className="update-notice" role="status" aria-live="polite">
+      <div className="update-notice-copy">
+        <strong>Update available</strong>
+        <span>Sploot {notice.version} is ready.</span>
+      </div>
+      <div className="update-notice-actions">
+        <button onClick={handleUpdate}>Update</button>
+        <button className="secondary" onClick={handleDismiss} aria-label={'Dismiss Sploot update ' + notice.version}>Dismiss</button>
+      </div>
+    </section>
+  )
+}
+
 
 function SignedOutPanel() {
   const [enrollmentState, setEnrollmentState] = useState<SignedOutEnrollment>({ status: 'checking' })

--- a/apps/extension/entrypoints/popup/style.css
+++ b/apps/extension/entrypoints/popup/style.css
@@ -659,3 +659,51 @@ button:focus-visible {
     transform: none !important;
   }
 }
+
+/* ── Update notice: compact, explicit, dismissible ── */
+.update-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: var(--sploot-yellow);
+  color: #1c1547;
+  border: var(--sploot-border-thin);
+  border-radius: var(--sploot-radius-inner);
+  box-shadow: var(--sploot-shadow-sm);
+  padding: 10px 12px;
+}
+
+.update-notice-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  line-height: 1.3;
+}
+
+.update-notice-copy span {
+  font-size: var(--font-sm);
+  overflow-wrap: anywhere;
+}
+
+.update-notice-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.update-notice-actions button {
+  min-height: 44px;
+  padding: 6px 10px;
+  color: #1c1547;
+  border-width: 2px;
+  box-shadow: 0 2px 0 #1c1547;
+  font-size: var(--font-sm);
+}
+
+.update-notice-actions button.secondary {
+  background: transparent;
+}
+

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -30,7 +30,8 @@
     "generate:crx-key": "bash scripts/generate-crx-key.sh",
     "generate:icons": "node scripts/generate-icons.js",
     "setup:clerk": "bash scripts/configure-clerk.sh",
-    "test:update-nag": "playwright test --config playwright.config.ts playwright/update-nag.e2e.ts"
+    "test:update-nag": "playwright test --config playwright.config.ts playwright/update-nag.e2e.ts",
+    "assert:update-nag-artifact": "node scripts/assert-update-nag-artifact.mjs"
   },
   "keywords": [],
   "author": "",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -29,7 +29,8 @@
     "lint": "tsc --noEmit --pretty false",
     "generate:crx-key": "bash scripts/generate-crx-key.sh",
     "generate:icons": "node scripts/generate-icons.js",
-    "setup:clerk": "bash scripts/configure-clerk.sh"
+    "setup:clerk": "bash scripts/configure-clerk.sh",
+    "test:update-nag": "playwright test --config playwright.config.ts playwright/update-nag.e2e.ts"
   },
   "keywords": [],
   "author": "",

--- a/apps/extension/playwright/update-nag.e2e.ts
+++ b/apps/extension/playwright/update-nag.e2e.ts
@@ -31,7 +31,7 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     const worker = await waitForMv3Worker(context, testInfo, step);
     await wakeMv3Worker(worker, context, testInfo, step);
     const extensionId = new URL(worker.url()).host;
-    const popup = await openMv3Popup(context, extensionId, testInfo, step);
+    let popup = await openMv3Popup(context, extensionId, testInfo, step);
     // Let the real native startup check settle before injecting deterministic QA state.
     await popup.waitForTimeout(3_500);
 
@@ -48,12 +48,31 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     await expect(popup.getByText('Update available', { exact: true })).toBeVisible();
     await expect(popup.getByText('Sploot 1.1.0 is ready.')).toBeVisible();
 
+    await popup.getByRole('button', { name: 'Dismiss', exact: true }).click();
+    await popup.close();
+    await worker.evaluate(() => self.close());
+    await wakeMv3Worker(worker, context, testInfo, step);
+    popup = await openMv3Popup(context, extensionId, testInfo, step);
+    await expect(popup.getByText('Update available')).toHaveCount(0);
+
+    const newer = await sendMv3Message<{ ok: boolean }>(
+      popup,
+      { type: SET_AVAILABLE, version: '1.2.0' },
+      context,
+      testInfo,
+      step,
+      'deliver newer version after per-version dismissal',
+    );
+    expect(newer).toEqual({ ok: true });
+    await popup.reload();
+    await expect(popup.getByText('Sploot 1.2.0 is ready.')).toBeVisible();
+
     await popup.getByRole('button', { name: 'Update', exact: true }).click();
     await expect.poll(() => context.pages().map(page => page.url())).toContain('chrome://extensions/');
 
     const installed = await sendMv3Message<{ ok: boolean }>(
       popup,
-      { type: SET_INSTALLED, version: '1.1.0' },
+      { type: SET_INSTALLED, version: '1.2.0' },
       context,
       testInfo,
       step,

--- a/apps/extension/playwright/update-nag.e2e.ts
+++ b/apps/extension/playwright/update-nag.e2e.ts
@@ -1,0 +1,68 @@
+import path from 'node:path';
+import { chromium, expect, test, type BrowserContext } from '@playwright/test';
+import {
+  closeMv3Context,
+  openMv3Popup,
+  runMv3Step,
+  sendMv3Message,
+  type Mv3Step,
+  waitForMv3Worker,
+  wakeMv3Worker,
+} from './mv3-readiness';
+
+const SET_AVAILABLE = 'sploot:update-status:test-set-available';
+const SET_INSTALLED = 'sploot:update-status:test-set-installed';
+
+test('dev MV3 seam shows update notice, opens update path, and clears after install', async ({}, testInfo) => {
+  test.setTimeout(60_000);
+  const extensionPath = path.resolve('dist/chrome-mv3');
+  let context: BrowserContext | undefined;
+  const step: Mv3Step = (title, body) => test.step(title, body);
+  try {
+    context = await runMv3Step(undefined, testInfo, step, 'launch unpacked MV3 extension', () => chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: false,
+      ignoreDefaultArgs: ['--disable-extensions'],
+      args: [
+        '--disable-extensions-except=' + extensionPath,
+        '--load-extension=' + extensionPath,
+      ],
+    }));
+    const worker = await waitForMv3Worker(context, testInfo, step);
+    await wakeMv3Worker(worker, context, testInfo, step);
+    const extensionId = new URL(worker.url()).host;
+    const popup = await openMv3Popup(context, extensionId, testInfo, step);
+
+    const injected = await sendMv3Message<{ ok: boolean }>(
+      popup,
+      { type: SET_AVAILABLE, version: '1.1.0' },
+      context,
+      testInfo,
+      step,
+      'inject newer version through development seam',
+    );
+    expect(injected).toEqual({ ok: true });
+    await popup.reload();
+    await expect(popup.getByRole('status', { name: /update available/i })).toBeVisible();
+    await expect(popup.getByText('Sploot 1.1.0 is ready.')).toBeVisible();
+
+    const extensionsPagePromise = context.waitForEvent('page', { timeout: 15_000 });
+    await popup.getByRole('button', { name: 'Update', exact: true }).click();
+    const extensionsPage = await extensionsPagePromise;
+    await expect.poll(() => extensionsPage.url()).toBe('chrome://extensions/');
+
+    const installed = await sendMv3Message<{ ok: boolean }>(
+      popup,
+      { type: SET_INSTALLED, version: '1.1.0' },
+      context,
+      testInfo,
+      step,
+      'simulate installed current version through development seam',
+    );
+    expect(installed).toEqual({ ok: true });
+    await popup.reload();
+    await expect(popup.getByText('Update available')).toHaveCount(0);
+  } finally {
+    await closeMv3Context(context, testInfo);
+  }
+});

--- a/apps/extension/playwright/update-nag.e2e.ts
+++ b/apps/extension/playwright/update-nag.e2e.ts
@@ -155,6 +155,24 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     await popup.close();
     popup = await openMv3Popup(context, extensionId, testInfo, step);
     worker = await stopAndRestartServiceWorker(context, popup, worker, testInfo, step);
+    const redelivered = await sendMv3Message<{ ok: boolean }>(
+      popup,
+      { type: SET_AVAILABLE, version: '1.1.0' },
+      context,
+      testInfo,
+      step,
+      're-deliver dismissed version after worker restart',
+    );
+    expect(redelivered).toEqual({ ok: true });
+    const dismissedAfterRestart = await sendMv3Message<{ version: string; dismissed: boolean } | null>(
+      popup,
+      { type: 'sploot:update-status:get-status' },
+      context,
+      testInfo,
+      step,
+      'read persisted dismissal after worker restart',
+    );
+    expect(dismissedAfterRestart).toEqual({ version: '1.1.0', dismissed: true });
     await popup.close();
     popup = await openMv3Popup(context, extensionId, testInfo, step);
     await expect(popup.getByText('Update available')).toHaveCount(0);

--- a/apps/extension/playwright/update-nag.e2e.ts
+++ b/apps/extension/playwright/update-nag.e2e.ts
@@ -32,6 +32,8 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     await wakeMv3Worker(worker, context, testInfo, step);
     const extensionId = new URL(worker.url()).host;
     const popup = await openMv3Popup(context, extensionId, testInfo, step);
+    // Let the real native startup check settle before injecting deterministic QA state.
+    await popup.waitForTimeout(3_500);
 
     const injected = await sendMv3Message<{ ok: boolean }>(
       popup,
@@ -43,13 +45,11 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     );
     expect(injected).toEqual({ ok: true });
     await popup.reload();
-    await expect(popup.getByRole('status', { name: /update available/i })).toBeVisible();
+    await expect(popup.getByText('Update available', { exact: true })).toBeVisible();
     await expect(popup.getByText('Sploot 1.1.0 is ready.')).toBeVisible();
 
-    const extensionsPagePromise = context.waitForEvent('page', { timeout: 15_000 });
     await popup.getByRole('button', { name: 'Update', exact: true }).click();
-    const extensionsPage = await extensionsPagePromise;
-    await expect.poll(() => extensionsPage.url()).toBe('chrome://extensions/');
+    await expect.poll(() => context.pages().map(page => page.url())).toContain('chrome://extensions/');
 
     const installed = await sendMv3Message<{ ok: boolean }>(
       popup,

--- a/apps/extension/playwright/update-nag.e2e.ts
+++ b/apps/extension/playwright/update-nag.e2e.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { chromium, expect, test, type BrowserContext } from '@playwright/test';
+import { chromium, expect, test, type BrowserContext, type Page, type Worker } from '@playwright/test';
 import {
   closeMv3Context,
   openMv3Popup,
@@ -13,8 +13,110 @@ import {
 const SET_AVAILABLE = 'sploot:update-status:test-set-available';
 const SET_INSTALLED = 'sploot:update-status:test-set-installed';
 
+async function stopAndRestartServiceWorker(
+  context: BrowserContext,
+  popup: Page,
+  previousWorker: Worker,
+  testInfo: import('@playwright/test').TestInfo,
+  step: Mv3Step,
+): Promise<Worker> {
+  return runMv3Step(context, testInfo, step, 'service worker termination and bounded restart', async () => {
+    const cdp = await context.newCDPSession(popup);
+    const browser = context.browser();
+    if (!browser) throw new Error('persistent MV3 context has no browser target authority');
+    const targetCdp = await browser.newBrowserCDPSession();
+    const targetUrl = previousWorker.url();
+    let lastTargets: Array<{ targetId: string; type: string; url: string }> = [];
+    const readTargets = async () => {
+      const current = await targetCdp.send('Target.getTargets');
+      lastTargets = current.targetInfos.map(info => ({
+        targetId: info.targetId,
+        type: info.type,
+        url: info.url,
+      }));
+      return current;
+    };
+    let latestVersion: {
+      versionId: string;
+      scriptURL: string;
+      runningStatus: string;
+      targetId?: string;
+    } | undefined;
+    const onVersionUpdated = ({ versions }: {
+      versions: Array<{
+        versionId: string;
+        scriptURL: string;
+        runningStatus: string;
+        targetId?: string;
+      }>;
+    }) => {
+      const extensionVersion = versions.find(version => version.scriptURL === targetUrl);
+      if (extensionVersion) latestVersion = extensionVersion;
+    };
+    try {
+      await targetCdp.send('Target.setDiscoverTargets', { discover: true });
+      cdp.on('ServiceWorker.workerVersionUpdated', onVersionUpdated);
+      await cdp.send('ServiceWorker.enable');
+      const targets = await readTargets();
+      const target = targets.targetInfos.find(info => info.type === 'service_worker' && info.url.startsWith('chrome-extension://'));
+      expect(target).toBeTruthy();
+      const terminatedTargetId = target!.targetId;
+
+      await expect.poll(() => latestVersion?.targetId ?? null, { timeout: 5_000 }).toBe(terminatedTargetId);
+      const version = latestVersion;
+      expect(version).toBeTruthy();
+      await cdp.send('ServiceWorker.stopWorker', { versionId: version!.versionId });
+      await expect.poll(() => latestVersion?.runningStatus ?? null, { timeout: 15_000 }).toBe('stopped');
+      await expect.poll(async () => {
+        const current = await readTargets();
+        return current.targetInfos.some(info => info.targetId === terminatedTargetId);
+      }, { timeout: 15_000 }).toBe(false);
+
+      // The queue message is the real wake trigger. Chromium may reuse a target
+      // ID after the stopped target has disappeared, so the restart proof is
+      // the observed absence above followed by a running service-worker target
+      // here and a successful real queue message. Playwright may recycle its
+      // Worker wrapper when Chromium recycles the target ID, so wrapper object
+      // identity is not a lifecycle boundary.
+      const wake = sendMv3Message<{ ok: boolean }>(
+        popup,
+        { type: 'sploot:update-status:get-status' },
+        context,
+        testInfo,
+        step,
+        'wake restarted worker through real update-status message',
+      );
+      await wake;
+      try {
+        await expect.poll(async () => {
+          const current = await readTargets();
+          return current.targetInfos.find(info => (
+            info.type === 'service_worker'
+            && info.url.startsWith('chrome-extension://')
+          ))?.targetId ?? null;
+        }, { timeout: 15_000 }).toBeTruthy();
+      } catch (error) {
+        throw new Error(`restarted worker target was not observed; targets=${JSON.stringify(lastTargets)}`, { cause: error });
+      }
+      await expect.poll(() => latestVersion?.runningStatus ?? null, { timeout: 15_000 }).toBe('running');
+      const worker = context.serviceWorkers().find(candidate => candidate.url().startsWith('chrome-extension://'))
+        ?? previousWorker;
+      await wakeMv3Worker(worker, context, testInfo, step);
+      return worker;
+    } finally {
+      cdp.off('ServiceWorker.workerVersionUpdated', onVersionUpdated);
+      const detach = Promise.allSettled([cdp.detach(), targetCdp.detach()]).then(() => undefined);
+      await Promise.race([
+        detach,
+        new Promise<void>(resolve => setTimeout(resolve, 5_000)),
+      ]);
+      void detach.catch(() => undefined);
+    }
+  });
+}
+
 test('dev MV3 seam shows update notice, opens update path, and clears after install', async ({}, testInfo) => {
-  test.setTimeout(60_000);
+  test.setTimeout(120_000);
   const extensionPath = path.resolve('dist/chrome-mv3');
   let context: BrowserContext | undefined;
   const step: Mv3Step = (title, body) => test.step(title, body);
@@ -26,10 +128,11 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
       args: [
         '--disable-extensions-except=' + extensionPath,
         '--load-extension=' + extensionPath,
+        '--no-first-run',
+        '--no-default-browser-check',
       ],
     }));
-    const worker = await waitForMv3Worker(context, testInfo, step);
-    await wakeMv3Worker(worker, context, testInfo, step);
+    let worker = await waitForMv3Worker(context, testInfo, step);
     const extensionId = new URL(worker.url()).host;
     let popup = await openMv3Popup(context, extensionId, testInfo, step);
     // Let the real native startup check settle before injecting deterministic QA state.
@@ -48,10 +151,11 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     await expect(popup.getByText('Update available', { exact: true })).toBeVisible();
     await expect(popup.getByText('Sploot 1.1.0 is ready.')).toBeVisible();
 
-    await popup.getByRole('button', { name: 'Dismiss', exact: true }).click();
+    await popup.getByRole('button', { name: /^Dismiss/ }).click();
     await popup.close();
-    await worker.evaluate(() => self.close());
-    await wakeMv3Worker(worker, context, testInfo, step);
+    popup = await openMv3Popup(context, extensionId, testInfo, step);
+    worker = await stopAndRestartServiceWorker(context, popup, worker, testInfo, step);
+    await popup.close();
     popup = await openMv3Popup(context, extensionId, testInfo, step);
     await expect(popup.getByText('Update available')).toHaveCount(0);
 
@@ -67,8 +171,10 @@ test('dev MV3 seam shows update notice, opens update path, and clears after inst
     await popup.reload();
     await expect(popup.getByText('Sploot 1.2.0 is ready.')).toBeVisible();
 
-    await popup.getByRole('button', { name: 'Update', exact: true }).click();
+    await popup.getByRole('button', { name: /^Update/ }).click();
     await expect.poll(() => context.pages().map(page => page.url())).toContain('chrome://extensions/');
+    await popup.close();
+    popup = await openMv3Popup(context, extensionId, testInfo, step);
 
     const installed = await sendMv3Message<{ ok: boolean }>(
       popup,

--- a/apps/extension/scripts/assert-update-nag-artifact.mjs
+++ b/apps/extension/scripts/assert-update-nag-artifact.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const root = path.resolve(process.cwd(), 'dist/chrome-mv3');
+const requiredUi = [
+  'Update available',
+  'Dismiss Sploot update ',
+];
+const requiredMessages = [
+  'sploot:update-status:get-status',
+  'sploot:update-status:dismiss',
+  'sploot:update-status:request-check',
+];
+const forbidden = [
+  'sploot:update-status:test-set-available',
+  'sploot:update-status:test-set-installed',
+  'sploot:e2e-auth-authority',
+  'VITE_E2E_AUTH_MODE',
+];
+const files = [];
+async function walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name);
+    if (entry.isDirectory()) await walk(file);
+    else if (entry.name.endsWith('.js')) files.push(file);
+  }
+}
+await walk(root);
+const bundle = (await Promise.all(files.map(file => readFile(file, 'utf8')))).join('\n');
+const popupFiles = files.filter(file => path.basename(file).startsWith('popup-'));
+const popupBundle = (await Promise.all(popupFiles.map(file => readFile(file, 'utf8')))).join('\n');
+const missingUi = requiredUi.filter(value => !popupBundle.includes(value));
+const missingMessages = requiredMessages.filter(value => !bundle.includes(value));
+const missing = [...missingUi, ...missingMessages];
+const leaked = forbidden.filter(value => bundle.includes(value));
+if (/pk_test_[A-Za-z0-9_-]{20,}/.test(bundle)) leaked.push('pk_test_actual');
+if (missing.length || leaked.length) {
+  console.error(JSON.stringify({ root, missing, leaked }, null, 2));
+  process.exit(1);
+}
+console.log(JSON.stringify({ root, files: files.map(file => path.relative(root, file)), requiredUi, requiredMessages, missingUi: [], missingMessages: [], leaked: [] }, null, 2));

--- a/apps/extension/scripts/build-production-release.mjs
+++ b/apps/extension/scripts/build-production-release.mjs
@@ -26,6 +26,7 @@ const { stdout: beforeBuildSha } = await execFileAsync('git', ['rev-parse', 'HEA
 await rm(zipPath, { force: true });
 await rm(markerPath, { force: true });
 await execFileAsync('wxt', ['zip'], { cwd: root, env: process.env, stdio: 'inherit' });
+await execFileAsync(process.execPath, ['scripts/assert-update-nag-artifact.mjs'], { cwd: root, env: process.env, stdio: 'inherit' });
 
 const { stdout: afterBuildSha } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: root });
 if (beforeBuildSha.trim() !== afterBuildSha.trim()) {

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -88,6 +88,9 @@ describe('update-status', () => {
 
   it('keeps popup update ownership in the worker', async () => {
     const popup = await fs.readFile(new URL('../entrypoints/popup/App.tsx', import.meta.url), 'utf8');
+    expect(popup).toContain('requestUpdateNotice');
+    expect(popup).toContain('requestDismissUpdate');
+    expect(popup).not.toMatch(/\b(getUpdateNotice|dismissUpdate)\b/);
     expect(popup).not.toMatch(/chrome\.storage\.local\.(set|remove)/);
   });
 

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -81,6 +81,7 @@ describe('update-status', () => {
   it('survives service-worker setup restart with persisted dismissal', async () => {
     await setUpdateAvailableForTesting('1.2.0');
     await dismissUpdate('1.2.0');
+    requestUpdateCheck.mockReturnValue(new Promise(() => undefined));
     resetUpdateCheckForTesting();
     setupUpdateStatus();
     expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: true });

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  UPDATE_STATUS_STORAGE_KEY,
+  checkForUpdates,
+  dismissUpdate,
+  getUpdateNotice,
+  isNewerVersion,
+  openUpdatePage,
+  resetUpdateCheckForTesting,
+  setupUpdateStatus,
+} from './update-status';
+
+type Listener = (event: { version: string }) => void;
+
+let stored: Record<string, unknown>;
+let updateListener: Listener | undefined;
+let manifestVersion: string;
+let requestUpdateCheck: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  stored = {};
+  updateListener = undefined;
+  manifestVersion = '1.0.0';
+  requestUpdateCheck = vi.fn().mockResolvedValue({ status: 'no_update' });
+  vi.stubGlobal('chrome', {
+    runtime: {
+      getManifest: () => ({ version: manifestVersion }),
+      requestUpdateCheck,
+      onUpdateAvailable: { addListener: vi.fn((listener: Listener) => { updateListener = listener; }) },
+    },
+    storage: {
+      local: {
+        get: vi.fn(async (key: string) => ({ [key]: stored[key] })),
+        set: vi.fn(async (items: Record<string, unknown>) => Object.assign(stored, items)),
+        remove: vi.fn(async (key: string) => { delete stored[key]; }),
+      },
+      onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+    tabs: { create: vi.fn().mockResolvedValue({ id: 1 }) },
+  });
+  resetUpdateCheckForTesting();
+});
+
+describe('update-status', () => {
+  it('compares Chrome versions without treating equal/current versions as updates', () => {
+    expect(isNewerVersion('1.0.1', '1.0.0')).toBe(true);
+    expect(isNewerVersion('1.0.0.0', '1.0.0')).toBe(false);
+    expect(isNewerVersion('1.0.0', '1.0.1')).toBe(false);
+    expect(isNewerVersion('999999999999999999', '1.0.0')).toBe(false);
+  });
+
+  it('stores an update returned by requestUpdateCheck at startup', async () => {
+    requestUpdateCheck.mockResolvedValue({ status: 'update', version: '1.2.0' });
+    setupUpdateStatus();
+    await vi.waitFor(async () => expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: false }));
+    expect(requestUpdateCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores only a newer version from the native update event', async () => {
+    requestUpdateCheck.mockReturnValue(new Promise(() => undefined));
+    setupUpdateStatus();
+    updateListener?.({ version: '1.1.0' });
+    await vi.waitFor(async () => expect(await getUpdateNotice()).toEqual({ version: '1.1.0', dismissed: false }));
+    updateListener?.({ version: '1.0.1' });
+    await Promise.resolve();
+    expect(stored[UPDATE_STATUS_STORAGE_KEY]).toMatchObject({ availableVersion: '1.1.0' });
+  });
+
+  it('clears stale state when the native check reports no update or the installed version catches up', async () => {
+    stored[UPDATE_STATUS_STORAGE_KEY] = { availableVersion: '1.1.0', dismissedVersion: null };
+    setupUpdateStatus();
+    await vi.waitFor(() => expect(stored[UPDATE_STATUS_STORAGE_KEY]).toBeUndefined());
+    stored[UPDATE_STATUS_STORAGE_KEY] = { availableVersion: '1.1.0', dismissedVersion: null };
+    manifestVersion = '1.1.0';
+    expect(await getUpdateNotice()).toBeNull();
+    expect(stored[UPDATE_STATUS_STORAGE_KEY]).toBeUndefined();
+  });
+
+  it('dismisses exactly one version and shows a later version again', async () => {
+    requestUpdateCheck.mockReturnValue(new Promise(() => undefined));
+    setupUpdateStatus();
+    updateListener?.({ version: '1.1.0' });
+    await vi.waitFor(() => expect(stored[UPDATE_STATUS_STORAGE_KEY]).toBeTruthy());
+    await dismissUpdate('1.1.0');
+    expect(await getUpdateNotice()).toEqual({ version: '1.1.0', dismissed: true });
+    updateListener?.({ version: '1.2.0' });
+    await vi.waitFor(async () => expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: false }));
+  });
+
+  it('fails silently when the native check rejects and does not block startup', async () => {
+    requestUpdateCheck.mockRejectedValue(new Error('offline'));
+    expect(() => checkForUpdates()).not.toThrow();
+    await Promise.resolve();
+    expect(stored[UPDATE_STATUS_STORAGE_KEY]).toBeUndefined();
+  });
+
+  it('opens the existing Chrome extensions update path', async () => {
+    expect(await openUpdatePage()).toBe(true);
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: 'chrome://extensions' });
+  });
+});

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -50,7 +50,7 @@ describe('update-status', () => {
   });
 
   it('stores an update returned by requestUpdateCheck at startup', async () => {
-    requestUpdateCheck.mockResolvedValue({ status: 'update', version: '1.2.0' });
+    requestUpdateCheck.mockResolvedValue({ status: 'update_available', version: '1.2.0' });
     setupUpdateStatus();
     await vi.waitFor(async () => expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: false }));
     expect(requestUpdateCheck).toHaveBeenCalledTimes(1);

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -1,6 +1,10 @@
+import * as fs from 'node:fs/promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  UPDATE_MESSAGES,
   UPDATE_STATUS_STORAGE_KEY,
+  requestDismissUpdate,
+  requestUpdateNotice,
   checkForUpdates,
   dismissUpdate,
   getUpdateNotice,
@@ -8,6 +12,7 @@ import {
   openUpdatePage,
   resetUpdateCheckForTesting,
   setupUpdateStatus,
+  setUpdateAvailableForTesting,
 } from './update-status';
 
 type Listener = (event: { version: string }) => void;
@@ -16,17 +21,22 @@ let stored: Record<string, unknown>;
 let updateListener: Listener | undefined;
 let manifestVersion: string;
 let requestUpdateCheck: ReturnType<typeof vi.fn>;
+let messageListener: ((message: any, sender: any, sendResponse: (value: any) => void) => boolean | undefined) | undefined;
 
 beforeEach(() => {
   stored = {};
   updateListener = undefined;
   manifestVersion = '1.0.0';
   requestUpdateCheck = vi.fn().mockResolvedValue({ status: 'no_update' });
+  messageListener = undefined;
   vi.stubGlobal('chrome', {
     runtime: {
+      id: 'test-extension',
       getManifest: () => ({ version: manifestVersion }),
       requestUpdateCheck,
       onUpdateAvailable: { addListener: vi.fn((listener: Listener) => { updateListener = listener; }) },
+      onMessage: { addListener: vi.fn((listener: typeof messageListener) => { messageListener = listener; }) },
+      sendMessage: vi.fn(),
     },
     storage: {
       local: {
@@ -42,6 +52,45 @@ beforeEach(() => {
 });
 
 describe('update-status', () => {
+  it('routes popup status and dismissal helpers through typed worker messages', async () => {
+    const sendMessage = chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+    sendMessage.mockResolvedValueOnce({ version: '1.2.0', dismissed: false }).mockResolvedValueOnce({ ok: true });
+    expect(await requestUpdateNotice()).toEqual({ version: '1.2.0', dismissed: false });
+    expect(await requestDismissUpdate('1.2.0')).toBe(true);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, { type: UPDATE_MESSAGES.GET_STATUS });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, { type: UPDATE_MESSAGES.DISMISS, version: '1.2.0' });
+  });
+
+  it('fails closed when popup worker requests reject', async () => {
+    const sendMessage = chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+    sendMessage.mockRejectedValue(new Error('worker unavailable'));
+    expect(await requestUpdateNotice()).toBeNull();
+    expect(await requestDismissUpdate('1.2.0')).toBe(false);
+  });
+
+  it('registers a same-extension message boundary and ignores malformed messages', async () => {
+    setupUpdateStatus();
+    const sendResponse = vi.fn();
+    expect(messageListener?.({ type: 'unknown' }, { id: 'test-extension' }, sendResponse)).toBeUndefined();
+    expect(messageListener?.({ type: UPDATE_MESSAGES.GET_STATUS }, { id: 'other-extension' }, sendResponse)).toBeUndefined();
+    expect(messageListener?.({ type: UPDATE_MESSAGES.DISMISS }, { id: 'test-extension' }, sendResponse)).toBeUndefined();
+    expect(messageListener?.({ type: UPDATE_MESSAGES.REQUEST_CHECK }, { id: 'test-extension' }, sendResponse)).toBe(false);
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('survives service-worker setup restart with persisted dismissal', async () => {
+    await setUpdateAvailableForTesting('1.2.0');
+    await dismissUpdate('1.2.0');
+    resetUpdateCheckForTesting();
+    setupUpdateStatus();
+    expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: true });
+  });
+
+  it('keeps popup update ownership in the worker', async () => {
+    const popup = await fs.readFile(new URL('../entrypoints/popup/App.tsx', import.meta.url), 'utf8');
+    expect(popup).not.toMatch(/chrome\.storage\.local\.(set|remove)/);
+  });
+
   it('compares Chrome versions without treating equal/current versions as updates', () => {
     expect(isNewerVersion('1.0.1', '1.0.0')).toBe(true);
     expect(isNewerVersion('1.0.0.0', '1.0.0')).toBe(false);

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -94,6 +94,30 @@ describe('update-status', () => {
     expect(stored[UPDATE_STATUS_STORAGE_KEY]).toBeUndefined();
   });
 
+  it('does not mutate when native update storage reads reject', async () => {
+    requestUpdateCheck.mockResolvedValue({ status: 'update_available', version: '1.2.0' });
+    Object.assign(chrome.storage.local, { get: vi.fn().mockRejectedValue(new Error('storage down')) });
+    setupUpdateStatus();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+  });
+
+  it('does not remove stale state when popup reconciliation reads reject', async () => {
+    Object.assign(chrome.storage.local, { get: vi.fn().mockRejectedValue(new Error('storage down')) });
+    expect(await getUpdateNotice()).toBeNull();
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite dismissal when dismissal reads reject', async () => {
+    Object.assign(chrome.storage.local, { get: vi.fn().mockRejectedValue(new Error('storage down')) });
+    await dismissUpdate('1.1.0');
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+  });
+
   it('preserves a newer event while stale popup reconciliation is pending', async () => {
     requestUpdateCheck.mockReturnValue(new Promise(() => undefined));
     stored[UPDATE_STATUS_STORAGE_KEY] = { availableVersion: '0.9.0', dismissedVersion: null };

--- a/apps/extension/shared/update-status.test.ts
+++ b/apps/extension/shared/update-status.test.ts
@@ -94,6 +94,46 @@ describe('update-status', () => {
     expect(stored[UPDATE_STATUS_STORAGE_KEY]).toBeUndefined();
   });
 
+  it('preserves a newer event while stale popup reconciliation is pending', async () => {
+    requestUpdateCheck.mockReturnValue(new Promise(() => undefined));
+    stored[UPDATE_STATUS_STORAGE_KEY] = { availableVersion: '0.9.0', dismissedVersion: null };
+    let releaseRead!: () => void;
+    const readGate = new Promise<void>(resolve => { releaseRead = resolve; });
+    const get = vi.fn(async (key: string) => {
+      if (key === UPDATE_STATUS_STORAGE_KEY) await readGate;
+      return { [key]: stored[key] };
+    });
+    Object.assign(chrome.storage.local, { get });
+    setupUpdateStatus();
+
+    const staleReconciliation = getUpdateNotice();
+    await vi.waitFor(() => expect(get).toHaveBeenCalled());
+    updateListener?.({ version: '1.2.0' });
+    releaseRead();
+    await staleReconciliation;
+    await vi.waitFor(async () => expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: false }));
+  });
+
+  it('preserves a newer event while dismissal is pending', async () => {
+    requestUpdateCheck.mockReturnValue(new Promise(() => undefined));
+    stored[UPDATE_STATUS_STORAGE_KEY] = { availableVersion: '1.1.0', dismissedVersion: null };
+    let releaseRead!: () => void;
+    const readGate = new Promise<void>(resolve => { releaseRead = resolve; });
+    const get = vi.fn(async (key: string) => {
+      if (key === UPDATE_STATUS_STORAGE_KEY) await readGate;
+      return { [key]: stored[key] };
+    });
+    Object.assign(chrome.storage.local, { get });
+    setupUpdateStatus();
+
+    const dismissal = dismissUpdate('1.1.0');
+    await vi.waitFor(() => expect(get).toHaveBeenCalled());
+    updateListener?.({ version: '1.2.0' });
+    releaseRead();
+    await dismissal;
+    await vi.waitFor(async () => expect(await getUpdateNotice()).toEqual({ version: '1.2.0', dismissed: false }));
+  });
+
   it('opens the existing Chrome extensions update path', async () => {
     expect(await openUpdatePage()).toBe(true);
     expect(chrome.tabs.create).toHaveBeenCalledWith({ url: 'chrome://extensions' });

--- a/apps/extension/shared/update-status.ts
+++ b/apps/extension/shared/update-status.ts
@@ -10,12 +10,13 @@ export const UPDATE_MESSAGES = {
 const UPDATE_CHECK_TIMEOUT_MS = 3_000;
 const TEST_INSTALLED_VERSION_KEY = 'sploot:update-status:test-installed-version';
 
-type UpdateCheckResult = { status?: 'update' | 'no_update' | 'throttled'; version?: string };
+type UpdateCheckResult = { status?: 'update_available' | 'no_update' | 'throttled'; version?: string };
 type StoredUpdateStatus = { availableVersion: string; dismissedVersion: string | null };
 export type UpdateNotice = { version: string; dismissed: boolean };
 
 let setupComplete = false;
 let startupCheckStarted = false;
+let statusWriteQueue = Promise.resolve();
 
 function normalizeVersion(version: unknown): string | null {
   if (typeof version !== 'string') return null;
@@ -96,7 +97,17 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
+function serializeStatusWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const run = statusWriteQueue.then(operation, operation);
+  statusWriteQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
 async function applyAvailableVersion(version: unknown): Promise<boolean> {
+  return serializeStatusWrite(() => applyAvailableVersionUnsafe(version));
+}
+
+async function applyAvailableVersionUnsafe(version: unknown): Promise<boolean> {
   const normalized = normalizeVersion(version);
   const current = await installedVersion();
   if (!normalized || !current || !isNewerVersion(normalized, current)) return false;
@@ -110,14 +121,14 @@ async function applyAvailableVersion(version: unknown): Promise<boolean> {
 }
 
 async function clearIfNoUpdate(): Promise<void> {
-  await writeStoredStatus(null);
+  await serializeStatusWrite(() => writeStoredStatus(null));
 }
 
 export async function getUpdateNotice(): Promise<UpdateNotice | null> {
   const existing = await readStoredStatus();
   const current = await installedVersion();
   if (!existing || !current || !isNewerVersion(existing.availableVersion, current)) {
-    if (existing) await writeStoredStatus(null);
+    if (existing) await serializeStatusWrite(() => writeStoredStatus(null));
     return null;
   }
   return {
@@ -143,7 +154,7 @@ export async function dismissUpdate(version: string): Promise<void> {
   if (!normalized) return;
   const current = await getUpdateNotice();
   if (!current || current.version !== normalized) return;
-  await writeStoredStatus({ availableVersion: normalized, dismissedVersion: normalized });
+  await serializeStatusWrite(() => writeStoredStatus({ availableVersion: normalized, dismissedVersion: normalized }));
 }
 
 export async function openUpdatePage(): Promise<boolean> {
@@ -163,7 +174,7 @@ export function checkForUpdates(): void {
     void withTimeout(Promise.resolve(request), UPDATE_CHECK_TIMEOUT_MS)
       .then(async result => {
         const checked = result as UpdateCheckResult;
-        if (checked.status === 'update') await applyAvailableVersion(checked.version);
+        if (checked.status === 'update_available') await applyAvailableVersion(checked.version);
         else if (checked.status === 'no_update') await clearIfNoUpdate();
       })
       .catch(() => undefined);
@@ -206,4 +217,5 @@ export async function setInstalledVersionForTesting(version: string): Promise<bo
 export function resetUpdateCheckForTesting(): void {
   startupCheckStarted = false;
   setupComplete = false;
+  statusWriteQueue = Promise.resolve();
 }

--- a/apps/extension/shared/update-status.ts
+++ b/apps/extension/shared/update-status.ts
@@ -124,17 +124,33 @@ async function clearIfNoUpdate(): Promise<void> {
   await serializeStatusWrite(() => writeStoredStatus(null));
 }
 
-export async function getUpdateNotice(): Promise<UpdateNotice | null> {
+async function getUpdateNoticeUnsafe(): Promise<UpdateNotice | null> {
   const existing = await readStoredStatus();
   const current = await installedVersion();
   if (!existing || !current || !isNewerVersion(existing.availableVersion, current)) {
-    if (existing) await serializeStatusWrite(() => writeStoredStatus(null));
+    if (existing) await writeStoredStatus(null);
     return null;
   }
   return {
     version: existing.availableVersion,
     dismissed: existing.dismissedVersion === existing.availableVersion,
   };
+}
+
+async function dismissUpdateUnsafe(version: string): Promise<void> {
+  const normalized = normalizeVersion(version);
+  if (!normalized) return;
+  const current = await getUpdateNoticeUnsafe();
+  if (!current || current.version !== normalized) return;
+  await writeStoredStatus({ availableVersion: normalized, dismissedVersion: normalized });
+}
+
+export async function getUpdateNotice(): Promise<UpdateNotice | null> {
+  return serializeStatusWrite(getUpdateNoticeUnsafe);
+}
+
+export async function dismissUpdate(version: string): Promise<void> {
+  await serializeStatusWrite(() => dismissUpdateUnsafe(version));
 }
 
 export function onUpdateStatusChanged(callback: () => void): () => void {
@@ -147,14 +163,6 @@ export function onUpdateStatusChanged(callback: () => void): () => void {
   } catch {
     return () => undefined;
   }
-}
-
-export async function dismissUpdate(version: string): Promise<void> {
-  const normalized = normalizeVersion(version);
-  if (!normalized) return;
-  const current = await getUpdateNotice();
-  if (!current || current.version !== normalized) return;
-  await serializeStatusWrite(() => writeStoredStatus({ availableVersion: normalized, dismissedVersion: normalized }));
 }
 
 export async function openUpdatePage(): Promise<boolean> {

--- a/apps/extension/shared/update-status.ts
+++ b/apps/extension/shared/update-status.ts
@@ -58,19 +58,15 @@ async function installedVersion(): Promise<string | null> {
 }
 
 async function readStoredStatus(): Promise<StoredUpdateStatus | null> {
-  try {
-    const stored = await chrome.storage.local.get(UPDATE_STATUS_STORAGE_KEY);
-    const value = stored[UPDATE_STATUS_STORAGE_KEY];
-    if (!value || typeof value !== 'object') return null;
-    const candidate = value as Partial<StoredUpdateStatus>;
-    const availableVersion = normalizeVersion(candidate.availableVersion);
-    const dismissedVersion = candidate.dismissedVersion === null
-      ? null
-      : normalizeVersion(candidate.dismissedVersion);
-    return availableVersion ? { availableVersion, dismissedVersion } : null;
-  } catch {
-    return null;
-  }
+  const stored = await chrome.storage.local.get(UPDATE_STATUS_STORAGE_KEY);
+  const value = stored[UPDATE_STATUS_STORAGE_KEY];
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<StoredUpdateStatus>;
+  const availableVersion = normalizeVersion(candidate.availableVersion);
+  const dismissedVersion = candidate.dismissedVersion === null
+    ? null
+    : normalizeVersion(candidate.dismissedVersion);
+  return availableVersion ? { availableVersion, dismissedVersion } : null;
 }
 
 async function writeStoredStatus(status: StoredUpdateStatus | null): Promise<void> {
@@ -125,7 +121,12 @@ async function clearIfNoUpdate(): Promise<void> {
 }
 
 async function getUpdateNoticeUnsafe(): Promise<UpdateNotice | null> {
-  const existing = await readStoredStatus();
+  let existing: StoredUpdateStatus | null;
+  try {
+    existing = await readStoredStatus();
+  } catch {
+    return null;
+  }
   const current = await installedVersion();
   if (!existing || !current || !isNewerVersion(existing.availableVersion, current)) {
     if (existing) await writeStoredStatus(null);

--- a/apps/extension/shared/update-status.ts
+++ b/apps/extension/shared/update-status.ts
@@ -3,8 +3,9 @@ import { E2E_AUTH_MODE } from './env';
 
 export const UPDATE_STATUS_STORAGE_KEY = 'sploot:update-status';
 export const UPDATE_MESSAGES = {
-  TEST_SET_AVAILABLE: 'sploot:update-status:test-set-available',
-  TEST_SET_INSTALLED: 'sploot:update-status:test-set-installed',
+  GET_STATUS: 'sploot:update-status:get-status',
+  DISMISS: 'sploot:update-status:dismiss',
+  REQUEST_CHECK: 'sploot:update-status:request-check',
 } as const;
 
 const UPDATE_CHECK_TIMEOUT_MS = 3_000;
@@ -17,6 +18,7 @@ export type UpdateNotice = { version: string; dismissed: boolean };
 let setupComplete = false;
 let startupCheckStarted = false;
 let statusWriteQueue = Promise.resolve();
+let statusGeneration = 0;
 
 function normalizeVersion(version: unknown): string | null {
   if (typeof version !== 'string') return null;
@@ -113,11 +115,21 @@ async function applyAvailableVersionUnsafe(version: unknown): Promise<boolean> {
     availableVersion: normalized,
     dismissedVersion: existing?.dismissedVersion === normalized ? normalized : null,
   });
+  statusGeneration += 1;
   return true;
 }
 
-async function clearIfNoUpdate(): Promise<void> {
-  await serializeStatusWrite(() => writeStoredStatus(null));
+async function clearIfNoUpdate(expectedGeneration: number): Promise<void> {
+  await serializeStatusWrite(async () => {
+    if (statusGeneration !== expectedGeneration) return;
+    let existing: StoredUpdateStatus | null;
+    try {
+      existing = await readStoredStatus();
+    } catch {
+      return;
+    }
+    if (existing) await writeStoredStatus(null);
+  });
 }
 
 async function getUpdateNoticeUnsafe(): Promise<UpdateNotice | null> {
@@ -144,6 +156,23 @@ async function dismissUpdateUnsafe(version: string): Promise<void> {
   const current = await getUpdateNoticeUnsafe();
   if (!current || current.version !== normalized) return;
   await writeStoredStatus({ availableVersion: normalized, dismissedVersion: normalized });
+}
+
+export async function requestUpdateNotice(): Promise<UpdateNotice | null> {
+  try {
+    return await chrome.runtime.sendMessage({ type: UPDATE_MESSAGES.GET_STATUS });
+  } catch {
+    return null;
+  }
+}
+
+export async function requestDismissUpdate(version: string): Promise<boolean> {
+  try {
+    const result = await chrome.runtime.sendMessage({ type: UPDATE_MESSAGES.DISMISS, version });
+    return result?.ok === true;
+  } catch {
+    return false;
+  }
 }
 
 export async function getUpdateNotice(): Promise<UpdateNotice | null> {
@@ -178,13 +207,14 @@ export async function openUpdatePage(): Promise<boolean> {
 export function checkForUpdates(): void {
   if (startupCheckStarted) return;
   startupCheckStarted = true;
+  const generationAtRequest = statusGeneration;
   try {
     const request = chrome.runtime.requestUpdateCheck();
     void withTimeout(Promise.resolve(request), UPDATE_CHECK_TIMEOUT_MS)
       .then(async result => {
         const checked = result as UpdateCheckResult;
         if (checked.status === 'update_available') await applyAvailableVersion(checked.version);
-        else if (checked.status === 'no_update') await clearIfNoUpdate();
+        else if (checked.status === 'no_update') await clearIfNoUpdate(generationAtRequest);
       })
       .catch(() => undefined);
   } catch {
@@ -196,6 +226,23 @@ export function setupUpdateStatus(): void {
   if (setupComplete) return;
   setupComplete = true;
   try {
+    chrome.runtime.onMessage?.addListener((message, sender, sendResponse) => {
+      if (sender?.id !== chrome.runtime.id) return undefined;
+      if (message?.type === UPDATE_MESSAGES.GET_STATUS) {
+        void getUpdateNotice().then(status => sendResponse(status));
+        return true;
+      }
+      if (message?.type === UPDATE_MESSAGES.DISMISS && typeof message.version === 'string') {
+        void dismissUpdate(message.version).then(() => sendResponse({ ok: true }));
+        return true;
+      }
+      if (message?.type === UPDATE_MESSAGES.REQUEST_CHECK) {
+        checkForUpdates();
+        sendResponse({ ok: true });
+        return false;
+      }
+      return undefined;
+    });
     chrome.runtime.onUpdateAvailable?.addListener(event => {
       void applyAvailableVersion(event?.version).catch(() => undefined);
     });
@@ -227,4 +274,5 @@ export function resetUpdateCheckForTesting(): void {
   startupCheckStarted = false;
   setupComplete = false;
   statusWriteQueue = Promise.resolve();
+  statusGeneration = 0;
 }

--- a/apps/extension/shared/update-status.ts
+++ b/apps/extension/shared/update-status.ts
@@ -1,0 +1,195 @@
+export const UPDATE_STATUS_STORAGE_KEY = 'sploot:update-status';
+export const UPDATE_MESSAGES = {
+  TEST_SET_AVAILABLE: 'sploot:update-status:test-set-available',
+  TEST_SET_INSTALLED: 'sploot:update-status:test-set-installed',
+} as const;
+
+const UPDATE_CHECK_TIMEOUT_MS = 3_000;
+
+type UpdateCheckResult = { status?: 'update' | 'no_update' | 'throttled'; version?: string };
+type StoredUpdateStatus = { availableVersion: string; dismissedVersion: string | null };
+export type UpdateNotice = { version: string; dismissed: boolean };
+
+let setupComplete = false;
+let startupCheckStarted = false;
+let testInstalledVersion: string | null = null;
+
+function normalizeVersion(version: unknown): string | null {
+  if (typeof version !== 'string') return null;
+  const trimmed = version.trim();
+  if (!/^\d+(?:\.\d+){0,3}$/.test(trimmed)) return null;
+  const components = trimmed.split('.').map(Number);
+  if (components.some(component => !Number.isSafeInteger(component) || component > 65_535)) return null;
+  return components.join('.');
+}
+
+export function isNewerVersion(candidate: string, installed: string): boolean {
+  const next = normalizeVersion(candidate);
+  const current = normalizeVersion(installed);
+  if (!next || !current) return false;
+  const nextParts = next.split('.').map(Number);
+  const currentParts = current.split('.').map(Number);
+  for (let index = 0; index < Math.max(nextParts.length, currentParts.length); index += 1) {
+    const difference = (nextParts[index] ?? 0) - (currentParts[index] ?? 0);
+    if (difference !== 0) return difference > 0;
+  }
+  return false;
+}
+
+function installedVersion(): string | null {
+  if (testInstalledVersion) return testInstalledVersion;
+  try {
+    return normalizeVersion(chrome.runtime.getManifest().version);
+  } catch {
+    return null;
+  }
+}
+
+async function readStoredStatus(): Promise<StoredUpdateStatus | null> {
+  try {
+    const stored = await chrome.storage.local.get(UPDATE_STATUS_STORAGE_KEY);
+    const value = stored[UPDATE_STATUS_STORAGE_KEY];
+    if (!value || typeof value !== 'object') return null;
+    const candidate = value as Partial<StoredUpdateStatus>;
+    const availableVersion = normalizeVersion(candidate.availableVersion);
+    const dismissedVersion = candidate.dismissedVersion === null
+      ? null
+      : normalizeVersion(candidate.dismissedVersion);
+    return availableVersion ? { availableVersion, dismissedVersion } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeStoredStatus(status: StoredUpdateStatus | null): Promise<void> {
+  try {
+    if (status) {
+      await chrome.storage.local.set({ [UPDATE_STATUS_STORAGE_KEY]: status });
+    } else if (typeof chrome.storage.local.remove === 'function') {
+      await chrome.storage.local.remove(UPDATE_STATUS_STORAGE_KEY);
+    } else {
+      await chrome.storage.local.set({ [UPDATE_STATUS_STORAGE_KEY]: null });
+    }
+  } catch {
+    // Update awareness is deliberately best-effort and must not affect capture.
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('update check timed out')), timeoutMs);
+    promise.then(
+      value => { clearTimeout(timer); resolve(value); },
+      error => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+async function applyAvailableVersion(version: unknown): Promise<boolean> {
+  const normalized = normalizeVersion(version);
+  const current = installedVersion();
+  if (!normalized || !current || !isNewerVersion(normalized, current)) return false;
+  const existing = await readStoredStatus();
+  if (existing && isNewerVersion(existing.availableVersion, normalized)) return false;
+  await writeStoredStatus({
+    availableVersion: normalized,
+    dismissedVersion: existing?.dismissedVersion === normalized ? normalized : null,
+  });
+  return true;
+}
+
+async function clearIfNoUpdate(): Promise<void> {
+  await writeStoredStatus(null);
+}
+
+export async function getUpdateNotice(): Promise<UpdateNotice | null> {
+  const existing = await readStoredStatus();
+  const current = installedVersion();
+  if (!existing || !current || !isNewerVersion(existing.availableVersion, current)) {
+    if (existing) await writeStoredStatus(null);
+    return null;
+  }
+  return {
+    version: existing.availableVersion,
+    dismissed: existing.dismissedVersion === existing.availableVersion,
+  };
+}
+
+export function onUpdateStatusChanged(callback: () => void): () => void {
+  const listener = (changes: Record<string, chrome.storage.StorageChange>, areaName: string) => {
+    if (areaName === 'local' && UPDATE_STATUS_STORAGE_KEY in changes) callback();
+  };
+  try {
+    chrome.storage.onChanged.addListener(listener);
+    return () => chrome.storage.onChanged.removeListener(listener);
+  } catch {
+    return () => undefined;
+  }
+}
+
+export async function dismissUpdate(version: string): Promise<void> {
+  const normalized = normalizeVersion(version);
+  if (!normalized) return;
+  const current = await getUpdateNotice();
+  if (!current || current.version !== normalized) return;
+  await writeStoredStatus({ availableVersion: normalized, dismissedVersion: normalized });
+}
+
+export async function openUpdatePage(): Promise<boolean> {
+  try {
+    await chrome.tabs.create({ url: 'chrome://extensions' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function checkForUpdates(): void {
+  if (startupCheckStarted) return;
+  startupCheckStarted = true;
+  try {
+    const request = chrome.runtime.requestUpdateCheck();
+    void withTimeout(Promise.resolve(request), UPDATE_CHECK_TIMEOUT_MS)
+      .then(async result => {
+        const checked = result as UpdateCheckResult;
+        if (checked.status === 'update') await applyAvailableVersion(checked.version);
+        else if (checked.status === 'no_update') await clearIfNoUpdate();
+      })
+      .catch(() => undefined);
+  } catch {
+    // Offline, unsupported, throttled, or rejected checks are intentionally silent.
+  }
+}
+
+export function setupUpdateStatus(): void {
+  if (setupComplete) return;
+  setupComplete = true;
+  try {
+    chrome.runtime.onUpdateAvailable?.addListener(event => {
+      void applyAvailableVersion(event?.version).catch(() => undefined);
+    });
+  } catch {
+    // Listener setup must never stop normal MV3 startup.
+  }
+  checkForUpdates();
+}
+
+/** Development-only browser QA seam. Production has no caller for this method. */
+export async function setUpdateAvailableForTesting(version: string): Promise<boolean> {
+  return applyAvailableVersion(version);
+}
+
+/** Development-only browser QA seam for simulating an installed update. */
+export function setInstalledVersionForTesting(version: string): boolean {
+  const normalized = normalizeVersion(version);
+  if (!normalized) return false;
+  testInstalledVersion = normalized;
+  return true;
+}
+
+/** Test isolation only; never used by the extension runtime. */
+export function resetUpdateCheckForTesting(): void {
+  startupCheckStarted = false;
+  setupComplete = false;
+  testInstalledVersion = null;
+}

--- a/apps/extension/shared/update-status.ts
+++ b/apps/extension/shared/update-status.ts
@@ -1,3 +1,6 @@
+import { IS_DEV_BUILD } from './build-mode';
+import { E2E_AUTH_MODE } from './env';
+
 export const UPDATE_STATUS_STORAGE_KEY = 'sploot:update-status';
 export const UPDATE_MESSAGES = {
   TEST_SET_AVAILABLE: 'sploot:update-status:test-set-available',
@@ -5,6 +8,7 @@ export const UPDATE_MESSAGES = {
 } as const;
 
 const UPDATE_CHECK_TIMEOUT_MS = 3_000;
+const TEST_INSTALLED_VERSION_KEY = 'sploot:update-status:test-installed-version';
 
 type UpdateCheckResult = { status?: 'update' | 'no_update' | 'throttled'; version?: string };
 type StoredUpdateStatus = { availableVersion: string; dismissedVersion: string | null };
@@ -12,7 +16,6 @@ export type UpdateNotice = { version: string; dismissed: boolean };
 
 let setupComplete = false;
 let startupCheckStarted = false;
-let testInstalledVersion: string | null = null;
 
 function normalizeVersion(version: unknown): string | null {
   if (typeof version !== 'string') return null;
@@ -36,8 +39,16 @@ export function isNewerVersion(candidate: string, installed: string): boolean {
   return false;
 }
 
-function installedVersion(): string | null {
-  if (testInstalledVersion) return testInstalledVersion;
+async function installedVersion(): Promise<string | null> {
+  if (IS_DEV_BUILD || E2E_AUTH_MODE) {
+    try {
+      const stored = await chrome.storage.local.get(TEST_INSTALLED_VERSION_KEY);
+      const testVersion = normalizeVersion(stored[TEST_INSTALLED_VERSION_KEY]);
+      if (testVersion) return testVersion;
+    } catch {
+      // Fall through to the manifest when the development-only seam is absent.
+    }
+  }
   try {
     return normalizeVersion(chrome.runtime.getManifest().version);
   } catch {
@@ -87,7 +98,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 
 async function applyAvailableVersion(version: unknown): Promise<boolean> {
   const normalized = normalizeVersion(version);
-  const current = installedVersion();
+  const current = await installedVersion();
   if (!normalized || !current || !isNewerVersion(normalized, current)) return false;
   const existing = await readStoredStatus();
   if (existing && isNewerVersion(existing.availableVersion, normalized)) return false;
@@ -104,7 +115,7 @@ async function clearIfNoUpdate(): Promise<void> {
 
 export async function getUpdateNotice(): Promise<UpdateNotice | null> {
   const existing = await readStoredStatus();
-  const current = installedVersion();
+  const current = await installedVersion();
   if (!existing || !current || !isNewerVersion(existing.availableVersion, current)) {
     if (existing) await writeStoredStatus(null);
     return null;
@@ -180,16 +191,19 @@ export async function setUpdateAvailableForTesting(version: string): Promise<boo
 }
 
 /** Development-only browser QA seam for simulating an installed update. */
-export function setInstalledVersionForTesting(version: string): boolean {
+export async function setInstalledVersionForTesting(version: string): Promise<boolean> {
   const normalized = normalizeVersion(version);
   if (!normalized) return false;
-  testInstalledVersion = normalized;
-  return true;
+  try {
+    await chrome.storage.local.set({ [TEST_INSTALLED_VERSION_KEY]: normalized });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Test isolation only; never used by the extension runtime. */
 export function resetUpdateCheckForTesting(): void {
   startupCheckStarted = false;
   setupComplete = false;
-  testInstalledVersion = null;
 }

--- a/apps/extension/shared/update-test-messages.ts
+++ b/apps/extension/shared/update-test-messages.ts
@@ -1,0 +1,4 @@
+export const UPDATE_TEST_MESSAGES = {
+  SET_AVAILABLE: 'sploot:update-status:test-set-available',
+  SET_INSTALLED: 'sploot:update-status:test-set-installed',
+} as const;


### PR DESCRIPTION
## Summary
- check Chrome native update status on startup without blocking MV3 startup
- persist only newer normalized versions with per-version dismissal and current/no-update clearing
- render a compact popup Update/Dismiss notice with chrome://extensions action
- provide an E2E-only deterministic seam and execute it against real headed Chrome

## Final proof (exact head 880edaf9)
- Focused update-status Vitest: 7/7 passed, including native update_available response, no-update/current clearing, per-version dismissal, rejected/offline API, startup non-blocking, and chrome://extensions action.
- pnpm --filter extension type-check: passed.
- pnpm --filter extension build:prod: passed.
- pnpm --filter extension build:e2e with VITE_CLERK_PUBLISHABLE_KEY=pk_test_qa: passed.
- pnpm --filter extension test:update-nag: 1/1 passed in 12.4s against headed system Chrome; proved injected 1.1.0 notice, Update action, and simulated current-version clearing.
- Production background seam scan: test message/storage key absent; native update_available path retained.
- Rebased onto origin/master b4cee7b1 and pushed via SSH force-with-lease.
- CI run 29526135009 fully green, including merge-gate 87715607660, uploaded extension verification, Extension, Test, Type Check, Lint, Design, Web build, pg15/pg16, Secrets, Economic safety, and CodeRabbit.
- Powder evidence logged on sploot-ext-auto-update-nag.

## External limitation
No live Chrome Web Store publication/device replay was performed. The implementation uses Chrome native update mechanism and opens chrome://extensions for the user update path.