### PR TITLE
fix(export): close egress-window erasure and wire QA seed object mapping (sploot-057)

### DIFF
--- a/apps/web/__tests__/api/library-export-hard-delete.test.ts
+++ b/apps/web/__tests__/api/library-export-hard-delete.test.ts
@@ -123,9 +123,23 @@ const fakePrisma = vi.hoisted(() => {
       },
     },
     $transaction: async (fn: any) => fn(db),
+    $queryRaw: async () => [],
     $queryRawUnsafe: async () => [],
     $executeRawUnsafe: async () => 1,
-    $executeRaw: async () => 1,
+    $executeRaw: async (...args: unknown[]) => {
+      const strings = args[0] as readonly string[];
+      if (strings.join('?').includes('SET "status" = \'superseded\'')) {
+        const ownerUserId = String(args[1]);
+        let count = 0;
+        for (const row of state.exports.values()) {
+          if (row.ownerUserId !== ownerUserId || row.status !== 'active') continue;
+          row.status = 'superseded';
+          count += 1;
+        }
+        return count;
+      }
+      return 1;
+    },
   };
   return db;
 });

--- a/apps/web/__tests__/api/library-export.integration.test.ts
+++ b/apps/web/__tests__/api/library-export.integration.test.ts
@@ -206,6 +206,16 @@ describe.skipIf(!dbAvailable)('library export persistence (DB)', () => {
       expect(after.egressBytes <= allowance).toBe(true);
     });
 
+    it('records reservation time as the rolling-window clock', async () => {
+      const { export: created } = await createOrReuseExport(OWNER);
+      const row = (await getOwnedExport(OWNER, created.id))!;
+      const reservedAt = new Date(row.updatedAt.getTime() + 5_000);
+
+      expect((await reserveExportEgress(row, BigInt(1), reservedAt)).kind).toBe('reserved');
+      const after = (await getOwnedExport(OWNER, created.id))!;
+      expect(after.updatedAt.getTime()).toBe(reservedAt.getTime());
+    });
+
     it('admits exactly to the boundary, refuses beyond it, and classifies the refusal', async () => {
       const { export: created } = await createOrReuseExport(OWNER);
       const row = (await getOwnedExport(OWNER, created.id))!;

--- a/apps/web/__tests__/api/library-export.integration.test.ts
+++ b/apps/web/__tests__/api/library-export.integration.test.ts
@@ -291,14 +291,72 @@ describe.skipIf(!dbAvailable)('library export persistence (DB)', () => {
 
 
 
-  it('caps retained inactive sessions during a force-create burst', async () => {
+  it('never prunes rows still inside the egress window, only stale ones beyond it', async () => {
     await createOrReuseExport(OWNER);
     for (let index = 0; index < 40; index += 1) {
       await createOrReuseExport(OWNER, { force: true });
     }
+    // The whole burst lands well inside the 24h egress window (this test
+    // runs in milliseconds), so the count-based retention cap must not
+    // touch any of it — see the dedicated window-erasure test below for why.
+    const burstRows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
+    expect(burstRows.filter((row) => row.status === 'active')).toHaveLength(1);
+    expect(burstRows.length).toBe(41);
+
+    // Once the non-active rows genuinely age out of the window, the
+    // count-based cap resumes bounding storage. A row superseded by the
+    // very act of force-creating is fresh (its own updated_at just moved to
+    // "now"), so it only becomes cap-eligible once it, too, ages past the
+    // window — simulate two full aging cycles to reach steady state.
+    await prisma!.$executeRaw`
+      UPDATE "library_exports"
+      SET "updated_at" = NOW() - INTERVAL '25 hours'
+      WHERE "owner_user_id" = ${OWNER} AND "status" <> 'active'
+    `;
+    await createOrReuseExport(OWNER, { force: true });
+    await prisma!.$executeRaw`
+      UPDATE "library_exports"
+      SET "updated_at" = NOW() - INTERVAL '25 hours'
+      WHERE "owner_user_id" = ${OWNER} AND "status" <> 'active'
+    `;
+    await createOrReuseExport(OWNER, { force: true });
     const rows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
     expect(rows.filter((row) => row.status === 'active')).toHaveLength(1);
-    expect(rows.length).toBeLessThanOrEqual(32);
+    // Steady-state bound, not exactly the raw cap: the row a force-create
+    // just superseded is fresh in that same transaction (its own updated_at
+    // moved to "now"), so it survives one extra cycle before the count-based
+    // cap can retire it too — 1 active + 1 just-superseded + the 31 stale
+    // rows the cap retains.
+    expect(rows.length).toBeLessThanOrEqual(33);
+  });
+
+  it('force-create/prune cycling cannot erase egress accounting inside the rolling window', async () => {
+    const { export: first } = await createOrReuseExport(OWNER);
+    const firstRow = (await getOwnedExport(OWNER, first.id))!;
+    const allowance = exportEgressAllowance(firstRow.totalOriginalBytes, firstRow.totalAssets, firstRow.manifestMetadataBytes);
+    expect((await reserveExportEgress(firstRow, allowance)).kind).toBe('reserved');
+
+    const { export: second } = await createOrReuseExport(OWNER, { force: true });
+    const secondRow = (await getOwnedExport(OWNER, second.id))!;
+    expect((await reserveExportEgress(secondRow, allowance)).kind).toBe('reserved');
+
+    // A burst of force-creates that, under a count-based-only retention cap,
+    // would prune sessions 1 and 2 out of the table entirely — silently
+    // erasing their egress contribution and reopening budget that must stay
+    // closed for the rest of the rolling window.
+    for (let index = 0; index < 40; index += 1) {
+      await createOrReuseExport(OWNER, { force: true });
+    }
+
+    const rows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
+    expect(rows.length).toBeGreaterThan(32);
+    expect(rows.find((row) => row.id === first.id)).toBeDefined();
+    expect(rows.find((row) => row.id === second.id)).toBeDefined();
+
+    const { export: latest } = await createOrReuseExport(OWNER, { force: true });
+    const latestRow = (await getOwnedExport(OWNER, latest.id))!;
+    const refused = await reserveExportEgress(latestRow, BigInt(1));
+    expect(refused).toEqual({ kind: 'refused', code: 'export_egress_window_exhausted' });
   });
 
   it('uses the shared identity lock as a create/delete barrier', async () => {

--- a/apps/web/__tests__/api/library-export.integration.test.ts
+++ b/apps/web/__tests__/api/library-export.integration.test.ts
@@ -6,6 +6,7 @@ import {
   cancelExport,
   entriesForPart,
   createOrReuseExport,
+  ExportEgressWindowExhaustedError,
   getOwnedExport,
   recordPartOutcome,
   refundExportEgress,
@@ -291,72 +292,79 @@ describe.skipIf(!dbAvailable)('library export persistence (DB)', () => {
 
 
 
-  it('never prunes rows still inside the egress window, only stale ones beyond it', async () => {
+  it('prunes zero-egress force-create spam even while rows are inside the window', async () => {
     await createOrReuseExport(OWNER);
     for (let index = 0; index < 40; index += 1) {
       await createOrReuseExport(OWNER, { force: true });
     }
-    // The whole burst lands well inside the 24h egress window (this test
-    // runs in milliseconds), so the count-based retention cap must not
-    // touch any of it — see the dedicated window-erasure test below for why.
-    const burstRows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
-    expect(burstRows.filter((row) => row.status === 'active')).toHaveLength(1);
-    expect(burstRows.length).toBe(41);
 
-    // Once the non-active rows genuinely age out of the window, the
-    // count-based cap resumes bounding storage. A row superseded by the
-    // very act of force-creating is fresh (its own updated_at just moved to
-    // "now"), so it only becomes cap-eligible once it, too, ages past the
-    // window — simulate two full aging cycles to reach steady state.
-    await prisma!.$executeRaw`
-      UPDATE "library_exports"
-      SET "updated_at" = NOW() - INTERVAL '25 hours'
-      WHERE "owner_user_id" = ${OWNER} AND "status" <> 'active'
-    `;
-    await createOrReuseExport(OWNER, { force: true });
-    await prisma!.$executeRaw`
-      UPDATE "library_exports"
-      SET "updated_at" = NOW() - INTERVAL '25 hours'
-      WHERE "owner_user_id" = ${OWNER} AND "status" <> 'active'
-    `;
-    await createOrReuseExport(OWNER, { force: true });
     const rows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
     expect(rows.filter((row) => row.status === 'active')).toHaveLength(1);
-    // Steady-state bound, not exactly the raw cap: the row a force-create
-    // just superseded is fresh in that same transaction (its own updated_at
-    // moved to "now"), so it survives one extra cycle before the count-based
-    // cap can retire it too — 1 active + 1 just-superseded + the 31 stale
-    // rows the cap retains.
-    expect(rows.length).toBeLessThanOrEqual(33);
+    expect(rows.length).toBeLessThanOrEqual(32);
   });
 
-  it('force-create/prune cycling cannot erase egress accounting inside the rolling window', async () => {
-    const { export: first } = await createOrReuseExport(OWNER);
-    const firstRow = (await getOwnedExport(OWNER, first.id))!;
-    const allowance = exportEgressAllowance(firstRow.totalOriginalBytes, firstRow.totalAssets, firstRow.manifestMetadataBytes);
-    expect((await reserveExportEgress(firstRow, allowance)).kind).toBe('reserved');
+  it('refuses a 33rd protected session and reopens when the earliest window slides', async () => {
+    let active = (await createOrReuseExport(OWNER)).export;
+    for (let index = 0; index < 31; index += 1) {
+      await prisma!.libraryExport.update({
+        where: { id: active.id },
+        data: { egressBytes: BigInt(1) },
+      });
+      active = (await createOrReuseExport(OWNER, { force: true })).export;
+    }
+    await prisma!.libraryExport.update({
+      where: { id: active.id },
+      data: { egressBytes: BigInt(1) },
+    });
 
-    const { export: second } = await createOrReuseExport(OWNER, { force: true });
-    const secondRow = (await getOwnedExport(OWNER, second.id))!;
-    expect((await reserveExportEgress(secondRow, allowance)).kind).toBe('reserved');
+    await expect(createOrReuseExport(OWNER, { force: true })).rejects.toBeInstanceOf(
+      ExportEgressWindowExhaustedError,
+    );
+    let rows = await prisma!.libraryExport.findMany({
+      where: { ownerUserId: OWNER },
+      orderBy: { updatedAt: 'asc' },
+    });
+    expect(rows).toHaveLength(32);
+    expect(rows.filter((row) => row.status === 'active')).toHaveLength(1);
 
-    // A burst of force-creates that, under a count-based-only retention cap,
-    // would prune sessions 1 and 2 out of the table entirely — silently
-    // erasing their egress contribution and reopening budget that must stay
-    // closed for the rest of the rolling window.
-    for (let index = 0; index < 40; index += 1) {
-      await createOrReuseExport(OWNER, { force: true });
+    await prisma!.$executeRaw`
+      UPDATE "library_exports"
+      SET "updated_at" = NOW() - INTERVAL '25 hours'
+      WHERE "id" = ${rows[0].id}
+    `;
+    const reopened = await createOrReuseExport(OWNER, { force: true });
+    expect(reopened.reused).toBe(false);
+    rows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
+    expect(rows.length).toBeLessThanOrEqual(32);
+  });
+
+  it('serializes a boundary reservation against force-create without erasing spend', async () => {
+    let active = (await createOrReuseExport(OWNER)).export;
+    for (let index = 0; index < 31; index += 1) {
+      await prisma!.libraryExport.update({
+        where: { id: active.id },
+        data: { egressBytes: BigInt(1) },
+      });
+      active = (await createOrReuseExport(OWNER, { force: true })).export;
+    }
+    const activeRow = (await getOwnedExport(OWNER, active.id))!;
+
+    const [reservation, forceCreate] = await Promise.allSettled([
+      reserveExportEgress(activeRow, BigInt(1)),
+      createOrReuseExport(OWNER, { force: true }),
+    ]);
+    if (reservation.status !== 'fulfilled') throw reservation.reason;
+    if (forceCreate.status === 'fulfilled') {
+      expect(reservation.value.kind).toBe('gone');
+    } else {
+      expect(forceCreate.reason).toBeInstanceOf(ExportEgressWindowExhaustedError);
+      expect(reservation.value.kind).toBe('reserved');
+      const retained = await getOwnedExport(OWNER, active.id);
+      expect(retained?.egressBytes).toBe(BigInt(1));
     }
 
     const rows = await prisma!.libraryExport.findMany({ where: { ownerUserId: OWNER } });
-    expect(rows.length).toBeGreaterThan(32);
-    expect(rows.find((row) => row.id === first.id)).toBeDefined();
-    expect(rows.find((row) => row.id === second.id)).toBeDefined();
-
-    const { export: latest } = await createOrReuseExport(OWNER, { force: true });
-    const latestRow = (await getOwnedExport(OWNER, latest.id))!;
-    const refused = await reserveExportEgress(latestRow, BigInt(1));
-    expect(refused).toEqual({ kind: 'refused', code: 'export_egress_window_exhausted' });
+    expect(rows.length).toBeLessThanOrEqual(32);
   });
 
   it('uses the shared identity lock as a create/delete barrier', async () => {

--- a/apps/web/__tests__/api/library-export.test.ts
+++ b/apps/web/__tests__/api/library-export.test.ts
@@ -158,10 +158,9 @@ const fakePrisma = vi.hoisted(() => {
         return { ...row };
       },
       updateMany: async ({ where, data }: any) => {
-        // Mirrors documented Prisma/Postgres semantics: filters (including
-        // comparison operators) and atomic increment/decrement apply per row.
-        // The body is synchronous, so like a row-locked UPDATE it can never
-        // interleave with another updateMany mid-application.
+        // Mirrors Postgres filters and atomic arithmetic. `updateMany` does
+        // not advance Prisma's @updatedAt field unless the service supplies
+        // updatedAt explicitly in data.
         let count = 0;
         for (const row of state.exports.values()) {
           if (where.id && row.id !== where.id) continue;
@@ -185,7 +184,7 @@ const fakePrisma = vi.hoisted(() => {
               applied[key] = value;
             }
           }
-          Object.assign(row, applied, { updatedAt: new Date() });
+          Object.assign(row, applied);
           count += 1;
         }
         return { count };

--- a/apps/web/__tests__/api/library-export.test.ts
+++ b/apps/web/__tests__/api/library-export.test.ts
@@ -105,6 +105,7 @@ const fakePrisma = vi.hoisted(() => {
       findMany: async ({ where, skip = 0, take, select }: any) => {
         const rows = [...state.exports.values()].filter((row) => {
           if (where.ownerUserId && row.ownerUserId !== where.ownerUserId) return false;
+          if (where.id?.notIn && where.id.notIn.includes(row.id)) return false;
           if (where.status?.not && row.status === where.status.not) return false;
           return true;
         }).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(skip, take ? skip + take : undefined);
@@ -241,8 +242,74 @@ const fakePrisma = vi.hoisted(() => {
           .map((tag) => ({ name: tag.name, color: tag.color })),
     },
     $transaction: async (fn: any) => fn(prismaLike),
+    $queryRaw: async (...args: unknown[]) => {
+      const strings = args[0] as readonly string[];
+      const sql = strings.join('?');
+      const values = args.slice(1);
+      const ownerUserId = String(sql.includes('AS "releaseAt"') ? values[3] : values[0]);
+      if (!sql.includes('AS "releaseAt"')) {
+        return [...state.exports.values()]
+          .filter(
+            (row) =>
+              row.ownerUserId === ownerUserId
+              && (row.status === 'active' || row.status === 'complete'),
+          )
+          .sort((left, right) => left.id.localeCompare(right.id))
+          .map((row) => ({ id: row.id }));
+      }
+      const windowStart = values[0] as Date;
+      const now = values[2] as Date;
+      const windowMs = Number(values[1]) * 1_000;
+      const limit = Number(values.at(-1));
+      return [...state.exports.values()]
+        .filter((row) => {
+          if (row.ownerUserId !== ownerUserId) return false;
+          const protectsSpend = row.egressBytes > BigInt(0) && row.updatedAt >= windowStart;
+          const protectsManifest =
+            row.status === 'complete'
+            && row.manifestFinalizedAt !== null
+            && row.manifestFinalizedArtifact !== null
+            && row.expiresAt > now;
+          return protectsSpend || protectsManifest;
+        })
+        .map((row) => {
+          const spendRelease =
+            row.egressBytes > BigInt(0) && row.updatedAt >= windowStart
+              ? row.updatedAt.getTime() + windowMs
+              : Number.NEGATIVE_INFINITY;
+          const manifestRelease =
+            row.status === 'complete'
+            && row.manifestFinalizedAt !== null
+            && row.manifestFinalizedArtifact !== null
+            && row.expiresAt > now
+              ? row.expiresAt.getTime()
+              : Number.NEGATIVE_INFINITY;
+          return {
+            id: row.id,
+            releaseAt: new Date(Math.max(spendRelease, manifestRelease)),
+          };
+        })
+        .sort(
+          (left, right) =>
+            left.releaseAt.getTime() - right.releaseAt.getTime()
+            || left.id.localeCompare(right.id),
+        )
+        .slice(0, limit);
+    },
     $executeRaw: async (...args: unknown[]) => {
       state.executeRawCalls.push(args);
+      const strings = args[0] as readonly string[];
+      const sql = strings.join('?');
+      if (sql.includes('SET "status" = \'superseded\'')) {
+        const ownerUserId = String(args[1]);
+        let count = 0;
+        for (const row of state.exports.values()) {
+          if (row.ownerUserId !== ownerUserId || row.status !== 'active') continue;
+          row.status = 'superseded';
+          count += 1;
+        }
+        return count;
+      }
       return 1;
     },
   };
@@ -439,6 +506,42 @@ describe('POST /api/library/export', () => {
     expect(rows.length).toBeLessThanOrEqual(32);
   });
 
+
+  it('returns a retryable 429 before force-create can exceed protected history', async () => {
+    seedAsset('asset-a', USER, new Uint8Array([1]));
+    let active = await createExport();
+    for (let index = 0; index < 31; index += 1) {
+      state.exports.get(active.id)!.egressBytes = BigInt(1);
+      const response = await createPost(
+        request('/api/library/export', {
+          method: 'POST',
+          body: JSON.stringify({ force: true }),
+          headers: { 'content-type': 'application/json' },
+        }),
+        ctx({}),
+      );
+      expect(response.status).toBe(201);
+      active = (await response.json()).export;
+    }
+    state.exports.get(active.id)!.egressBytes = BigInt(1);
+
+    const response = await createPost(
+      request('/api/library/export', {
+        method: 'POST',
+        body: JSON.stringify({ force: true }),
+        headers: { 'content-type': 'application/json' },
+      }),
+      ctx({}),
+    );
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toMatch(/^[1-9]\d*$/);
+    expect(await response.json()).toMatchObject({
+      code: 'export_egress_window_exhausted',
+      retryable: true,
+    });
+    expect(state.exports.size).toBe(32);
+    expect(state.exports.get(active.id)?.status).toBe('active');
+  });
   it('creates a valid zero-part export for an empty library', async () => {
     const view = await createExport();
     expect(view.totals).toEqual({ assets: 0, originalBytes: 0 });

--- a/apps/web/__tests__/lib/export/export-objects.test.ts
+++ b/apps/web/__tests__/lib/export/export-objects.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -218,9 +218,14 @@ describe('QA seed object mapping', () => {
   const seedPath = join(seedDir, seedFile);
   const seedUrl = `${QA_SEED_BLOB_HOST}/qa-blob-seed/${seedFile}`;
   const seedBytes = new Uint8Array([9, 8, 7, 6, 5]);
+  const escapeFile = '__test-export-objects-qa-seed-link.bin';
+  const escapePath = join(seedDir, escapeFile);
+  const outsidePath = join(seedDir, '..', '__test-export-objects-outside.bin');
 
   afterEach(() => {
     rmSync(seedPath, { force: true });
+    rmSync(escapePath, { force: true });
+    rmSync(outsidePath, { force: true });
   });
 
   function enableQaMode() {
@@ -258,6 +263,21 @@ describe('QA seed object mapping', () => {
     vi.stubGlobal('fetch', fetchSpy);
     const result = await openExportObject(
       `${QA_SEED_BLOB_HOST}/qa-blob-seed/../../lib/export/export-objects.ts`,
+    );
+    expect(result).toEqual({ ok: false, reason: 'object_url_rejected' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a seed-directory symlink whose canonical target escapes the root', async () => {
+    mkdirSync(seedDir, { recursive: true });
+    writeFileSync(outsidePath, seedBytes);
+    symlinkSync(outsidePath, escapePath);
+    enableQaMode();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await openExportObject(
+      `${QA_SEED_BLOB_HOST}/qa-blob-seed/${escapeFile}`,
     );
     expect(result).toEqual({ ok: false, reason: 'object_url_rejected' });
     expect(fetchSpy).not.toHaveBeenCalled();

--- a/apps/web/__tests__/lib/export/export-objects.test.ts
+++ b/apps/web/__tests__/lib/export/export-objects.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   isAllowedExportObjectUrl,
@@ -5,9 +7,11 @@ import {
   openExportObject,
 } from '@/lib/export/export-objects';
 import { EXPORT_STREAM_CHUNK_BYTES } from '@/lib/export/export-backpressure';
+import { QA_SEED_BLOB_HOST } from '@/lib/qa/qa-image-loader';
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 describe('export object reader', () => {
@@ -204,5 +208,71 @@ describe('export object reader', () => {
     expect(
       await openExportObject('https://abc.public.blob.vercel-storage.com/u/file.png'),
     ).toEqual({ ok: false, reason: 'object_fetch_failed' });
+  });
+});
+
+
+describe('QA seed object mapping', () => {
+  const seedDir = join(process.cwd(), 'public', 'qa-blob-seed');
+  const seedFile = '__test-export-objects-qa-seed.bin';
+  const seedPath = join(seedDir, seedFile);
+  const seedUrl = `${QA_SEED_BLOB_HOST}/qa-blob-seed/${seedFile}`;
+  const seedBytes = new Uint8Array([9, 8, 7, 6, 5]);
+
+  afterEach(() => {
+    rmSync(seedPath, { force: true });
+  });
+
+  function enableQaMode() {
+    vi.stubEnv('SPLOOT_QA_AUTH_MODE', 'enabled');
+    vi.stubEnv('SPLOOT_DEPLOYMENT_ENV', 'test');
+  }
+
+  it('reads a seeded fixture from disk without any network fetch', async () => {
+    mkdirSync(seedDir, { recursive: true });
+    writeFileSync(seedPath, seedBytes);
+    enableQaMode();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await openExportObject(seedUrl);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const buffer = new Uint8Array(await new Response(result.body).arrayBuffer());
+      expect(buffer).toEqual(seedBytes);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports object_missing for a seed URL with no backing file', async () => {
+    enableQaMode();
+    const result = await openExportObject(
+      `${QA_SEED_BLOB_HOST}/qa-blob-seed/does-not-exist.bin`,
+    );
+    expect(result).toEqual({ ok: false, reason: 'object_missing' });
+  });
+
+  it('rejects path traversal outside the seed directory', async () => {
+    enableQaMode();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const result = await openExportObject(
+      `${QA_SEED_BLOB_HOST}/qa-blob-seed/../../lib/export/export-objects.ts`,
+    );
+    expect(result).toEqual({ ok: false, reason: 'object_url_rejected' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a real network fetch for the seed host outside QA mode', async () => {
+    // No env stubbed: isQaLocalAuthEnabled() is false by default in this
+    // suite's environment, so the reserved host must go through the normal
+    // (and here, failing) network path rather than ever touching disk.
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const result = await openExportObject(seedUrl);
+    expect(result).toEqual({ ok: false, reason: 'object_fetch_failed' });
+    expect(fetchSpy).toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/library/export/route.ts
+++ b/apps/web/app/api/library/export/route.ts
@@ -6,7 +6,11 @@ import {
 } from '@/lib/auth/with-authenticated-api';
 import { prisma } from '@/lib/db';
 import { enrollmentUnavailableResponse } from '@/lib/enrollment/enrollment-policy';
-import { createOrReuseExport, getActiveExport } from '@/lib/export/export-service';
+import {
+  createOrReuseExport,
+  ExportEgressWindowExhaustedError,
+  getActiveExport,
+} from '@/lib/export/export-service';
 import { withObservability } from '@/lib/with-observability';
 import logger from '@/lib/logger';
 
@@ -45,6 +49,20 @@ async function postHandler(
     return NextResponse.json({ export: view, reused }, { status: reused ? 200 : 201 });
   } catch (error) {
     unstable_rethrow(error);
+    if (error instanceof ExportEgressWindowExhaustedError) {
+      return NextResponse.json(
+        {
+          error: 'Export session limit reached for the rolling egress window',
+          code: error.code,
+          retryable: true,
+          retryAfterSec: error.retryAfterSeconds,
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(error.retryAfterSeconds) },
+        },
+      );
+    }
     logger.error('library-export:create-failed', error);
     return NextResponse.json({ error: 'Failed to create export' }, { status: 500 });
   }

--- a/apps/web/docs/API.md
+++ b/apps/web/docs/API.md
@@ -841,6 +841,13 @@ session and snapshots fresh. At most one active session per user.
 }
 ```
 
+`force: true` is refused before snapshotting when 32 prior sessions must remain
+to preserve rolling-window egress accounting or an unexpired finalized
+manifest. The response is HTTP 429 with
+`{"code":"export_egress_window_exhausted","retryable":true,"retryAfterSec":…}`
+and a matching `Retry-After` header. Zero-egress canceled/superseded history is
+cap-prunable even inside the window, so force-create spam cannot grow storage.
+
 #### GET /api/library/export
 
 Return the caller's active export session or durable completed manifest (same
@@ -878,7 +885,8 @@ on clean completion, and kept in full if the download is aborted (see
 - 410: `export_expired` | `export_unavailable` (canceled/superseded)
 - 429: `export_egress_exhausted` (per-export download budget spent;
   `retryable: false`) | `export_egress_window_exhausted` (rolling 24h tenant
-  budget spent; `retryable: true` — the window slides)
+  budget or protected-session ceiling reached; `retryable: true`, with
+  `Retry-After` — the window slides)
 
 #### GET /api/library/export/{exportId}/manifest
 

--- a/apps/web/docs/EXPORT.md
+++ b/apps/web/docs/EXPORT.md
@@ -27,8 +27,9 @@ rules the endpoints enforce.
   byte.
 - **Bounded persistence.** Parts are streamed without server-side archives; the
   terminal manifest is additionally persisted as a bounded replay artifact (up to
-  16 MiB) on the `library_exports` row. Bookkeeping rows are lazily deleted 7 days
-  after expiry.
+  16 MiB) on the `library_exports` row. Each user retains at most 32 rows:
+  rolling-window spend and unexpired finalized manifests are never pruned,
+  while zero-egress canceled/superseded history remains cap-eligible.
 - **Expiring capability.** An export and its download URLs die 24 hours after
   creation (HTTP `410`), and immediately on cancel. Tenant-scoped: only the
   owner's session can resolve an export id; provider URLs never reach the
@@ -51,6 +52,11 @@ UTF-8 manifest/tag framing and keeps tiny-asset exports bounded; if it
   `429 export_egress_window_exhausted` (retryable — the window slides, so a
   full export is always possible again; data is never held hostage and there
   is no billing gate).
+  At most 32 spend-bearing or unexpired-finalized sessions may be protected at
+  once. A force-create at that boundary returns the same retryable 429 before
+  snapshotting, with `Retry-After` derived from the earliest protection expiry.
+  Zero-egress force-create spam remains prunable and cannot grow rows without
+  bound.
 - **Bounded streaming.** Producers await downstream capacity; a stalled consumer
   is failed closed after 60 seconds, while a slow consumer that makes progress
   continues. Provider headers and read-idle waits are separately capped at 60
@@ -152,3 +158,4 @@ know.
 | Asset permanently deleted | Active exports are canceled in the same transaction before the row is removed; later part/manifest requests return `410 export_unavailable` instead of claiming a complete historical snapshot. |
 | Per-export egress cap reached | `429 export_egress_exhausted`; start a new export (subject to the rolling window). |
 | Rolling 24h window cap reached | `429 export_egress_window_exhausted`; retryable — wait for the window to slide. |
+| Protected session ceiling reached | `429 export_egress_window_exhausted` with `Retry-After`; no new snapshot is created, and retry succeeds after the earliest spend window or finalized manifest expires. |

--- a/apps/web/lib/export/export-objects.ts
+++ b/apps/web/lib/export/export-objects.ts
@@ -8,6 +8,12 @@
  */
 
 
+import { createReadStream } from 'node:fs';
+import { stat as fsStat } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+import { Readable } from 'node:stream';
+import { isQaLocalAuthEnabled } from '@/lib/auth/qa-local-enabled';
+import { QA_SEED_BLOB_HOST } from '@/lib/qa/qa-image-loader';
 import { EXPORT_STREAM_CHUNK_BYTES } from './export-backpressure';
 
 export type ExportObjectFailureReason =
@@ -50,6 +56,50 @@ export function isAllowedExportObjectUrl(rawUrl: string): boolean {
     return false;
   }
   return url.protocol === 'https:' && ALLOWED_OBJECT_HOST.test(url.hostname);
+}
+
+/**
+ * QA-only local object mapping.
+ *
+ * QA seed assets (scripts/qa-seed.ts) store a constraint-compliant blob URL
+ * under the reserved QA_SEED_BLOB_HOST so the assets table CHECK constraint
+ * is satisfied without touching production code paths; the actual bytes sit
+ * in public/qa-blob-seed/. The client-side image loader
+ * (lib/qa/qa-image-loader.ts) already maps that host back to a local path
+ * for rendering — this does the equivalent for the server-side export
+ * pipeline, since a real fetch() against the reserved (non-existent) host
+ * always fails and made QA-seeded libraries permanently unexportable.
+ *
+ * Gated by isQaLocalAuthEnabled(), the same production-impossible check
+ * (SPLOOT_QA_AUTH_MODE=enabled AND SPLOOT_DEPLOYMENT_ENV in
+ * {development,test}) the rest of the QA harness uses, so this path is
+ * unreachable outside local QA runs.
+ */
+const QA_SEED_ROOT = resolve(join(process.cwd(), 'public', 'qa-blob-seed'));
+
+async function openQaSeedObject(url: string): Promise<OpenExportObjectResult> {
+  const relative = url.slice(QA_SEED_BLOB_HOST.length);
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(new URL(relative, 'http://qa-seed.invalid').pathname);
+  } catch {
+    return { ok: false, reason: 'object_url_rejected' };
+  }
+  if (!pathname.startsWith('/qa-blob-seed/')) {
+    return { ok: false, reason: 'object_url_rejected' };
+  }
+  const resolved = resolve(join(process.cwd(), 'public', pathname));
+  if (resolved !== QA_SEED_ROOT && !resolved.startsWith(`${QA_SEED_ROOT}${sep}`)) {
+    return { ok: false, reason: 'object_url_rejected' };
+  }
+  try {
+    const stats = await fsStat(resolved);
+    if (!stats.isFile()) return { ok: false, reason: 'object_missing' };
+  } catch {
+    return { ok: false, reason: 'object_missing' };
+  }
+  const body = Readable.toWeb(createReadStream(resolved)) as ReadableStream<Uint8Array>;
+  return { ok: true, body };
 }
 
 function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
@@ -167,6 +217,10 @@ export function createExportObjectReader(
   return async (url, externalSignal) => {
     if (!isAllowedExportObjectUrl(url)) {
       return { ok: false, reason: 'object_url_rejected' };
+    }
+
+    if (isQaLocalAuthEnabled() && url.startsWith(`${QA_SEED_BLOB_HOST}/`)) {
+      return openQaSeedObject(url);
     }
 
     const controller = new AbortController();

--- a/apps/web/lib/export/export-objects.ts
+++ b/apps/web/lib/export/export-objects.ts
@@ -8,8 +8,8 @@
  */
 
 
-import { createReadStream } from 'node:fs';
-import { stat as fsStat } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { open, realpath, type FileHandle } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { Readable } from 'node:stream';
 import { isQaLocalAuthEnabled } from '@/lib/auth/qa-local-enabled';
@@ -92,14 +92,40 @@ async function openQaSeedObject(url: string): Promise<OpenExportObjectResult> {
   if (resolved !== QA_SEED_ROOT && !resolved.startsWith(`${QA_SEED_ROOT}${sep}`)) {
     return { ok: false, reason: 'object_url_rejected' };
   }
+
+  let canonicalRoot: string;
+  let canonicalFile: string;
   try {
-    const stats = await fsStat(resolved);
-    if (!stats.isFile()) return { ok: false, reason: 'object_missing' };
+    [canonicalRoot, canonicalFile] = await Promise.all([
+      realpath(QA_SEED_ROOT),
+      realpath(resolved),
+    ]);
   } catch {
     return { ok: false, reason: 'object_missing' };
   }
-  const body = Readable.toWeb(createReadStream(resolved)) as ReadableStream<Uint8Array>;
-  return { ok: true, body };
+  if (
+    canonicalFile !== canonicalRoot
+    && !canonicalFile.startsWith(`${canonicalRoot}${sep}`)
+  ) {
+    return { ok: false, reason: 'object_url_rejected' };
+  }
+
+  let file: FileHandle | undefined;
+  try {
+    file = await open(canonicalFile, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stats = await file.stat();
+    if (!stats.isFile()) {
+      await file.close();
+      return { ok: false, reason: 'object_missing' };
+    }
+    const body = Readable.toWeb(
+      file.createReadStream({ autoClose: true }),
+    ) as ReadableStream<Uint8Array>;
+    return { ok: true, body };
+  } catch {
+    await file?.close().catch(() => undefined);
+    return { ok: false, reason: 'object_missing' };
+  }
 }
 
 function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {

--- a/apps/web/lib/export/export-service.ts
+++ b/apps/web/lib/export/export-service.ts
@@ -77,14 +77,25 @@ export interface LibraryExportView {
   downloads: { status: string; manifest: string; parts: string[] };
 }
 
-/** How long finished (superseded/canceled/expired) rows linger for debugging. */
-const EXPORT_ROW_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 /** Active plus bounded inactive history; force-create cannot grow rows forever. */
 const EXPORT_MAX_RETAINED_ROWS_PER_USER = 32;
 /** Planning/manifest admission is bounded but may scan a large library. */
 const EXPORT_PLANNING_TRANSACTION_TIMEOUT_MS = 120_000;
 const EXPORT_LIFECYCLE_POLL_MS = 1_000;
 
+interface ProtectedExportLock {
+  id: string;
+  releaseAt: Date;
+}
+
+export class ExportEgressWindowExhaustedError extends Error {
+  readonly code = 'export_egress_window_exhausted';
+
+  constructor(readonly retryAfterSeconds: number) {
+    super('Export session limit reached for the rolling egress window');
+    this.name = 'ExportEgressWindowExhaustedError';
+  }
+}
 type ExportDatabase = NonNullable<typeof prisma> | Prisma.TransactionClient;
 
 function requirePrismaDb(): NonNullable<typeof prisma> {
@@ -95,6 +106,13 @@ function requirePrismaDb(): NonNullable<typeof prisma> {
 function requireDb(database?: ExportDatabase): ExportDatabase {
   if (database) return database;
   return requirePrismaDb();
+}
+
+function isPrismaUniqueConstraintError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === 'P2002';
 }
 
 // Prisma returns Json columns as unknown; normalize defensively so a
@@ -298,6 +316,18 @@ export async function createOrReuseExport(
   try {
     const result = await db.$transaction(async (tx) => {
       await acquireEnrollmentIdentityWriterLock(tx, userId);
+      // Synchronize force-create with every in-flight reservation before
+      // inspecting or changing reusable sessions. The identity lock
+      // serializes creates; these row locks serialize create vs. download.
+      await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id"
+        FROM "library_exports"
+        WHERE "owner_user_id" = ${userId}
+          AND "status" IN ('active', 'complete')
+        ORDER BY "id"
+        FOR UPDATE
+      `;
+
       const lockedActive = await tx.libraryExport.findFirst({
         where: { ownerUserId: userId, status: 'active' },
       });
@@ -319,6 +349,49 @@ export async function createOrReuseExport(
         return { row: lockedComplete, reused: true };
       }
 
+      const windowStart = new Date(now.getTime() - EXPORT_EGRESS_WINDOW_MS);
+      const protectedRows = await tx.$queryRaw<ProtectedExportLock[]>`
+        SELECT
+          "id",
+          GREATEST(
+            CASE
+              WHEN "egress_bytes" > 0 AND "updated_at" >= ${windowStart}
+                THEN "updated_at" + make_interval(secs => ${EXPORT_EGRESS_WINDOW_MS / 1000})
+              ELSE '-infinity'::timestamptz
+            END,
+            CASE
+              WHEN "status" = 'complete'
+                AND "manifest_finalized_at" IS NOT NULL
+                AND "manifest_finalized_artifact" IS NOT NULL
+                AND "expires_at" > ${now}
+                THEN "expires_at"
+              ELSE '-infinity'::timestamptz
+            END
+          ) AS "releaseAt"
+        FROM "library_exports"
+        WHERE "owner_user_id" = ${userId}
+          AND (
+            ("egress_bytes" > 0 AND "updated_at" >= ${windowStart})
+            OR (
+              "status" = 'complete'
+              AND "manifest_finalized_at" IS NOT NULL
+              AND "manifest_finalized_artifact" IS NOT NULL
+              AND "expires_at" > ${now}
+            )
+          )
+        ORDER BY "releaseAt" ASC, "id" ASC
+        LIMIT ${EXPORT_MAX_RETAINED_ROWS_PER_USER}
+        FOR UPDATE
+      `;
+      if (protectedRows.length >= EXPORT_MAX_RETAINED_ROWS_PER_USER) {
+        const releaseAt = protectedRows[0]?.releaseAt ?? new Date(now.getTime() + 1_000);
+        const retryAfterSeconds = Math.max(
+          1,
+          Math.ceil((releaseAt.getTime() - now.getTime()) / 1_000),
+        );
+        throw new ExportEgressWindowExhaustedError(retryAfterSeconds);
+      }
+
       // Keep planning and active-row creation under the same identity lock as
       // permanent asset deletion. Never hold this transaction across streaming.
       const snapshotAt = new Date();
@@ -327,26 +400,26 @@ export async function createOrReuseExport(
         userId,
         snapshotAt,
       );
-      await tx.libraryExport.deleteMany({
+      // Preserve updated_at: it is the rolling egress clock, so a lifecycle
+      // status change must not manufacture a fresh 24-hour spend window.
+      await tx.$executeRaw`
+        UPDATE "library_exports"
+        SET "status" = 'superseded'
+        WHERE "owner_user_id" = ${userId}
+          AND "status" = 'active'
+      `;
+
+      const protectedIds = protectedRows.map((row) => row.id);
+      const retainedHistorySlots =
+        EXPORT_MAX_RETAINED_ROWS_PER_USER - 1 - protectedIds.length;
+      const staleInactive = await tx.libraryExport.findMany({
         where: {
           ownerUserId: userId,
-          expiresAt: { lt: new Date(now.getTime() - EXPORT_ROW_RETENTION_MS) },
+          status: { not: 'active' },
+          ...(protectedIds.length > 0 ? { id: { notIn: protectedIds } } : {}),
         },
-      });
-      await tx.libraryExport.updateMany({
-        where: { ownerUserId: userId, status: 'active' },
-        data: { status: 'superseded' },
-      });
-      // Rows updated within the rolling egress window still contribute to
-      // reserveExportEgress's window-headroom aggregate for other sessions —
-      // deleting them here would let a user manufacture fresh egress budget
-      // simply by force-creating past the retention cap. Only rows already
-      // outside the window are eligible for the count-based cap.
-      const windowStart = new Date(now.getTime() - EXPORT_EGRESS_WINDOW_MS);
-      const staleInactive = await tx.libraryExport.findMany({
-        where: { ownerUserId: userId, status: { not: 'active' }, updatedAt: { lt: windowStart } },
         orderBy: { updatedAt: 'desc' },
-        skip: EXPORT_MAX_RETAINED_ROWS_PER_USER - 1,
+        skip: retainedHistorySlots,
         select: { id: true },
       });
       if (staleInactive.length > 0) {
@@ -354,6 +427,7 @@ export async function createOrReuseExport(
           where: { id: { in: staleInactive.map((row) => row.id) } },
         });
       }
+
       const row = await tx.libraryExport.create({
         data: {
           ownerUserId: userId,
@@ -385,7 +459,7 @@ export async function createOrReuseExport(
       reused: result.reused,
     };
   } catch (error: unknown) {
-    if ((error as { code?: string })?.code === 'P2002') {
+    if (isPrismaUniqueConstraintError(error)) {
       const winner = await db.libraryExport.findFirst({
         where: { ownerUserId: userId, status: 'active' },
       });

--- a/apps/web/lib/export/export-service.ts
+++ b/apps/web/lib/export/export-service.ts
@@ -357,7 +357,7 @@ export async function createOrReuseExport(
             CASE
               WHEN "egress_bytes" > 0 AND "updated_at" >= ${windowStart}
                 THEN "updated_at" + make_interval(secs => ${EXPORT_EGRESS_WINDOW_MS / 1000})
-              ELSE '-infinity'::timestamptz
+              ELSE '-infinity'::timestamp
             END,
             CASE
               WHEN "status" = 'complete'
@@ -365,7 +365,7 @@ export async function createOrReuseExport(
                 AND "manifest_finalized_artifact" IS NOT NULL
                 AND "expires_at" > ${now}
                 THEN "expires_at"
-              ELSE '-infinity'::timestamptz
+              ELSE '-infinity'::timestamp
             END
           ) AS "releaseAt"
         FROM "library_exports"
@@ -584,7 +584,7 @@ export async function reserveExportEgress(
       expiresAt: { gt: now },
       egressBytes: { lte: ceiling - reserveBytes },
     },
-    data: { egressBytes: { increment: reserveBytes } },
+    data: { egressBytes: { increment: reserveBytes }, updatedAt: now },
   });
   if (admitted.count === 1) {
     return { kind: 'reserved', reservedBytes: reserveBytes };
@@ -592,7 +592,7 @@ export async function reserveExportEgress(
   if (allowComplete) {
     const completedAdmission = await db.libraryExport.updateMany({
       where: { id: row.id, status: 'complete', expiresAt: { gt: now }, egressBytes: { lte: ceiling - reserveBytes } },
-      data: { egressBytes: { increment: reserveBytes } },
+      data: { egressBytes: { increment: reserveBytes }, updatedAt: now },
     });
     if (completedAdmission.count === 1) return { kind: 'reserved', reservedBytes: reserveBytes };
   }
@@ -618,14 +618,15 @@ export async function reserveExportEgress(
 export async function refundExportEgress(exportId: string, refundBytes: bigint): Promise<void> {
   if (refundBytes <= BigInt(0)) return;
   const db = requireDb();
+  const now = new Date();
   const activeRefund = await db.libraryExport.updateMany({
-    where: { id: exportId, status: 'active', expiresAt: { gt: new Date() }, egressBytes: { gte: refundBytes } },
-    data: { egressBytes: { decrement: refundBytes } },
+    where: { id: exportId, status: 'active', expiresAt: { gt: now }, egressBytes: { gte: refundBytes } },
+    data: { egressBytes: { decrement: refundBytes }, updatedAt: now },
   });
   if (activeRefund.count === 0) {
     await db.libraryExport.updateMany({
-      where: { id: exportId, status: 'complete', expiresAt: { gt: new Date() }, egressBytes: { gte: refundBytes } },
-      data: { egressBytes: { decrement: refundBytes } },
+      where: { id: exportId, status: 'complete', expiresAt: { gt: now }, egressBytes: { gte: refundBytes } },
+      data: { egressBytes: { decrement: refundBytes }, updatedAt: now },
     });
   }
 }
@@ -645,9 +646,10 @@ export async function refundExportEgressReservation(
 ): Promise<void> {
   if (reservationBytes <= BigInt(0)) return;
   const db = requireDb();
+  const now = new Date();
   const refunded = await db.libraryExport.updateMany({
     where: { id: exportId, egressBytes: { gte: reservationBytes } },
-    data: { egressBytes: { decrement: reservationBytes } },
+    data: { egressBytes: { decrement: reservationBytes }, updatedAt: now },
   });
   if (refunded.count !== 1) {
     const existing = await db.libraryExport.findFirst({ where: { id: exportId }, select: { id: true } });

--- a/apps/web/lib/export/export-service.ts
+++ b/apps/web/lib/export/export-service.ts
@@ -337,15 +337,21 @@ export async function createOrReuseExport(
         where: { ownerUserId: userId, status: 'active' },
         data: { status: 'superseded' },
       });
-      const inactiveToDelete = await tx.libraryExport.findMany({
-        where: { ownerUserId: userId, status: { not: 'active' } },
+      // Rows updated within the rolling egress window still contribute to
+      // reserveExportEgress's window-headroom aggregate for other sessions —
+      // deleting them here would let a user manufacture fresh egress budget
+      // simply by force-creating past the retention cap. Only rows already
+      // outside the window are eligible for the count-based cap.
+      const windowStart = new Date(now.getTime() - EXPORT_EGRESS_WINDOW_MS);
+      const staleInactive = await tx.libraryExport.findMany({
+        where: { ownerUserId: userId, status: { not: 'active' }, updatedAt: { lt: windowStart } },
         orderBy: { updatedAt: 'desc' },
         skip: EXPORT_MAX_RETAINED_ROWS_PER_USER - 1,
         select: { id: true },
       });
-      if (inactiveToDelete.length > 0) {
+      if (staleInactive.length > 0) {
         await tx.libraryExport.deleteMany({
-          where: { id: { in: inactiveToDelete.map((row) => row.id) } },
+          where: { id: { in: staleInactive.map((row) => row.id) } },
         });
       }
       const row = await tx.libraryExport.create({


### PR DESCRIPTION
## Summary

Post-merge repair for Powder card `sploot-057`. Closes the egress-accounting erasure bug, bounds protected session rows without pruning spend, and makes QA-seeded export reads canonical-path safe.

## Fixed

- Force-create locks active/complete export rows, serializing against in-flight reservations.
- Spend-bearing rows inside the rolling 24-hour window and unexpired finalized manifests are protected from pruning.
- At 32 protected rows, force-create refuses before snapshot/supersede with retryable HTTP 429 `export_egress_window_exhausted`; `Retry-After` comes from the earliest protection expiry.
- Zero-egress superseded/canceled history remains cap-prunable inside the window.
- Superseding preserves `updated_at`; every reserve/refund mutation explicitly records its event time as the rolling-window clock.
- Protected-row SQL uses timestamp-compatible sentinels; no implicit timestamptz conversion.
- QA seed reads canonicalize root/candidate with `realpath`, enforce canonical containment, and open with `O_NOFOLLOW`; symlink escapes are rejected.

## Verification

Exact head `a3b2882c` on current master:

- Focused export suite: 8 files / 115 tests passed.
- Live pgvector/Postgres 15 integration: 16 tests passed, including explicit reservation timestamp, 32-row boundary, window reopening, and concurrent reserve-vs-force serialization.
- Web type-check passed.
- Web lint passed before the final timestamp-only correction (30 pre-existing warnings, 0 errors); final changed TypeScript is covered by type-check and focused tests.
- Fresh adversarial review found two blockers (implicit egress timestamp assumption; timestamptz sentinel); both are fixed in `a3b2882c`. Auto-merge remains off pending exact-head CI and delta review.