### PR TITLE
fix(web): unify hand-rolled asset->DTO mappers behind toGridAsset (sploot-049)

### DIFF
--- a/apps/web/__tests__/api/assets-detail.test.ts
+++ b/apps/web/__tests__/api/assets-detail.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  authenticatedUserId: 'qa-design-user',
+  findFirstAsset: vi.fn(),
+  transaction: vi.fn(),
+  clearCache: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/with-authenticated-api', () => ({
+  withAuthenticatedApi: (handler: any) => async (req: any, context: any = {}) => {
+    if (!mocks.authenticatedUserId) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return handler(req, context, {
+      principal: { userId: mocks.authenticatedUserId },
+      auth: { status: 'authenticated' },
+    });
+  },
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    asset: {
+      findFirst: mocks.findFirstAsset,
+    },
+    $transaction: mocks.transaction,
+  },
+}));
+
+vi.mock('@/lib/cache', () => ({
+  getCacheService: () => ({
+    clear: mocks.clearCache,
+  }),
+}));
+
+vi.mock('@/lib/with-observability', () => ({
+  withObservability: (handler: any) => handler,
+}));
+
+import { GET, PATCH } from '@/app/api/assets/[id]/route';
+
+function request(id: string, init?: RequestInit) {
+  return {
+    req: new NextRequest(`http://localhost:3000/api/assets/${id}`, init),
+    context: { params: Promise.resolve({ id }) },
+  };
+}
+
+const RAW_EMBEDDING_ROW = {
+  assetId: 'asset-1',
+  modelName: 'clip',
+  modelVersion: 'v1',
+  dim: 768,
+  status: 'ready',
+  // Internal fields a full Prisma `include: { embedding: true }` relation
+  // carries that must never reach the client DTO.
+  processingClaimToken: 'secret-claim-token',
+  error: null,
+  attemptCount: 0,
+  reviveCount: 0,
+  nextAttemptAt: null,
+  terminalAt: null,
+  completedAt: new Date('2026-07-01T00:00:00Z'),
+  createdAt: new Date('2026-07-01T00:00:00Z'),
+  updatedAt: new Date('2026-07-01T00:00:00Z'),
+};
+
+describe('GET /api/assets/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticatedUserId = 'qa-design-user';
+  });
+
+  it('returns thumbnailUrl and a sanitized embedding sub-object, never the raw Prisma relation', async () => {
+    mocks.findFirstAsset.mockResolvedValue({
+      id: 'asset-1',
+      blobUrl: 'https://blob/a.png',
+      thumbnailUrl: 'https://blob/thumb-a.png',
+      pathname: 'memes/a.png',
+      mime: 'image/png',
+      size: 1024,
+      width: 320,
+      height: 240,
+      favorite: true,
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+      updatedAt: new Date('2026-07-01T00:00:00Z'),
+      embedding: RAW_EMBEDDING_ROW,
+      tags: [{ tag: { id: 'tag-1', name: 'reaction' } }],
+    });
+
+    const { req, context } = request('asset-1');
+    const res = await GET(req, context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // sploot-049: the detail route hand-rolled its response and dropped
+    // thumbnailUrl entirely, the same field-drop bug 048 fixed elsewhere.
+    expect(body.asset.thumbnailUrl).toBe('https://blob/thumb-a.png');
+    expect(body.asset.tags).toEqual([{ id: 'tag-1', name: 'reaction' }]);
+    expect(body.asset.embedding).toEqual({
+      assetId: 'asset-1',
+      modelName: 'clip',
+      modelVersion: 'v1',
+      status: 'ready',
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+    });
+    expect(body.asset.embedding).not.toHaveProperty('processingClaimToken');
+    expect(body.asset.embedding).not.toHaveProperty('attemptCount');
+    expect(body.asset.embedding).not.toHaveProperty('dim');
+  });
+
+  it('returns 404 when the asset is not found', async () => {
+    mocks.findFirstAsset.mockResolvedValue(null);
+    const { req, context } = request('missing');
+    const res = await GET(req, context);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PATCH /api/assets/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticatedUserId = 'qa-design-user';
+  });
+
+  it('returns thumbnailUrl and a sanitized embedding sub-object after an update', async () => {
+    mocks.transaction.mockImplementation(async (fn: any) =>
+      fn({
+        $executeRaw: vi.fn().mockResolvedValue(undefined),
+        asset: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'asset-1' }),
+          update: vi.fn().mockResolvedValue({}),
+          findUnique: vi.fn().mockResolvedValue({
+            id: 'asset-1',
+            blobUrl: 'https://blob/a.png',
+            thumbnailUrl: 'https://blob/thumb-a.png',
+            pathname: 'memes/a.png',
+            mime: 'image/png',
+            size: 1024,
+            width: 320,
+            height: 240,
+            favorite: true,
+            createdAt: new Date('2026-07-01T00:00:00Z'),
+            updatedAt: new Date('2026-07-01T00:00:00Z'),
+            embedding: RAW_EMBEDDING_ROW,
+            tags: [{ tag: { id: 'tag-1', name: 'reaction' } }],
+          }),
+        },
+        assetTag: { deleteMany: vi.fn(), create: vi.fn() },
+        tag: { count: vi.fn().mockResolvedValue(0), findFirst: vi.fn(), create: vi.fn() },
+      }),
+    );
+
+    const { req, context } = request('asset-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ favorite: true }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await PATCH(req, context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.asset.thumbnailUrl).toBe('https://blob/thumb-a.png');
+    expect(body.asset.embedding).toEqual({
+      assetId: 'asset-1',
+      modelName: 'clip',
+      modelVersion: 'v1',
+      status: 'ready',
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+    });
+    expect(body.asset.embedding).not.toHaveProperty('processingClaimToken');
+  });
+});

--- a/apps/web/__tests__/api/assets.test.ts
+++ b/apps/web/__tests__/api/assets.test.ts
@@ -139,6 +139,11 @@ describe("GET /api/assets", () => {
     ]);
     // 048: the shuffle mapping must carry the stored thumbnail through to the grid.
     expect(body.assets[0].thumbnailUrl).toBe("https://blob.test/thumb-b.png");
+    // sploot-049: the shuffle raw SQL selects a."updatedAt", but the
+    // pre-canonicalization list response never surfaced it on any mode --
+    // it must not leak into the shuffle-only shape now.
+    expect(body.assets[0]).not.toHaveProperty("updatedAt");
+    expect(body.assets[1]).not.toHaveProperty("updatedAt");
     expect(body.pagination).toEqual({
       total: 2,
       limit: 2,
@@ -304,6 +309,10 @@ describe("GET /api/assets", () => {
         embeddingStatus: "ready",
       }),
     ]);
+    // sploot-049: the taste raw SQL also selects a."updatedAt" (needed for
+    // its own query, unrelated to the response shape) -- it must not leak
+    // into the taste-only response either, matching shuffle/normal.
+    expect(body.assets[0]).not.toHaveProperty("updatedAt");
     expect(body.pagination.total).toBe(1);
     expect(body.taste).toEqual({
       status: "ready",

--- a/apps/web/__tests__/api/search-advanced.test.ts
+++ b/apps/web/__tests__/api/search-advanced.test.ts
@@ -162,5 +162,21 @@ describe('POST /api/search/advanced', () => {
     expect(body.results[0].filename).toBe('b.png');
     expect(body.results[0].similarity).toBe(0);
     expect(body.results[0].relevance).toBe(0);
+
+    // sploot-049: the Prisma `where` clause must query the real `pathname`
+    // column -- `filename` does not exist on Asset (schema.prisma) and a
+    // permissive mock previously hid a real-runtime Prisma validation error
+    // on this exact fallback path.
+    expect(mocks.findManyAssets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          ownerUserId: 'qa-design-user',
+          deletedAt: null,
+          pathname: { contains: 'b', mode: 'insensitive' },
+        }),
+      }),
+    );
+    const [findManyArgs] = mocks.findManyAssets.mock.calls[0];
+    expect(findManyArgs.where).not.toHaveProperty('filename');
   });
 });

--- a/apps/web/__tests__/api/search-advanced.test.ts
+++ b/apps/web/__tests__/api/search-advanced.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  authenticatedUserId: 'qa-design-user',
+  createEmbeddingService: vi.fn(),
+  getSearchResults: vi.fn(),
+  setSearchResults: vi.fn(),
+  findManyAssetTags: vi.fn(),
+  findManyAssets: vi.fn(),
+  queryRaw: vi.fn(),
+  logSearch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/with-authenticated-api', () => ({
+  withAuthenticatedApi: (handler: any) => async (req: any, context: any = {}) => {
+    if (!mocks.authenticatedUserId) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return handler(req, context, {
+      principal: { userId: mocks.authenticatedUserId },
+      auth: { status: 'authenticated' },
+    });
+  },
+}));
+
+vi.mock('@/lib/embeddings', () => ({
+  createEmbeddingService: mocks.createEmbeddingService,
+  EmbeddingAdmissionError: class EmbeddingAdmissionError extends Error {
+    constructor(message: string, public statusCode?: number, public code?: string) {
+      super(message);
+    }
+  },
+  EmbeddingError: class EmbeddingError extends Error {
+    constructor(message: string, public statusCode?: number) {
+      super(message);
+    }
+  },
+}));
+
+vi.mock('@/lib/cache', () => ({
+  getCacheService: () => ({
+    getSearchResults: mocks.getSearchResults,
+    setSearchResults: mocks.setSearchResults,
+  }),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ id: 'qa-design-user' }),
+    },
+    asset: {
+      findMany: mocks.findManyAssets,
+    },
+    assetTag: {
+      findMany: mocks.findManyAssetTags,
+    },
+    $queryRaw: mocks.queryRaw,
+  },
+  logSearch: mocks.logSearch,
+}));
+
+vi.mock('@/lib/with-observability', () => ({
+  withObservability: (handler: any) => handler,
+}));
+
+import { POST as advancedSearch } from '@/app/api/search/advanced/route';
+
+function searchRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3001/api/search/advanced', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST /api/search/advanced', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticatedUserId = 'qa-design-user';
+    mocks.getSearchResults.mockResolvedValue(null);
+    mocks.setSearchResults.mockResolvedValue(undefined);
+    mocks.findManyAssetTags.mockResolvedValue([]);
+    mocks.logSearch.mockResolvedValue(undefined);
+    mocks.createEmbeddingService.mockReturnValue({
+      embedText: vi.fn().mockResolvedValue({ embedding: new Array(768).fill(0), model: 'test/clip:model' }),
+    });
+  });
+
+  it('selects thumbnail_url and derives filename from pathname instead of a non-existent column', async () => {
+    mocks.queryRaw.mockResolvedValue([
+      {
+        id: 'asset-1',
+        blob_url: 'https://blob/a.png',
+        thumbnail_url: 'https://blob/thumb-a.png',
+        pathname: 'memes/deep/a.png',
+        mime: 'image/png',
+        size: 1234,
+        width: 800,
+        height: 800,
+        favorite: false,
+        created_at: new Date('2026-07-01T00:00:00Z'),
+        updated_at: new Date('2026-07-01T00:00:00Z'),
+        similarity: 0.87,
+        total_count: BigInt(1),
+      },
+    ]);
+
+    const res = await advancedSearch(searchRequest({ query: 'reaction face meme' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.results).toHaveLength(1);
+    // sploot-049: the raw SQL previously selected a.filename, a column that
+    // does not exist on the assets table -- this always threw at runtime.
+    // toGridAsset derives the basename from pathname instead.
+    expect(body.results[0].filename).toBe('a.png');
+    // sploot-048/049: thumbnail_url must be selected and survive to the DTO.
+    expect(body.results[0].thumbnailUrl).toBe('https://blob/thumb-a.png');
+    expect(body.results[0].similarity).toBeCloseTo(0.87);
+    expect(body.results[0].relevance).toBe(87);
+
+    const [sqlObject] = mocks.queryRaw.mock.calls[0];
+    const sql = sqlObject.text;
+    expect(sql).toContain('a.thumbnail_url');
+    expect(sql).not.toContain('a.filename');
+  });
+
+  it('falls back to metadata search with thumbnailUrl and a derived filename when the embedding service is unconfigured', async () => {
+    mocks.createEmbeddingService.mockImplementation(() => {
+      throw new Error('Replicate API token not configured');
+    });
+    mocks.findManyAssets.mockResolvedValue([
+      {
+        id: 'asset-2',
+        blobUrl: 'https://blob/b.png',
+        thumbnailUrl: 'https://blob/thumb-b.png',
+        pathname: 'memes/deep/b.png',
+        mime: 'image/png',
+        size: 2048,
+        width: 640,
+        height: 480,
+        favorite: true,
+        createdAt: new Date('2026-07-01T00:00:00Z'),
+        updatedAt: new Date('2026-07-01T00:00:00Z'),
+        tags: [],
+      },
+    ]);
+
+    const res = await advancedSearch(searchRequest({ query: 'b' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.searchType).toBe('metadata');
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].thumbnailUrl).toBe('https://blob/thumb-b.png');
+    expect(body.results[0].filename).toBe('b.png');
+    expect(body.results[0].similarity).toBe(0);
+    expect(body.results[0].relevance).toBe(0);
+  });
+});

--- a/apps/web/__tests__/lib/asset-dto.test.ts
+++ b/apps/web/__tests__/lib/asset-dto.test.ts
@@ -106,11 +106,13 @@ describe('toGridAsset', () => {
     expect(asset.relevance).toBe(1);
     expect(asset.embeddingStatus).toBe('ready');
     // Vector-search rows are always matched via an inner join on
-    // asset_embeddings, so a ready embedding is always present.
+    // asset_embeddings, so a ready embedding is always present -- but the
+    // row never selects the embedding's own model/timestamp columns, so
+    // toGridAsset must not fabricate them (sploot-049 Cerberus correction:
+    // a fake empty modelName + the asset's own createdAt reused as the
+    // embedding's createdAt is a lie, not a truthful assetId-only shape).
     expect(asset.embedding).toEqual({
       assetId: 'asset-3',
-      modelName: '',
-      createdAt: new Date('2026-07-01T00:00:00Z'),
     });
   });
 

--- a/apps/web/__tests__/lib/asset-dto.test.ts
+++ b/apps/web/__tests__/lib/asset-dto.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import { mapAssetTags, toGridAsset } from '@/lib/asset-dto';
+
+describe('toGridAsset', () => {
+  it('normalizes a camelCase Prisma select row (GET /api/assets normal-list path)', () => {
+    const asset = toGridAsset({
+      id: 'asset-1',
+      blobUrl: 'https://blob/a.png',
+      thumbnailUrl: 'https://blob/thumb-a.png',
+      pathname: 'memes/a.png',
+      filename: 'memes/a.png',
+      mime: 'image/png',
+      size: 1024,
+      width: 320,
+      height: 240,
+      favorite: true,
+      createdAt: new Date('2026-05-14T12:00:00.000Z'),
+      embedding: {
+        status: 'ready',
+        modelName: 'clip',
+        modelVersion: 'v1',
+        createdAt: new Date('2026-05-14T12:00:00.000Z'),
+      },
+    });
+
+    // sploot-048: thumbnailUrl must survive every read path.
+    expect(asset.thumbnailUrl).toBe('https://blob/thumb-a.png');
+    expect(asset.embedding).toEqual({
+      assetId: 'asset-1',
+      modelName: 'clip',
+      modelVersion: 'v1',
+      status: 'ready',
+      createdAt: new Date('2026-05-14T12:00:00.000Z'),
+    });
+    expect(asset.embeddingStatus).toBe('ready');
+  });
+
+  it('normalizes the flat raw-SQL shuffle/taste row shape and omits embedding when absent', () => {
+    const asset = toGridAsset({
+      id: 'asset-2',
+      blobUrl: 'https://blob/b.png',
+      thumbnailUrl: null,
+      pathname: 'memes/b.png',
+      filename: 'memes/b.png',
+      mime: 'image/png',
+      size: 2048,
+      width: 640,
+      height: 480,
+      favorite: false,
+      createdAt: new Date('2026-05-15T12:00:00.000Z'),
+      updatedAt: new Date('2026-05-15T12:00:00.000Z'),
+      embeddingId: null,
+      embeddingModelName: null,
+      embeddingModelVersion: null,
+      embeddingStatus: null,
+      embeddingCreatedAt: null,
+    });
+
+    expect(asset.thumbnailUrl).toBeNull();
+    expect(asset.embedding).toBeUndefined();
+    expect(asset.embeddingStatus).toBeUndefined();
+  });
+
+  it('rounds tasteScore to 3 decimals like the taste-ranked read path', () => {
+    const asset = toGridAsset({
+      id: 'asset-near',
+      blobUrl: 'https://blob/near.png',
+      pathname: 'memes/near.png',
+      mime: 'image/png',
+      size: 2048,
+      width: 640,
+      height: 480,
+      favorite: false,
+      createdAt: new Date('2026-05-15T12:00:00.000Z'),
+      tasteScore: 0.8764,
+      embeddingId: 'asset-near',
+      embeddingModelName: 'clip',
+      embeddingModelVersion: 'v1',
+      embeddingStatus: 'ready',
+      embeddingCreatedAt: new Date('2026-05-15T12:00:00.000Z'),
+    });
+
+    expect(asset.tasteScore).toBe(0.876);
+    expect(asset.embeddingStatus).toBe('ready');
+  });
+
+  it('normalizes a snake_case vectorSearch row, deriving filename and relevance from distance', () => {
+    const asset = toGridAsset({
+      id: 'asset-3',
+      blob_url: 'https://blob/c.png',
+      thumbnail_url: null,
+      pathname: 'pile/deeply/nested/c.png',
+      mime: 'image/png',
+      size: 512,
+      width: 100,
+      height: 100,
+      favorite: false,
+      created_at: new Date('2026-07-01T00:00:00Z'),
+      distance: 0.01,
+    });
+
+    // sploot-049: search/similar rows never carried a filename column;
+    // toGridAsset derives the basename so every path agrees on the shape.
+    expect(asset.filename).toBe('c.png');
+    expect(asset.similarity).toBeCloseTo(0.01);
+    expect(asset.relevance).toBe(1);
+    expect(asset.embeddingStatus).toBe('ready');
+    // Vector-search rows are always matched via an inner join on
+    // asset_embeddings, so a ready embedding is always present.
+    expect(asset.embedding).toEqual({
+      assetId: 'asset-3',
+      modelName: '',
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+    });
+  });
+
+  it('prefers an explicit similarity field over distance (advanced-search raw SQL row)', () => {
+    const asset = toGridAsset({
+      id: 'asset-4',
+      blob_url: 'https://blob/d.png',
+      thumbnail_url: 'https://blob/thumb-d.png',
+      pathname: 'memes/d.png',
+      mime: 'image/png',
+      size: 512,
+      width: 100,
+      height: 100,
+      favorite: false,
+      created_at: new Date('2026-07-01T00:00:00Z'),
+      updated_at: new Date('2026-07-02T00:00:00Z'),
+      similarity: 0.42,
+    });
+
+    // sploot-049: the advanced-search SQL never selected thumbnail_url; a
+    // real per-path field drop of the exact 048 shape.
+    expect(asset.thumbnailUrl).toBe('https://blob/thumb-d.png');
+    expect(asset.similarity).toBeCloseTo(0.42);
+    expect(asset.relevance).toBe(42);
+    expect(asset.updatedAt).toEqual(new Date('2026-07-02T00:00:00Z'));
+  });
+
+  it('applies extensions.similarity for a metadata-only fallback row with no vector score', () => {
+    const asset = toGridAsset(
+      {
+        id: 'asset-5',
+        blobUrl: 'https://blob/e.png',
+        thumbnailUrl: null,
+        pathname: 'memes/e.png',
+        mime: 'image/png',
+        size: 100,
+        width: 10,
+        height: 10,
+        favorite: false,
+        createdAt: new Date('2026-07-01T00:00:00Z'),
+      },
+      { similarity: 0, relevance: 0 },
+    );
+
+    expect(asset.similarity).toBe(0);
+    expect(asset.relevance).toBe(0);
+  });
+
+  it('sanitizes the embedding sub-object to the public shape, never leaking internal Prisma fields', () => {
+    const asset = toGridAsset({
+      id: 'asset-6',
+      blobUrl: 'https://blob/f.png',
+      pathname: 'memes/f.png',
+      mime: 'image/png',
+      size: 100,
+      width: 10,
+      height: 10,
+      favorite: false,
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+      embedding: {
+        status: 'failed',
+        modelName: 'clip',
+        modelVersion: 'v1',
+        createdAt: new Date('2026-07-01T00:00:00Z'),
+        // Extra internal fields a full Prisma embedding relation carries
+        // (processingClaimToken, attemptCount, error, ...) must never reach
+        // toGridAsset's output even if the caller forwards the raw row.
+        ...({ processingClaimToken: 'secret-token', attemptCount: 3, error: 'boom' } as any),
+      },
+    });
+
+    expect(asset.embedding).toEqual({
+      assetId: 'asset-6',
+      modelName: 'clip',
+      modelVersion: 'v1',
+      status: 'failed',
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+    });
+    expect(asset.embedding).not.toHaveProperty('processingClaimToken');
+    expect(asset.embedding).not.toHaveProperty('attemptCount');
+    expect(asset.embedding).not.toHaveProperty('error');
+  });
+
+  it('applies tags and belowThreshold extensions uniformly', () => {
+    const asset = toGridAsset(
+      {
+        id: 'asset-7',
+        blob_url: 'https://blob/g.png',
+        pathname: 'memes/g.png',
+        mime: 'image/png',
+        size: 100,
+        width: 10,
+        height: 10,
+        favorite: false,
+        created_at: new Date('2026-07-01T00:00:00Z'),
+        distance: 0.2,
+      },
+      { tags: [{ id: 'tag-1', name: 'reaction' }], belowThreshold: false },
+    );
+
+    expect(asset.tags).toEqual([{ id: 'tag-1', name: 'reaction' }]);
+    expect(asset.belowThreshold).toBe(false);
+  });
+});
+
+describe('mapAssetTags', () => {
+  it('maps { tag: { id, name } } join rows to the flat AssetTag DTO', () => {
+    const tags = mapAssetTags([
+      { tag: { id: 'tag-1', name: 'reaction' } },
+      { tag: { id: 'tag-2', name: 'og' } },
+    ]);
+
+    expect(tags).toEqual([
+      { id: 'tag-1', name: 'reaction' },
+      { id: 'tag-2', name: 'og' },
+    ]);
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(mapAssetTags([])).toEqual([]);
+  });
+});

--- a/apps/web/app/api/assets/[id]/route.ts
+++ b/apps/web/app/api/assets/[id]/route.ts
@@ -3,6 +3,7 @@ import { TAG, isValidAssetId, isValidTagName } from '@sploot/common';
 import { unstable_rethrow } from 'next/navigation';
 import { getCacheService } from '@/lib/cache';
 import { prisma } from '@/lib/db';
+import { toGridAsset, mapAssetTags } from '@/lib/asset-dto';
 import { invalidateSlugCache } from '@/lib/slug-cache';
 import { enqueueAssetReplicaCleanup, markReplicaCleanupDone } from '@/lib/storage/permanent-delete';
 import { withObservability } from '@/lib/with-observability';
@@ -62,24 +63,10 @@ async function getHandler(
     }
 
     return NextResponse.json({
-      asset: {
-        id: asset.id,
-        blobUrl: asset.blobUrl,
-        pathname: asset.pathname,
-        filename: asset.pathname,
-        mime: asset.mime,
-        size: asset.size,
-        width: asset.width,
-        height: asset.height,
-        favorite: asset.favorite,
-        createdAt: asset.createdAt,
-        updatedAt: asset.updatedAt,
-        embedding: asset.embedding,
-        tags: asset.tags.map((at: any) => ({
-          id: at.tag.id,
-          name: at.tag.name,
-        })),
-      },
+      asset: toGridAsset(
+        { ...asset, filename: asset.pathname },
+        { tags: mapAssetTags(asset.tags) },
+      ),
     });
   } catch (error) {
     unstable_rethrow(error);
@@ -168,24 +155,10 @@ async function patchHandler(
     }
 
     return NextResponse.json({
-      asset: {
-        id: updatedAssetRow.id,
-        blobUrl: updatedAssetRow.blobUrl,
-        pathname: updatedAssetRow.pathname,
-        filename: updatedAssetRow.pathname,
-        mime: updatedAssetRow.mime,
-        size: updatedAssetRow.size,
-        width: updatedAssetRow.width,
-        height: updatedAssetRow.height,
-        favorite: updatedAssetRow.favorite,
-        createdAt: updatedAssetRow.createdAt,
-        updatedAt: updatedAssetRow.updatedAt,
-        embedding: updatedAssetRow.embedding,
-        tags: updatedAssetRow.tags.map((at: any) => ({
-          id: at.tag.id,
-          name: at.tag.name,
-        })),
-      },
+      asset: toGridAsset(
+        { ...updatedAssetRow, filename: updatedAssetRow.pathname },
+        { tags: mapAssetTags(updatedAssetRow.tags) },
+      ),
       message: 'Asset updated successfully',
     });
   } catch (error) {

--- a/apps/web/app/api/assets/[id]/similar/route.ts
+++ b/apps/web/app/api/assets/[id]/similar/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { unstable_rethrow } from 'next/navigation';
 import { prisma, vectorSearch, type VectorSearchRow } from '@/lib/db';
+import { toGridAsset } from '@/lib/asset-dto';
 import { withObservability } from '@/lib/with-observability';
 import { withAuthenticatedApi } from '@/lib/auth/with-authenticated-api';
 import type { AuthenticatedApiContext } from '@/lib/auth/with-authenticated-api';
@@ -80,23 +81,7 @@ async function getHandler(
       })
       .slice(0, limit);
 
-    const formattedResults = filtered.map((result: VectorSearchRow) => ({
-      id: result.id,
-      blobUrl: result.blob_url,
-      thumbnailUrl: result.thumbnail_url,
-      pathname: result.pathname,
-      filename: result.pathname.split('/').pop() || result.pathname,
-      mime: result.mime,
-      width: result.width,
-      height: result.height,
-      favorite: result.favorite,
-      size: result.size,
-      createdAt: result.created_at,
-      embedding: { assetId: result.id },
-      embeddingStatus: 'ready' as const,
-      similarity: result.distance,
-      relevance: Math.round(result.distance * 100),
-    }));
+    const formattedResults = filtered.map((result: VectorSearchRow) => toGridAsset(result));
 
     // Source is embedded but the library has nothing else near it. Distinct
     // from source-unembedded so the client can explain why the grid is empty.

--- a/apps/web/app/api/assets/route.ts
+++ b/apps/web/app/api/assets/route.ts
@@ -122,6 +122,16 @@ type AssetSelectRow = {
 
 type FormattableAssetRow = AssetListRow | TasteAssetRow | AssetSelectRow;
 
+// The shuffle and taste raw-SQL rows select the asset's own `updatedAt`
+// (needed by their ORDER BY/joins), but the pre-canonicalization list
+// response never surfaced it on any mode (see git history pre-sploot-049).
+// Strip it so normal/shuffle/taste stay on one response shape instead of
+// leaking a mode-dependent field. See sploot-049.
+function stripUpdatedAt<T extends { id: string; updatedAt?: Date }>(row: T): Omit<T, "updatedAt"> {
+  const { updatedAt: _updatedAt, ...rest } = row;
+  return rest;
+}
+
 type ShuffleQueryOptions = {
   userId: string;
   favorite: string | null;
@@ -487,7 +497,7 @@ async function getHandler(req: NextRequest) {
 
     const formattedAssets: Asset[] = assets.map((asset) =>
       toGridAsset(
-        { ...asset, filename: asset.pathname },
+        { ...stripUpdatedAt(asset), filename: asset.pathname },
         includeTags ? { tags: tagsByAssetId[asset.id] || [] } : {},
       ),
     );

--- a/apps/web/app/api/assets/route.ts
+++ b/apps/web/app/api/assets/route.ts
@@ -35,7 +35,10 @@ import {
 import {
   getTasteWeightedAssets,
   MIN_TASTE_BANGER_EMBEDDINGS,
+  type TasteAssetRow,
 } from "@/lib/taste/taste-engine";
+import { toGridAsset, mapAssetTags } from "@/lib/asset-dto";
+import type { Asset, AssetTag } from "@/lib/types";
 import {
   assertEnrolledUser,
   enrollmentDeniedResponse,
@@ -96,6 +99,28 @@ type AssetListRow = {
   embeddingStatus: string | null;
   embeddingCreatedAt: Date | null;
 };
+
+type AssetSelectRow = {
+  id: string;
+  blobUrl: string;
+  thumbnailUrl: string | null;
+  pathname: string;
+  mime: string;
+  width: number | null;
+  height: number | null;
+  favorite: boolean;
+  size: number;
+  createdAt: Date;
+  embedding: {
+    status: string | null;
+    modelName: string;
+    modelVersion: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+};
+
+type FormattableAssetRow = AssetListRow | TasteAssetRow | AssetSelectRow;
 
 type ShuffleQueryOptions = {
   userId: string;
@@ -396,7 +421,7 @@ async function getHandler(req: NextRequest) {
         })
       : null;
 
-    const [assets, total] = tasteResult
+    const [assets, total] = (tasteResult
       ? [tasteResult.assets, tasteResult.total]
       : await Promise.all([
           shuffleSeed !== undefined
@@ -437,12 +462,12 @@ async function getHandler(req: NextRequest) {
                 },
               }),
           prisma.asset.count({ where }),
-        ]);
+        ])) as [FormattableAssetRow[], number];
 
-    let tagsByAssetId: Record<string, Array<{ id: string; name: string }>> = {};
+    let tagsByAssetId: Record<string, AssetTag[]> = {};
 
     if (includeTags && assets.length > 0) {
-      const assetIds = assets.map((asset: any) => asset.id);
+      const assetIds = assets.map((asset) => asset.id);
       const tagRows = await prisma!.assetTag.findMany({
         where: { assetId: { in: assetIds } },
         select: {
@@ -451,49 +476,21 @@ async function getHandler(req: NextRequest) {
         },
       });
 
-      tagsByAssetId = tagRows.reduce(
-        (acc: Record<string, Array<{ id: string; name: string }>>, row) => {
-          if (!acc[row.assetId]) acc[row.assetId] = [];
-          acc[row.assetId].push({ id: row.tag.id, name: row.tag.name });
-          return acc;
-        },
-        {},
+      const rowsByAssetId: Record<string, Array<{ tag: { id: string; name: string } }>> = {};
+      for (const row of tagRows) {
+        (rowsByAssetId[row.assetId] ??= []).push(row);
+      }
+      tagsByAssetId = Object.fromEntries(
+        Object.entries(rowsByAssetId).map(([assetId, rows]) => [assetId, mapAssetTags(rows)]),
       );
     }
 
-    const formattedAssets = assets.map((asset: any) => ({
-      id: asset.id,
-      blobUrl: asset.blobUrl,
-      thumbnailUrl: asset.thumbnailUrl ?? null,
-      pathname: asset.pathname,
-      filename: asset.pathname,
-      mime: asset.mime,
-      size: asset.size,
-      width: asset.width,
-      height: asset.height,
-      favorite: asset.favorite,
-      createdAt: asset.createdAt,
-      // Format embedding data for both shuffle and normal queries without vector payload
-      embedding:
-        asset.embedding ||
-        (asset.embeddingId
-          ? {
-              assetId: asset.embeddingId,
-              modelName: asset.embeddingModelName,
-              modelVersion: asset.embeddingModelVersion,
-              createdAt: asset.embeddingCreatedAt,
-            }
-          : undefined),
-      embeddingStatus: asset.embeddingStatus || asset.embedding?.status,
-      ...(typeof asset.tasteScore === "number"
-        ? { tasteScore: Number(asset.tasteScore.toFixed(3)) }
-        : {}),
-      ...(includeTags
-        ? {
-            tags: tagsByAssetId[asset.id] || [],
-          }
-        : {}),
-    }));
+    const formattedAssets: Asset[] = assets.map((asset) =>
+      toGridAsset(
+        { ...asset, filename: asset.pathname },
+        includeTags ? { tags: tagsByAssetId[asset.id] || [] } : {},
+      ),
+    );
 
     // Drift detector: zero assets for known user hints at wrong DB branch
     if (total === 0 && !isTaste) {

--- a/apps/web/app/api/search/advanced/route.ts
+++ b/apps/web/app/api/search/advanced/route.ts
@@ -377,7 +377,10 @@ async function performMetadataSearch(
   const where: any = {
     ownerUserId: userId,
     deletedAt: null,
-    filename: {
+    // The assets table has no `filename` column (only `pathname`); querying
+    // a nonexistent Prisma field throws on every call to this fallback. See
+    // sploot-049.
+    pathname: {
       contains: query,
       mode: 'insensitive',
     },

--- a/apps/web/app/api/search/advanced/route.ts
+++ b/apps/web/app/api/search/advanced/route.ts
@@ -11,6 +11,7 @@ import {
   reportEmbeddingConfigurationErrorOnce,
 } from '@/lib/embedding-errors';
 import { getCacheService } from '@/lib/cache';
+import { toGridAsset, mapAssetTags } from '@/lib/asset-dto';
 import { withObservability } from '@/lib/with-observability';
 import { withAuthenticatedApi } from '@/lib/auth/with-authenticated-api';
 import type { AuthenticatedApiContext } from '@/lib/auth/with-authenticated-api';
@@ -190,11 +191,15 @@ async function postHandler(req: NextRequest, _context: unknown, { principal }: A
 
     // Execute parameterized search query
     // Using Prisma.sql template literal for safe parameterization
+    // Note: the assets table has no `filename` column (only `pathname`);
+    // toGridAsset() derives the client-facing filename from pathname's
+    // basename. thumbnail_url must be selected explicitly so the grid can
+    // render it directly instead of falling back to the full original.
     const results = await prisma!.$queryRaw<Array<{
       id: string;
       blob_url: string;
+      thumbnail_url: string | null;
       pathname: string;
-      filename: string;
       mime: string;
       size: number;
       width: number | null;
@@ -208,8 +213,8 @@ async function postHandler(req: NextRequest, _context: unknown, { principal }: A
       SELECT
         a.id,
         a.blob_url,
+        a.thumbnail_url,
         a.pathname,
-        a.filename,
         a.mime,
         a.size,
         a.width,
@@ -265,32 +270,19 @@ async function postHandler(req: NextRequest, _context: unknown, { principal }: A
     });
 
     // Group tags by asset
-    const tagsByAsset = allTags.reduce((acc: any, at: any) => {
-      if (!acc[at.assetId]) acc[at.assetId] = [];
-      acc[at.assetId].push({
-        id: at.tag.id,
-        name: at.tag.name,
-      });
-      return acc;
-    }, {} as Record<string, Array<{ id: string; name: string }>>);
+    const tagsByAsset: Record<string, ReturnType<typeof mapAssetTags>> = {};
+    const rowsByAsset: Record<string, Array<{ tag: { id: string; name: string } }>> = {};
+    for (const at of allTags) {
+      (rowsByAsset[at.assetId] ??= []).push(at);
+    }
+    for (const [assetId, rows] of Object.entries(rowsByAsset)) {
+      tagsByAsset[assetId] = mapAssetTags(rows);
+    }
 
     // Format results
-    const formattedResults = filteredResults.map((result: any) => ({
-      id: result.id,
-      blobUrl: result.blob_url,
-      pathname: result.pathname,
-      filename: result.filename,
-      mime: result.mime,
-      size: result.size,
-      width: result.width,
-      height: result.height,
-      favorite: result.favorite,
-      createdAt: result.created_at,
-      updatedAt: result.updated_at,
-      similarity: result.similarity,
-      relevance: Math.round(result.similarity * 100),
-      tags: tagsByAsset[result.id] || [],
-    }));
+    const formattedResults = filteredResults.map((result) =>
+      toGridAsset(result, { tags: tagsByAsset[result.id] || [] }),
+    );
 
     const queryTime = Date.now() - startTime;
     const totalCount = results.length > 0 ? Number(results[0].total_count) : 0;
@@ -431,25 +423,9 @@ async function performMetadataSearch(
     },
   });
 
-  return assets.map((asset: any) => ({
-    id: asset.id,
-    blobUrl: asset.blobUrl,
-    pathname: asset.pathname,
-    filename: asset.filename,
-    mime: asset.mime,
-    size: asset.size,
-    width: asset.width,
-    height: asset.height,
-    favorite: asset.favorite,
-    createdAt: asset.createdAt,
-    updatedAt: asset.updatedAt,
-    similarity: 0,
-    relevance: 0,
-    tags: asset.tags.map((at: any) => ({
-      id: at.tag.id,
-      name: at.tag.name,
-    })),
-  }));
+  return assets.map((asset) =>
+    toGridAsset(asset, { tags: mapAssetTags(asset.tags), similarity: 0, relevance: 0 }),
+  );
 }
 
 // Helper to validate ISO 8601 date strings

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { unstable_rethrow } from 'next/navigation';
 import { prisma, vectorSearch, logSearch, type VectorSearchRow } from '@/lib/db';
+import { toGridAsset, mapAssetTags } from '@/lib/asset-dto';
 import { CLIP_MODEL, createEmbeddingService, EmbeddingAdmissionError, EmbeddingError } from '@/lib/embeddings';
 import {
   EmbeddingConfigurationError,
@@ -138,29 +139,10 @@ const postHandler = withAuthenticatedApi(async (req: NextRequest, _context, { pr
           include: { tag: true },
         });
 
-        return {
-          id: result.id,
-          blobUrl: result.blob_url,
-          thumbnailUrl: result.thumbnail_url ?? null,
-          pathname: result.pathname,
-          filename: result.pathname.split('/').pop() || result.pathname,
-          mime: result.mime,
-          width: result.width,
-          height: result.height,
-          favorite: result.favorite,
-          size: result.size,
-          createdAt: result.created_at,
-          // Indicate embeddings exist (search results always have embeddings)
-          embedding: { assetId: result.id },
-          embeddingStatus: 'ready' as const,
-          similarity: result.distance, // 0-1 score, higher is better
-          relevance: Math.round(result.distance * 100), // Percentage for UI
+        return toGridAsset(result, {
+          tags: mapAssetTags(assetTags),
           belowThreshold: false,
-          tags: assetTags.map((at: any) => ({
-            id: at.tag.id,
-            name: at.tag.name,
-          })),
-        };
+        });
       })
     );
 

--- a/apps/web/lib/asset-dto.ts
+++ b/apps/web/lib/asset-dto.ts
@@ -1,0 +1,165 @@
+import type { Asset, AssetTag, EmbeddingStatus } from '@/lib/types';
+
+/**
+ * Canonical mapper for the grid/client asset DTO (`Asset`).
+ *
+ * Every read path that returns an asset to the client -- list / shuffle /
+ * taste (`GET /api/assets`), semantic search (`POST /api/search`,
+ * `POST /api/search/advanced`), similarity (`GET /api/assets/:id/similar`),
+ * and asset detail (`GET`/`PATCH /api/assets/:id`) -- normalizes its row
+ * shape through `toGridAsset` so a field can't be silently dropped (or
+ * over-exposed) on just one surface again. See sploot-048 / sploot-049.
+ */
+
+/**
+ * Prisma-shaped rows: `prisma.asset.findMany`/`findFirst` selects, and the
+ * camelCase raw-SQL rows used by the shuffle and taste-ranked queries.
+ */
+export interface CamelCaseAssetRow {
+  id: string;
+  blobUrl: string;
+  thumbnailUrl?: string | null;
+  pathname: string;
+  /** Pass the caller's existing filename convention through explicitly;
+   * omit to fall back to the pathname's basename. */
+  filename?: string | null;
+  mime: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  favorite: boolean;
+  createdAt: Date | string;
+  updatedAt?: Date | string | null;
+  tasteScore?: number;
+  /** Prisma relation shape (`select: { embedding: { select: {...} } }`). */
+  embedding?: {
+    modelName?: string | null;
+    modelVersion?: string | null;
+    status?: string | null;
+    createdAt?: Date | string | null;
+  } | null;
+  /** Flat raw-SQL shape (shuffle / taste queries join `asset_embeddings` directly). */
+  embeddingId?: string | null;
+  embeddingModelName?: string | null;
+  embeddingModelVersion?: string | null;
+  embeddingStatus?: string | null;
+  embeddingCreatedAt?: Date | string | null;
+}
+
+/** Raw pgvector search rows (`vectorSearch`, and the advanced-search SQL). */
+export interface SnakeCaseAssetRow {
+  id: string;
+  blob_url: string;
+  thumbnail_url?: string | null;
+  pathname: string;
+  filename?: string | null;
+  mime: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  favorite: boolean;
+  created_at: Date | string;
+  updated_at?: Date | string | null;
+  /** `vectorSearch` names this `distance`; the advanced-search raw SQL names
+   * the identical 0-1 cosine-similarity score `similarity`. */
+  distance?: number;
+  similarity?: number;
+}
+
+export type GridAssetRow = CamelCaseAssetRow | SnakeCaseAssetRow;
+
+export interface GridAssetExtensions {
+  tags?: AssetTag[];
+  /** Explicit similarity score (0-1). For snake_case rows this defaults to
+   * the row's own `similarity`/`distance` field when omitted. */
+  similarity?: number;
+  /** Override the derived `Math.round(similarity * 100)` relevance percentage. */
+  relevance?: number;
+  belowThreshold?: boolean;
+}
+
+function isSnakeCaseRow(row: GridAssetRow): row is SnakeCaseAssetRow {
+  return 'blob_url' in row;
+}
+
+function deriveFilename(pathname: string, filename?: string | null): string {
+  return filename || pathname.split('/').pop() || pathname;
+}
+
+/** Shared `{ id, name }` tag mapper, deduplicating the identical inline
+ * `.map((at) => ({ id: at.tag.id, name: at.tag.name }))` repeated across every
+ * asset read path that embeds an asset's tags. */
+export function mapAssetTags(rows: Array<{ tag: { id: string; name: string } }>): AssetTag[] {
+  return rows.map((row) => ({ id: row.tag.id, name: row.tag.name }));
+}
+
+function baseFromSnakeCase(row: SnakeCaseAssetRow): Asset {
+  return {
+    id: row.id,
+    blobUrl: row.blob_url,
+    thumbnailUrl: row.thumbnail_url ?? null,
+    pathname: row.pathname,
+    filename: deriveFilename(row.pathname, row.filename),
+    mime: row.mime,
+    size: row.size,
+    width: row.width,
+    height: row.height,
+    favorite: row.favorite,
+    createdAt: row.created_at,
+    ...(row.updated_at ? { updatedAt: row.updated_at } : {}),
+    // Vector-search rows are matched via an inner join on asset_embeddings,
+    // so a returned row always has a ready embedding.
+    embedding: { assetId: row.id, modelName: '', createdAt: row.created_at },
+    embeddingStatus: 'ready',
+  };
+}
+
+function baseFromCamelCase(row: CamelCaseAssetRow): Asset {
+  const embeddingStatus = row.embedding?.status ?? row.embeddingStatus ?? undefined;
+  const embeddingModelName = row.embedding?.modelName ?? row.embeddingModelName ?? undefined;
+  const embeddingModelVersion = row.embedding?.modelVersion ?? row.embeddingModelVersion ?? undefined;
+  const embeddingCreatedAt = row.embedding?.createdAt ?? row.embeddingCreatedAt ?? undefined;
+  const hasEmbedding = Boolean(row.embedding || row.embeddingId || embeddingStatus);
+
+  return {
+    id: row.id,
+    blobUrl: row.blobUrl,
+    thumbnailUrl: row.thumbnailUrl ?? null,
+    pathname: row.pathname,
+    filename: deriveFilename(row.pathname, row.filename),
+    mime: row.mime,
+    size: row.size,
+    width: row.width,
+    height: row.height,
+    favorite: row.favorite,
+    createdAt: row.createdAt,
+    ...(row.updatedAt ? { updatedAt: row.updatedAt } : {}),
+    ...(hasEmbedding
+      ? {
+          embedding: {
+            assetId: row.id,
+            modelName: embeddingModelName ?? '',
+            ...(embeddingModelVersion ? { modelVersion: embeddingModelVersion } : {}),
+            status: embeddingStatus ?? null,
+            createdAt: embeddingCreatedAt ?? row.createdAt,
+          },
+        }
+      : {}),
+    ...(embeddingStatus ? { embeddingStatus: embeddingStatus as EmbeddingStatus } : {}),
+    ...(typeof row.tasteScore === 'number' ? { tasteScore: Number(row.tasteScore.toFixed(3)) } : {}),
+  };
+}
+
+export function toGridAsset(row: GridAssetRow, extensions: GridAssetExtensions = {}): Asset {
+  const base = isSnakeCaseRow(row) ? baseFromSnakeCase(row) : baseFromCamelCase(row);
+  const similarity = extensions.similarity ?? (isSnakeCaseRow(row) ? row.similarity ?? row.distance : undefined);
+
+  return {
+    ...base,
+    ...(extensions.tags ? { tags: extensions.tags } : {}),
+    ...(typeof similarity === 'number'
+      ? { similarity, relevance: extensions.relevance ?? Math.round(similarity * 100) }
+      : {}),
+    ...(extensions.belowThreshold !== undefined ? { belowThreshold: extensions.belowThreshold } : {}),
+  };
+}

--- a/apps/web/lib/asset-dto.ts
+++ b/apps/web/lib/asset-dto.ts
@@ -108,8 +108,11 @@ function baseFromSnakeCase(row: SnakeCaseAssetRow): Asset {
     createdAt: row.created_at,
     ...(row.updated_at ? { updatedAt: row.updated_at } : {}),
     // Vector-search rows are matched via an inner join on asset_embeddings,
-    // so a returned row always has a ready embedding.
-    embedding: { assetId: row.id, modelName: '', createdAt: row.created_at },
+    // so a returned row always has a ready embedding -- but the row itself
+    // never selects the embedding's own model/timestamp columns, so this
+    // must stay assetId-only rather than fabricating a fake model name or
+    // reusing the asset's createdAt as the embedding's. See sploot-049.
+    embedding: { assetId: row.id },
     embeddingStatus: 'ready',
   };
 }

--- a/apps/web/lib/types/index.ts
+++ b/apps/web/lib/types/index.ts
@@ -14,12 +14,16 @@ export type EmbeddingStatus = 'pending' | 'processing' | 'ready' | 'failed';
 
 export interface AssetEmbedding {
   assetId: string;
-  modelName: string;
+  // Optional: snake-case pgvector rows (search/similar) only ever confirm
+  // that a matching embedding exists via the inner join -- they never carry
+  // the embedding's own model/timestamp metadata, so those fields must stay
+  // optional rather than being fabricated. See sploot-049.
+  modelName?: string;
   modelVersion?: string;
   // pending | processing | ready | failed — the API returns the full row,
   // so a present embedding is NOT necessarily a ready one.
   status?: string | null;
-  createdAt: Date | string;
+  createdAt?: Date | string;
 }
 
 export interface AssetTag {


### PR DESCRIPTION
## Summary

Sploot card `sploot-049`: unify the six hand-rolled asset-to-grid DTO mappers behind one typed `toGridAsset()` contract.

## Callsites migrated

- `GET /api/assets` (normal, shuffle, taste)
- `GET /api/assets/:id/similar`
- `POST /api/search`
- `POST /api/search/advanced` (vector SQL and metadata fallback)
- `GET` / `PATCH /api/assets/:id`

## Bugs fixed

- Advanced vector search no longer selects nonexistent `a.filename`; it selects `thumbnail_url` and derives filename from `pathname`.
- Advanced metadata fallback filters Prisma `pathname`, not nonexistent `filename`; regression test asserts exact query args.
- Detail GET/PATCH restores `thumbnailUrl` and sanitizes internal embedding state.
- Raw pgvector rows no longer fabricate embedding `modelName` or reuse asset `createdAt` as embedding metadata; they truthfully return `{assetId}`.
- Normal/shuffle/taste asset list modes consistently omit internal `updatedAt`.

## Verification

- Focused mapper/API suite: 6 files, 33 tests passed.
- Exact head `2b71e88c9f06aeaa89c0ae8da5950670c09d672f`: GitHub CI all 16 jobs green, including Type Check, web tests, pg15/pg16 restricted DB authority, browser seams, production build, and merge-gate (run 29612689873).
- Fresh adversarial exact-head review: PASS. No high-confidence blockers; every migrated response mode and fallback field was inspected.

Powder: `sploot-049`.