### PR TITLE
fix(db): accept resolved migration retry records

### DIFF
--- a/scripts/check-migration-history.mjs
+++ b/scripts/check-migration-history.mjs
@@ -77,6 +77,16 @@ export function assertMigrationHistory(rows, expected, compatibility = { approve
   let previousIndex = -1;
 
   for (const row of rows) {
+    // Prisma retains failed attempts after `migrate resolve --rolled-back`.
+    // They are audit records, not applied migrations: ignore only the canonical
+    // unfinished+rolled-back shape. A row cannot be both finished and rolled
+    // back without pausing deployment for reconciliation.
+    if (row.rolledBackAt !== null && row.rolledBackAt !== undefined) {
+      if (row.finishedAt) {
+        throw new Error(`[migration-history] migration ${row.migrationName} is both finished and rolled-back; deployment is paused`);
+      }
+      continue;
+    }
     const current = expected[row.migrationName];
     if (current) {
       if (seenNames.has(row.migrationName) || seenIdentities.has(row.migrationName)) {
@@ -92,8 +102,8 @@ export function assertMigrationHistory(rows, expected, compatibility = { approve
       if (current !== row.checksum) {
         throw new Error(`[migration-history] checksum mismatch for applied migration ${row.migrationName}; immutable history is paused`);
       }
-      if (!row.finishedAt || row.rolledBackAt !== null) {
-        throw new Error(`[migration-history] unfinished or rolled-back migration ${row.migrationName}; deployment is paused`);
+      if (!row.finishedAt) {
+        throw new Error(`[migration-history] unfinished migration ${row.migrationName}; deployment is paused`);
       }
       continue;
     }
@@ -110,8 +120,8 @@ export function assertMigrationHistory(rows, expected, compatibility = { approve
       previousIndex = index;
       seenNames.add(row.migrationName);
       seenIdentities.add(approved.replacement);
-      if (!row.finishedAt || row.rolledBackAt !== null) {
-        throw new Error(`[migration-history] unfinished or rolled-back compatibility migration ${row.migrationName}; deployment is paused`);
+      if (!row.finishedAt) {
+        throw new Error(`[migration-history] unfinished compatibility migration ${row.migrationName}; deployment is paused`);
       }
       continue;
     }

--- a/scripts/check-migration-history.test.mjs
+++ b/scripts/check-migration-history.test.mjs
@@ -92,9 +92,14 @@ test('migration history fails closed on modified, unknown, and safe compatibilit
   assert.throws(() => assertMigrationHistory(
     [{ migrationName: 'known', checksum: 'right', finishedAt: null, rolledBackAt: null }], { known: 'right' },
   ), /unfinished.*deployment is paused/);
+  assert.doesNotThrow(() => assertMigrationHistory([
+    { migrationName: 'known', checksum: 'old-failed-attempt', finishedAt: null, rolledBackAt: 'resolved' },
+    { migrationName: 'known', checksum: 'right', finishedAt: 'done', rolledBackAt: null },
+    { migrationName: 'known', checksum: 'older-failed-attempt', finishedAt: null, rolledBackAt: 'resolved' },
+  ], { known: 'right' }));
   assert.throws(() => assertMigrationHistory(
     [{ migrationName: 'known', checksum: 'right', finishedAt: 'done', rolledBackAt: 'rolled back' }], { known: 'right' },
-  ), /rolled-back.*deployment is paused/);
+  ), /finished and rolled-back.*deployment is paused/);
 });
 
 test('migration history rejects duplicate and reordered finished rows', () => {


### PR DESCRIPTION
## Problem
Production deployment `cecda541-ec44-4331-906e-b43154d6e5b3` failed in `web-pre-deploy-migrate`: the history gate treated two Prisma `migrate resolve --rolled-back` retry rows as applied checksum drift, even though the one finished/non-rolled-back row has the exact repository checksum.

## Fix
- Ignore only Prisma's canonical unfinished + explicitly rolled-back audit rows.
- Continue failing closed for unfinished active rows, finished+rolled-back contradictions, modified active checksums, unknown applied identities, duplicates, and reorderings.
- Add the exact retry → successful apply → retry ledger-shape regression.

## Proof
- `node --test scripts/check-migration-history.test.mjs` — 6/6 pass; the new regression failed before the source fix.
- `pnpm lint` — pass (existing warnings only).
- `pnpm type-check` — 4/4 pass after Prisma generation.

This is the narrow repair required before retrying the already-reviewed foundation deployment. No migration SQL, schema, role, or gate is weakened.