### PR TITLE
fix(storage): reimplement lost portability repair patch (sploot-blob-portability)

### DIFF
--- a/apps/web/__tests__/api/assets-permanent-delete.test.ts
+++ b/apps/web/__tests__/api/assets-permanent-delete.test.ts
@@ -48,4 +48,38 @@ describe('permanent asset deletion', () => {
     expect(query).toContain('source_key');
     expect(query).not.toContain('active=true');
   });
+
+  it('fences deletion of a replica still referenced by another live asset', async () => {
+    mockQuery.mockImplementation(async (sql: string, ...args: unknown[]) => {
+      if (sql.includes('AS shared')) {
+        const provider = args[1];
+        // Only the legacy vercel replica is shared with a sibling live asset.
+        return [{ shared: provider === 'vercel' }];
+      }
+      return [
+        { provider: 'vercel', source_key: 'uploads/shared.png', logical_key: 'legacy/asset/shared-deadbeef', delivery_url: 'https://blob.example.test/uploads/shared.png', active: false },
+        { provider: 's3', source_key: 'uploads/shared.png', logical_key: 'assets/asset-1/original.png', delivery_url: 'https://objects.example.test/sploot/assets/asset-1/original.png', active: true },
+      ];
+    });
+
+    const request = new NextRequest('https://sploot.example.test/api/assets/asset-1?permanent=true', { method: 'DELETE' });
+    const response = await DELETE(request, { params: Promise.resolve({ id: 'asset-1' }) });
+
+    expect(response.status).toBe(200);
+    // Only the unshared s3 replica is physically deleted; the vercel replica
+    // is fenced because a sibling live asset still references the same
+    // physical object (dedup/cutover multi-asset scenario).
+    expect(mockDeleteReplica).toHaveBeenCalledTimes(1);
+    expect(mockDeleteReplica).toHaveBeenCalledWith({ provider: 's3', key: 'assets/asset-1/original.png', url: 'https://objects.example.test/sploot/assets/asset-1/original.png' });
+    expect(mockDeleteReplica).not.toHaveBeenCalledWith(expect.objectContaining({ provider: 'vercel' }));
+    // No outbox row was queued for the fenced replica either — only the
+    // single unshared s3 replica gets an INSERT (the row this asserts on);
+    // the same mock also records the later markReplicaCleanupDone UPDATE
+    // for that one replica, which also mentions storage_cleanup_outbox, so
+    // this filters specifically to the enqueue INSERT.
+    const outboxInserts = (mockTx.$executeRawUnsafe as ReturnType<typeof vi.fn>).mock.calls.filter((call) => String(call[0]).startsWith('INSERT INTO storage_cleanup_outbox'));
+    expect(outboxInserts).toHaveLength(1);
+    expect(outboxInserts[0]).toContain('s3');
+    expect(outboxInserts[0]).not.toContain('vercel');
+  });
 });

--- a/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
+++ b/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
@@ -10,11 +10,17 @@ vi.mock('next/headers', () => ({
 }));
 
 // Mock lib/db
+const mockTx = {
+  asset: { update: vi.fn() },
+  assetStorageReplica: { createMany: vi.fn() },
+};
 const mockPrisma = {
   asset: {
     findMany: vi.fn(),
     update: vi.fn(),
   },
+  $transaction: vi.fn(async (fn: (tx: typeof mockTx) => unknown) => fn(mockTx)),
+  $executeRawUnsafe: vi.fn(),
 };
 
 let mockDatabaseAvailable = true;
@@ -92,6 +98,9 @@ describe('/api/cron/regenerate-thumbnails', () => {
     });
     mockDel.mockResolvedValue(undefined);
     mockPrisma.asset.update.mockResolvedValue({});
+    mockTx.asset.update.mockResolvedValue({});
+    mockTx.assetStorageReplica.createMany.mockResolvedValue({ count: 1 });
+    mockPrisma.$executeRawUnsafe.mockResolvedValue(1);
   });
 
   it('rejects requests without the cron secret', async () => {
@@ -120,7 +129,7 @@ describe('/api/cron/regenerate-thumbnails', () => {
     const meta = await sharp(uploadedBuffer).metadata();
     expect(Math.abs(meta.width! / meta.height! - 800 / 1000)).toBeLessThan(0.02);
 
-    expect(mockPrisma.asset.update).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockTx.asset.update).toHaveBeenCalledWith(expect.objectContaining({
       where: { id: 'asset-1' },
       data: expect.objectContaining({
         thumbnailUrl: 'https://blob.example/original-thumb-new.png',
@@ -130,6 +139,22 @@ describe('/api/cron/regenerate-thumbnails', () => {
         thumbnailStorageSha256: expect.any(String),
         storageConfigFingerprint: expect.any(String),
       }),
+    }));
+
+    // The new thumbnail object is recorded in the replica ledger in the same
+    // transaction, or a later permanent delete would never enqueue it for
+    // provider cleanup (it would have no row at all once any row exists for
+    // this asset — see permanent-delete.ts's authoritative-rows comment).
+    expect(mockTx.assetStorageReplica.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          assetId: 'asset-1',
+          rendition: 'thumbnail',
+          logicalKey: 'user/original-thumb-new.png',
+          deliveryUrl: 'https://blob.example/original-thumb-new.png',
+          active: true,
+        }),
+      ]),
     }));
 
     expect(mockDel).toHaveBeenCalledWith('https://blob.example/original-thumb.png');
@@ -148,7 +173,7 @@ describe('/api/cron/regenerate-thumbnails', () => {
     expect(res.status).toBe(200);
     expect(body.regenerated).toBe(1);
     expect(body.failed).toBe(0);
-    expect(mockPrisma.asset.update).toHaveBeenCalledTimes(1);
+    expect(mockTx.asset.update).toHaveBeenCalledTimes(1);
   });
 
   it('skips thumbnails whose aspect already matches the original', async () => {
@@ -183,5 +208,58 @@ describe('/api/cron/regenerate-thumbnails', () => {
     expect(body.failures[0].id).toBe('asset-1');
     expect(body.alreadyCorrect).toBe(1);
     expect(body.nextCursor).toBe('asset-2'); // third candidate signals more work
+  });
+
+  it('prefers the raw legacy source key over the inventoried logical key when recording an old-thumbnail cleanup failure', async () => {
+    const inventoriedAsset = {
+      ...baseAsset,
+      storageProvider: 'vercel',
+      thumbnailStorageSourceKey: 'user/raw-legacy-thumb.png',
+      thumbnailStorageKey: 'legacy/asset-1/thumbnail-deadbeef',
+    };
+    mockPrisma.asset.findMany.mockResolvedValue([inventoriedAsset]);
+    const legacySquareThumb = await png(256, 256);
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce(fetchResponse(legacySquareThumb))
+      .mockResolvedValueOnce(fetchResponse(original));
+    mockDel.mockRejectedValueOnce(new Error('provider outage'));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.failed).toBe(1);
+    // The replica ledger write and asset update still committed before the
+    // best-effort old-object delete failed, so the new thumbnail is not lost.
+    expect(mockTx.assetStorageReplica.createMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.any(String),
+      'asset-1',
+      'vercel',
+      'user/raw-legacy-thumb.png',
+      'https://blob.example/original-thumb.png',
+      'provider outage',
+    );
+  });
+
+  it('rolls back the asset update when the replica ledger write fails, and cleans up the newly uploaded object', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const legacySquareThumb = await png(256, 256);
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce(fetchResponse(legacySquareThumb))
+      .mockResolvedValueOnce(fetchResponse(original));
+    mockTx.assetStorageReplica.createMany.mockRejectedValueOnce(new Error('permission denied'));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(body.failed).toBe(1);
+    expect(body.failures[0].reason).toContain('permission denied');
+    // Cleanup deletes the just-uploaded object since the transaction rolled back.
+    expect(mockDel).toHaveBeenCalledWith('https://blob.example/original-thumb-new.png');
+    // The stale-crop thumbnail was never touched since the write never committed.
+    expect(mockDel).not.toHaveBeenCalledWith('https://blob.example/original-thumb.png');
   });
 });

--- a/apps/web/__tests__/integration/storage-portability-postgres.test.ts
+++ b/apps/web/__tests__/integration/storage-portability-postgres.test.ts
@@ -225,4 +225,181 @@ describeWithDatabase('storage portability PostgreSQL authority', () => {
     expect(snapshot?.deliveryUrl).toBe('https://source.public.blob.vercel-storage.com/uploads/regenerated-thumb.png');
     expect(snapshot?.sourceKey).not.toBe('uploads/stale-crop-thumb.png');
   });
+
+  it('restores the post-regeneration Vercel peer, not the stale pre-cutover Vercel identity, and leaves exactly one active replica when a target-phase thumbnail regeneration ran before rollback', async () => {
+    previousState = await admin.storageCutoverState.findUnique({ where: { id: 'default' } });
+    const config = createStorageConfig({
+      provider: 's3',
+      phase: 'dual-write',
+      endpoint: 'https://objects.example.test',
+      publicUrlBase: 'https://objects.example.test',
+      bucket: 'sploot',
+      accessKeyId: 'integration-id',
+      secretAccessKey: 'integration-secret',
+    });
+    const manifest = [
+      { logicalKey: 'assets/storage-portability-target-regen/original.png', sourceKey: 'uploads/original.png', rendition: 'original' as const, sourceProvider: 'vercel', size: 3, sha256: 'a'.repeat(64), contentType: 'image/png' },
+      { logicalKey: 'assets/storage-portability-target-regen/thumb.png', sourceKey: 'uploads/thumb.png', rendition: 'thumbnail' as const, sourceProvider: 'vercel', size: 3, sha256: 'b'.repeat(64), contentType: 'image/png' },
+    ];
+    const digest = manifestSha256(manifest);
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/original.png',
+      thumbnailUrl: 'https://source.public.blob.vercel-storage.com/uploads/thumb.png',
+      pathname: 'uploads/original.png',
+      thumbnailPath: 'uploads/thumb.png',
+      storageProvider: 'vercel',
+      storageKey: manifest[0]!.logicalKey,
+      storageSourceKey: manifest[0]!.sourceKey,
+      thumbnailStorageKey: manifest[1]!.logicalKey,
+      thumbnailStorageSourceKey: manifest[1]!.sourceKey,
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-target-regen-checksum',
+    } });
+    await admin.storageCutoverState.create({ data: { id: 'default', phase: 'dual-write', generation: 0, providerFingerprint: storageConfigFingerprint(config), manifestSha256: digest } });
+
+    await commitCutover(manifest, config, digest, admin);
+    // Post-cutover: state.generation is 1; the thumbnail rendition has an
+    // active s3 replica at generation=1 and an inactive vercel snapshot at
+    // generation=1, exactly like the plain-rollback test above.
+
+    // Simulate regenerate-thumbnails running while phase='target': it writes
+    // through ConfiguredStorageWriter, whose portable store still dual-writes
+    // both providers even in target phase (target first, legacy second), and
+    // inserts both replicas — insert-only, no deactivation of the superseded
+    // generation=1 pair, because the app runtime role has no UPDATE grant on
+    // this table. Both new rows share one fresh unix-seconds generation.
+    const regenGeneration = Math.floor(Date.now() / 1000) + 1000;
+    const regenVercelKey = 'uploads/regenerated-thumb.png';
+    const regenVercelUrl = 'https://source.public.blob.vercel-storage.com/uploads/regenerated-thumb.png';
+    const regenS3Key = 'assets/storage-portability-target-regen/thumb-regen.png';
+    const regenS3Url = 'https://objects.example.test/sploot/assets/storage-portability-target-regen/thumb-regen.png';
+    await admin.assetStorageReplica.createMany({ data: [
+      { assetId, rendition: 'thumbnail', provider: 's3', sourceKey: null, logicalKey: regenS3Key, deliveryUrl: regenS3Url, size: 3, sha256: 'e'.repeat(64), contentType: 'image/png', generation: regenGeneration, active: true },
+      { assetId, rendition: 'thumbnail', provider: 'vercel', sourceKey: regenVercelKey, logicalKey: regenVercelKey, deliveryUrl: regenVercelUrl, size: 3, sha256: 'e'.repeat(64), contentType: 'image/png', generation: regenGeneration, active: false },
+    ] });
+    // regenerate-thumbnails' own asset.update: the asset now points at the
+    // fresh s3 object, not the cutover-time one.
+    await admin.asset.update({ where: { id: assetId }, data: {
+      thumbnailUrl: regenS3Url, thumbnailStorageKey: regenS3Key, thumbnailStorageSourceKey: null,
+    } });
+
+    await restoreCutoverMappings(config, digest, admin);
+
+    const asset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: {
+      storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true,
+      thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailUrl: true,
+    } });
+    // Original rendition never regenerated — restores to its ordinary
+    // pre-cutover identity exactly like the plain-rollback test.
+    expect(asset.storageProvider).toBe('vercel');
+    expect(asset.storageKey).toBe(manifest[0]!.logicalKey);
+    expect(asset.storageSourceKey).toBe(manifest[0]!.sourceKey);
+    expect(asset.blobUrl).toBe('https://source.public.blob.vercel-storage.com/uploads/original.png');
+    // Thumbnail rendition must restore to the *regenerated* Vercel peer —
+    // never the stale pre-cutover Vercel identity the plain-rollback test
+    // uses — because that peer is the current live object.
+    expect(asset.thumbnailStorageKey).toBe(regenVercelKey);
+    expect(asset.thumbnailStorageSourceKey).toBe(regenVercelKey);
+    expect(asset.thumbnailUrl).toBe(regenVercelUrl);
+    expect(asset.thumbnailUrl).not.toBe('https://source.public.blob.vercel-storage.com/uploads/thumb.png');
+
+    const replicaRows = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { generation: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, generation: true, active: true } });
+    expect(replicaRows).toHaveLength(6);
+    const thumbnailRows = replicaRows.filter(row => row.rendition === 'thumbnail');
+    const activeThumbnailRows = thumbnailRows.filter(row => row.active);
+    // Exactly one active replica remains for the regenerated rendition —
+    // never both the stale cutover-generation target row and the fresher
+    // regen row, never zero.
+    expect(activeThumbnailRows).toHaveLength(1);
+    expect(activeThumbnailRows[0]).toMatchObject({ provider: 'vercel', generation: regenGeneration });
+    // The regen's own s3 replica — the "later target replica" the bug used
+    // to leave active — is deactivated.
+    expect(thumbnailRows.find(row => row.provider === 's3' && row.generation === regenGeneration)?.active).toBe(false);
+    // The stale cutover-generation pair is deactivated too, not resurrected.
+    expect(thumbnailRows.find(row => row.provider === 'vercel' && row.generation === 1)?.active).toBe(false);
+    expect(thumbnailRows.find(row => row.provider === 's3' && row.generation === 1)?.active).toBe(false);
+    // Original rendition is unaffected: single active legacy replica, as in
+    // the plain-rollback test.
+    const originalRows = replicaRows.filter(row => row.rendition === 'original');
+    expect(originalRows.filter(row => row.active)).toHaveLength(1);
+    expect(originalRows.find(row => row.active)).toMatchObject({ provider: 'vercel', generation: 1 });
+
+    expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual({ phase: 'rollback', generation: 1 });
+  });
+
+  it('fails closed and leaves the database unchanged when a target-provider replica has no paired source-provider peer at its generation', async () => {
+    previousState = await admin.storageCutoverState.findUnique({ where: { id: 'default' } });
+    const config = createStorageConfig({
+      provider: 's3',
+      phase: 'dual-write',
+      endpoint: 'https://objects.example.test',
+      publicUrlBase: 'https://objects.example.test',
+      bucket: 'sploot',
+      accessKeyId: 'integration-id',
+      secretAccessKey: 'integration-secret',
+    });
+    const manifest = [
+      { logicalKey: 'assets/storage-portability-incomplete-pair/original.png', sourceKey: 'uploads/original.png', rendition: 'original' as const, sourceProvider: 'vercel', size: 3, sha256: 'a'.repeat(64), contentType: 'image/png' },
+      { logicalKey: 'assets/storage-portability-incomplete-pair/thumb.png', sourceKey: 'uploads/thumb.png', rendition: 'thumbnail' as const, sourceProvider: 'vercel', size: 3, sha256: 'b'.repeat(64), contentType: 'image/png' },
+    ];
+    const digest = manifestSha256(manifest);
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/original.png',
+      thumbnailUrl: 'https://source.public.blob.vercel-storage.com/uploads/thumb.png',
+      pathname: 'uploads/original.png',
+      thumbnailPath: 'uploads/thumb.png',
+      storageProvider: 'vercel',
+      storageKey: manifest[0]!.logicalKey,
+      storageSourceKey: manifest[0]!.sourceKey,
+      thumbnailStorageKey: manifest[1]!.logicalKey,
+      thumbnailStorageSourceKey: manifest[1]!.sourceKey,
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-incomplete-pair-checksum',
+    } });
+    await admin.storageCutoverState.create({ data: { id: 'default', phase: 'dual-write', generation: 0, providerFingerprint: storageConfigFingerprint(config), manifestSha256: digest } });
+
+    await commitCutover(manifest, config, digest, admin);
+
+    // Simulate a broken/partial write: an active target-provider (s3) replica
+    // at a fresh generation with no paired vercel replica at that same
+    // generation — not a shape the app's atomic dual-write transaction can
+    // normally produce, but exactly the "incomplete pair" rollback must never
+    // paper over by falling back to some other (stale, mismatched) generation.
+    const orphanGeneration = Math.floor(Date.now() / 1000) + 2000;
+    await admin.assetStorageReplica.create({ data: {
+      assetId, rendition: 'thumbnail', provider: 's3', sourceKey: null,
+      logicalKey: 'assets/storage-portability-incomplete-pair/thumb-orphan.png',
+      deliveryUrl: 'https://objects.example.test/sploot/assets/storage-portability-incomplete-pair/thumb-orphan.png',
+      size: 3, sha256: 'f'.repeat(64), contentType: 'image/png', generation: orphanGeneration, active: true,
+    } });
+
+    const beforeAsset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: {
+      storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true,
+      thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailUrl: true,
+    } });
+    const beforeReplicas = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { generation: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, generation: true, active: true } });
+    const beforeState = await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } });
+
+    await expect(restoreCutoverMappings(config, digest, admin)).rejects.toThrow(/complete provider-paired replica generation/);
+
+    // Fails closed: not just the broken rendition, the whole transaction —
+    // including the otherwise-healthy original rendition and the cutover
+    // state — must be untouched, never a partial/mixed-generation commit.
+    const afterAsset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: {
+      storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true,
+      thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailUrl: true,
+    } });
+    expect(afterAsset).toEqual(beforeAsset);
+    const afterReplicas = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { generation: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, generation: true, active: true } });
+    expect(afterReplicas).toEqual(beforeReplicas);
+    expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual(beforeState);
+  });
 });

--- a/apps/web/__tests__/integration/storage-portability-postgres.test.ts
+++ b/apps/web/__tests__/integration/storage-portability-postgres.test.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createStorageConfig, storageConfigFingerprint } from '@/lib/storage/config';
-import { commitCutover, manifestSha256 } from '@/scripts/storage-portability';
+import { commitCutover, manifestSha256, restoreCutoverMappings } from '@/scripts/storage-portability';
 
 const hasAuthorityDatabase = Boolean(process.env.DATABASE_URL && process.env.STRIPE_LEDGER_ADMIN_DATABASE_URL);
 const describeWithDatabase = hasAuthorityDatabase ? describe.sequential : describe.skip;
@@ -69,5 +69,160 @@ describeWithDatabase('storage portability PostgreSQL authority', () => {
     expect(rows.find(row => row.rendition === 'original' && row.provider === 's3')?.deliveryUrl).toBe('https://objects.example.test/sploot/assets/storage-portability-cutover/original.png');
     expect(rows.find(row => row.rendition === 'thumbnail' && row.provider === 's3')?.deliveryUrl).toBe('https://objects.example.test/sploot/assets/storage-portability-cutover/thumb.png');
     expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual({ phase: 'target', generation: 1 });
+  });
+
+  it('restores both distinct pre-cutover key columns and reactivates exactly the legacy replica on rollback', async () => {
+    previousState = await admin.storageCutoverState.findUnique({ where: { id: 'default' } });
+    const config = createStorageConfig({
+      provider: 's3',
+      phase: 'dual-write',
+      endpoint: 'https://objects.example.test',
+      publicUrlBase: 'https://objects.example.test',
+      bucket: 'sploot',
+      accessKeyId: 'integration-id',
+      secretAccessKey: 'integration-secret',
+    });
+    // The canonical logical key (already inventoried) and the raw legacy
+    // provider key are deliberately different strings here, matching the
+    // real post-inventory shape: storageKey holds a clean canonical name
+    // while storageSourceKey keeps the original provider path.
+    const manifest = [
+      { logicalKey: 'assets/storage-portability-cutover/original.png', sourceKey: 'uploads/raw original.png', rendition: 'original' as const, sourceProvider: 'vercel', size: 3, sha256: 'a'.repeat(64), contentType: 'image/png' },
+      { logicalKey: 'assets/storage-portability-cutover/thumb.png', sourceKey: 'uploads/raw thumb.png', rendition: 'thumbnail' as const, sourceProvider: 'vercel', size: 3, sha256: 'b'.repeat(64), contentType: 'image/png' },
+    ];
+    const digest = manifestSha256(manifest);
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/raw%20original.png',
+      thumbnailUrl: 'https://source.public.blob.vercel-storage.com/uploads/raw%20thumb.png',
+      pathname: 'uploads/original.png',
+      thumbnailPath: 'uploads/thumb.png',
+      storageProvider: 'vercel',
+      storageKey: manifest[0]!.logicalKey,
+      storageSourceKey: manifest[0]!.sourceKey,
+      thumbnailStorageKey: manifest[1]!.logicalKey,
+      thumbnailStorageSourceKey: manifest[1]!.sourceKey,
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-rollback-checksum',
+    } });
+    await admin.storageCutoverState.create({ data: { id: 'default', phase: 'dual-write', generation: 0, providerFingerprint: storageConfigFingerprint(config), manifestSha256: digest } });
+
+    await commitCutover(manifest, config, digest, admin);
+    await restoreCutoverMappings(config, digest, admin);
+
+    const asset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: {
+      storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true,
+      thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailUrl: true,
+    } });
+    expect(asset.storageProvider).toBe('vercel');
+    // storageKey must be restored to the canonical logical key, not
+    // collapsed onto the raw legacy source key (or vice versa) — the two
+    // remain distinct values, exactly as they were pre-cutover.
+    expect(asset.storageKey).toBe(manifest[0]!.logicalKey);
+    expect(asset.storageSourceKey).toBe(manifest[0]!.sourceKey);
+    expect(asset.blobUrl).toBe('https://source.public.blob.vercel-storage.com/uploads/raw%20original.png');
+    expect(asset.thumbnailStorageKey).toBe(manifest[1]!.logicalKey);
+    expect(asset.thumbnailStorageSourceKey).toBe(manifest[1]!.sourceKey);
+    expect(asset.thumbnailUrl).toBe('https://source.public.blob.vercel-storage.com/uploads/raw%20thumb.png');
+
+    const replicaRows = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, active: true } });
+    expect(replicaRows).toHaveLength(4);
+    // Exactly the legacy replica is reactivated; the s3 target replica the
+    // asset no longer points to is deactivated — never both, never neither.
+    expect(replicaRows.filter(row => row.provider === 'vercel' && row.active)).toHaveLength(2);
+    expect(replicaRows.filter(row => row.provider === 's3' && row.active)).toHaveLength(0);
+
+    expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual({ phase: 'rollback', generation: 1 });
+  });
+
+  it('cutover snapshots the regenerated thumbnail replica, not the stale pre-regen upload row, because its unix-seconds generation outranks the small sequential counter', async () => {
+    previousState = await admin.storageCutoverState.findUnique({ where: { id: 'default' } });
+    const config = createStorageConfig({
+      provider: 's3',
+      phase: 'dual-write',
+      endpoint: 'https://objects.example.test',
+      publicUrlBase: 'https://objects.example.test',
+      bucket: 'sploot',
+      accessKeyId: 'integration-id',
+      secretAccessKey: 'integration-secret',
+    });
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    // Upload-time state: original + a since-superseded (stale) thumbnail,
+    // both recorded with the small default generation the initial upload
+    // path uses.
+    const manifest = [
+      { logicalKey: 'assets/storage-portability-generation-ordering/original.png', sourceKey: 'uploads/original.png', rendition: 'original' as const, sourceProvider: 'vercel', size: 3, sha256: 'a'.repeat(64), contentType: 'image/png' },
+      { logicalKey: 'assets/storage-portability-generation-ordering/thumb.png', sourceKey: 'uploads/regenerated-thumb.png', rendition: 'thumbnail' as const, sourceProvider: 'vercel', size: 3, sha256: 'd'.repeat(64), contentType: 'image/png' },
+    ];
+    const digest = manifestSha256(manifest);
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/original.png',
+      thumbnailUrl: 'https://source.public.blob.vercel-storage.com/uploads/regenerated-thumb.png',
+      pathname: 'uploads/original.png',
+      thumbnailPath: 'uploads/regenerated-thumb.png',
+      storageProvider: 'vercel',
+      // Already-inventoried shape (same convention the other cutover tests
+      // use): storageKey/thumbnailStorageKey hold the canonical logical key,
+      // storageSourceKey/thumbnailStorageSourceKey the raw legacy path. This
+      // isolates the thing under test to the replica-generation lookup
+      // below, not the asset-matching join.
+      storageKey: manifest[0]!.logicalKey,
+      storageSourceKey: manifest[0]!.sourceKey,
+      thumbnailStorageKey: manifest[1]!.logicalKey,
+      thumbnailStorageSourceKey: manifest[1]!.sourceKey,
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-generation-ordering-checksum',
+    } });
+    await admin.assetStorageReplica.create({ data: {
+      assetId, rendition: 'thumbnail', provider: 'vercel',
+      sourceKey: 'uploads/stale-crop-thumb.png', logicalKey: 'uploads/stale-crop-thumb.png',
+      deliveryUrl: 'https://source.public.blob.vercel-storage.com/uploads/stale-crop-thumb.png',
+      size: 3, sha256: 'c'.repeat(64), contentType: 'image/png', generation: 0, active: true,
+    } });
+    // The regen cron's exact insert shape: a second, later vercel replica
+    // row for the same rendition, generation stamped as (roughly) the
+    // current unix-seconds — never a small sequential integer — precisely
+    // because the app runtime role cannot SELECT the `generation` column to
+    // compute a real next value (column-restricted grant).
+    const regenGeneration = Math.floor(Date.now() / 1000);
+    await admin.assetStorageReplica.create({ data: {
+      assetId, rendition: 'thumbnail', provider: 'vercel',
+      sourceKey: 'uploads/regenerated-thumb.png', logicalKey: 'uploads/regenerated-thumb.png',
+      deliveryUrl: 'https://source.public.blob.vercel-storage.com/uploads/regenerated-thumb.png',
+      size: 3, sha256: 'd'.repeat(64), contentType: 'image/png', generation: regenGeneration, active: true,
+    } });
+
+    await admin.storageCutoverState.create({ data: { id: 'default', phase: 'dual-write', generation: 0, providerFingerprint: storageConfigFingerprint(config), manifestSha256: digest } });
+
+    await commitCutover(manifest, config, digest, admin);
+
+    // commitCutover's blanket `UPDATE ... SET active=false WHERE asset_id=$1
+    // AND rendition=$2` deactivates every pre-existing vercel row for this
+    // rendition (both the stale generation-0 row and the regenerated row),
+    // then inserts exactly one new snapshot row at the cutover's own fresh
+    // generation (the pre-cutover state's generation 0 + 1 = 1) carrying
+    // whatever `recordedSource` the ORDER BY generation DESC lookup picked.
+    // Filtering on that exact generation — not just `active: false`, which
+    // would also match the two now-deactivated pre-existing rows — isolates
+    // the one row this test actually cares about.
+    const snapshot = await admin.assetStorageReplica.findFirst({
+      where: { assetId, rendition: 'thumbnail', provider: 'vercel', generation: 1 },
+      select: { sourceKey: true, deliveryUrl: true, active: true },
+    });
+    expect(snapshot?.active).toBe(false);
+    // The cutover-created inactive snapshot must carry the regenerated
+    // object's identity — proof that commitCutover's `ORDER BY generation
+    // DESC LIMIT 1` source-replica lookup picked the post-regen row over
+    // the stale generation-0 upload row, so rollback would restore the
+    // still-live regenerated object rather than resurrecting a deleted one.
+    expect(snapshot?.sourceKey).toBe('uploads/regenerated-thumb.png');
+    expect(snapshot?.deliveryUrl).toBe('https://source.public.blob.vercel-storage.com/uploads/regenerated-thumb.png');
+    expect(snapshot?.sourceKey).not.toBe('uploads/stale-crop-thumb.png');
   });
 });

--- a/apps/web/__tests__/lib/storage/storage-contract.test.ts
+++ b/apps/web/__tests__/lib/storage/storage-contract.test.ts
@@ -135,6 +135,61 @@ describe('portable storage contract', () => {
     fetchMock.mockRestore();
   });
 
+  it('signs and persists the sha256 checksum as object metadata, and bounds the request with a timeout', async () => {
+    const config = createStorageConfig({ provider: 's3', endpoint: 'https://objects.example.test', publicUrlBase: 'https://objects.example.test/cdn/base', bucket: 'sploot', accessKeyId: 'public-id', secretAccessKey: 'secret' });
+    const target = new S3CompatibleObjectStore(config);
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(bytes, { status: 200, headers: { 'content-length': String(bytes.byteLength), 'content-type': 'image/png', 'x-amz-meta-sha256': metadata.sha256 } }));
+    await target.put('assets/checksum.png', bytes, metadata);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]! as [URL, RequestInit & { headers: Record<string, string> }];
+    expect(init.headers['x-amz-meta-sha256']).toBe(metadata.sha256);
+    // S3 rejects unsigned x-amz-* headers with SignatureDoesNotMatch, so the
+    // checksum header must be part of the signed-headers set the Authorization
+    // header declares, not merely present on the request.
+    const authorization = init.headers.authorization;
+    expect(authorization).toBeDefined();
+    const signedHeaders = authorization!.match(/SignedHeaders=([^,]+)/)?.[1]?.split(';') ?? [];
+    expect(signedHeaders).toContain('x-amz-meta-sha256');
+    // The request never hangs indefinitely against an unresponsive provider.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    fetchMock.mockRestore();
+  });
+
+  it('bounds the legacy Vercel Blob read with a request timeout', async () => {
+    const store = new VercelObjectStore('https://blob.example.test');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(bytes, { status: 200, headers: { 'content-length': String(bytes.byteLength), 'content-type': 'image/png' } }));
+    await store.get('assets/a.png');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    fetchMock.mockRestore();
+  });
+
+  it('surfaces a structured, actionable error instead of a raw abort exception when an S3-compatible request times out', async () => {
+    const target = new S3CompatibleObjectStore(createStorageConfig({ provider: 's3', endpoint: 'https://objects.example.test', publicUrlBase: 'https://objects.example.test/cdn/base', bucket: 'sploot', accessKeyId: 'public-id', secretAccessKey: 'secret' }));
+    const timeoutError = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(timeoutError);
+    await expect(target.put('assets/slow.png', bytes, metadata)).rejects.toThrow(/timed out after 30000ms/);
+    fetchMock.mockRestore();
+  });
+
+  it('surfaces a structured, actionable error instead of a raw abort exception when a legacy Vercel Blob read times out', async () => {
+    const store = new VercelObjectStore('https://blob.example.test');
+    const timeoutError = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(timeoutError);
+    await expect(store.get('assets/a.png')).rejects.toThrow(/timed out after 30000ms/);
+    fetchMock.mockRestore();
+  });
+
+  it('does not mask a non-timeout fetch failure behind the timeout message', async () => {
+    const store = new VercelObjectStore('https://blob.example.test');
+    const networkError = new Error('getaddrinfo ENOTFOUND blob.example.test');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(networkError);
+    await expect(store.get('assets/a.png')).rejects.toThrow('getaddrinfo ENOTFOUND blob.example.test');
+    fetchMock.mockRestore();
+  });
+
   it('reads back the exact URL returned by a provider', async () => {
     const calls: string[] = [];
     const provider = {

--- a/apps/web/__tests__/scripts/storage-portability.test.ts
+++ b/apps/web/__tests__/scripts/storage-portability.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { inventoryLogicalKey, manifestSha256, renditionMime } from '../../scripts/storage-portability';
+import { describe, expect, it, vi } from 'vitest';
+import { inventoryLogicalKey, manifestSha256, pruneStaleMigrationEntries, renditionMime } from '../../scripts/storage-portability';
 
 describe('storage portability CLI contracts', () => {
   it('maps legacy keys deterministically without mutating source identity', () => {
@@ -20,5 +20,32 @@ describe('storage portability CLI contracts', () => {
     const entries = [{ logicalKey: 'a', sourceKey: 'b', size: 1, sha256: '0'.repeat(64) }, { logicalKey: 'c', sourceKey: 'd', size: 2, sha256: '1'.repeat(64) }];
     expect(manifestSha256(entries)).toMatch(/^[a-f0-9]{64}$/);
     expect(manifestSha256([...entries].reverse())).not.toBe(manifestSha256(entries));
+  });
+
+  it('prunes only never-claimed migration entries orphaned relative to live assets, never in-flight or terminal rows', async () => {
+    const executeRaw = vi.fn().mockResolvedValue(2);
+    const db = { $executeRaw: executeRaw } as never;
+    const deleted = await pruneStaleMigrationEntries(db);
+    expect(deleted).toBe(2);
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    const [query] = executeRaw.mock.calls[0]!;
+    const sql = String(query.sql ?? query);
+    // Scoped to never-claimed rows only — in-flight ('copying') and terminal
+    // ('verified'/'rolled_back') work is never discarded.
+    expect(sql).toContain("e.status = 'pending'");
+    // Never touches an asset that has been soft-deleted; a live asset whose
+    // keys simply weren't re-seeded yet must not look orphaned.
+    expect(sql).toContain('a.deleted_at IS NULL');
+    // Original and thumbnail renditions are matched against their own
+    // current key columns, not each other's — this is the exact join that
+    // must catch a thumbnail entry superseded by regenerate-thumbnails
+    // rewriting thumbnail_storage_key/thumbnail_storage_source_key after
+    // the entry was inventoried.
+    expect(sql).toContain("e.rendition = 'original'");
+    expect(sql).toContain('a.storage_source_key = e.source_key');
+    expect(sql).toContain('a.storage_key = e.logical_key');
+    expect(sql).toContain("e.rendition = 'thumbnail'");
+    expect(sql).toContain('a.thumbnail_storage_source_key = e.source_key');
+    expect(sql).toContain('a.thumbnail_storage_key = e.logical_key');
   });
 });

--- a/apps/web/app/api/cron/regenerate-thumbnails/route.ts
+++ b/apps/web/app/api/cron/regenerate-thumbnails/route.ts
@@ -146,22 +146,75 @@ async function getHandler(request: NextRequest) {
       const metadata = { size: newThumb.byteLength, sha256: createHash('sha256').update(newThumb).digest('hex'), contentType: 'image/' + (format === 'jpeg' ? 'jpeg' : format) };
       const blob = await storage.put(key, newThumb, metadata);
       const oldThumbUrl = asset.thumbnailUrl!;
-      const oldThumb = { provider: asset.storageProvider, key: asset.thumbnailStorageKey ?? asset.thumbnailPath ?? '', url: oldThumbUrl };
+      // Match the read-path provider preference above: for a legacy Vercel
+      // asset the raw source key (not the inventoried logical key) is the
+      // real deletable pathname.
+      const oldThumbKey = asset.storageProvider === 'vercel'
+        ? (asset.thumbnailStorageSourceKey ?? asset.thumbnailStorageKey ?? asset.thumbnailPath ?? '')
+        : (asset.thumbnailStorageKey ?? asset.thumbnailPath ?? '');
+      const oldThumb = { provider: asset.storageProvider, key: oldThumbKey, url: oldThumbUrl };
+      const newReplicas = blob.replicas ?? [{ provider: blob.provider, key: blob.key, url: blob.url }];
+      // Unix-seconds generation: fits int4, is monotonic, and always
+      // outranks both upload's default generation 0 and cutover's small
+      // sequential counter (state.generation + 1) in every `ORDER BY
+      // generation DESC LIMIT 1` source-replica lookup a later cutover
+      // performs — so a pre-cutover regen correctly supersedes the stale
+      // (already-deleted) original thumbnail object as the recorded source.
+      // Reading the real next generation is not an option here: the app
+      // role's SELECT grant on this table is column-restricted and excludes
+      // `generation` (see stripe-ledger-bootstrap-post.sql).
+      const regenGeneration = Math.floor(Date.now() / 1000);
       try {
-        await prisma.asset.update({
-          where: { id: asset.id },
-          data: {
-            thumbnailUrl: blob.url,
-            thumbnailPath: blob.key,
-            thumbnailStorageKey: blob.key,
-            thumbnailStorageSourceKey: null,
-            thumbnailStorageSize: blob.metadata.size,
-            thumbnailStorageSha256: blob.metadata.sha256,
-            storageConfigFingerprint: configFingerprint,
-          },
+        await prisma.$transaction(async (tx) => {
+          await tx.asset.update({
+            where: { id: asset.id },
+            data: {
+              thumbnailUrl: blob.url,
+              thumbnailPath: blob.key,
+              thumbnailStorageKey: blob.key,
+              thumbnailStorageSourceKey: null,
+              thumbnailStorageSize: blob.metadata.size,
+              thumbnailStorageSha256: blob.metadata.sha256,
+              storageConfigFingerprint: configFingerprint,
+            },
+          });
+          // Insert-only: the app runtime role has no UPDATE/DELETE grant on
+          // this ledger, so the superseded row is left in place rather than
+          // deactivated. permanent-delete's replicasForPermanentDelete
+          // treats every row as authoritative regardless of `active`, so the
+          // old object still gets tombstoned for cleanup; without this
+          // insert the *new* thumbnail object would have no replica row at
+          // all once any row exists for this asset, and would leak forever
+          // on permanent delete.
+          // No skipDuplicates: the (assetId, rendition, generation, provider)
+          // unique constraint is our only collision guard against two
+          // concurrent regen attempts for the same asset within the same
+          // wall-clock second (both would compute an identical
+          // regenGeneration). Silently skipping a colliding insert would
+          // let the transaction commit with the asset pointed at a new
+          // object that has no ledger row — exactly the leak this insert
+          // exists to prevent. Letting the unique-constraint violation
+          // throw instead rolls back this entire transaction (including
+          // the asset.update above), so the loser is cleanly retried on
+          // the next cron pass with a fresh generation a second later.
+          await tx.assetStorageReplica.createMany({
+            data: newReplicas.map((replica) => ({
+              assetId: asset.id,
+              rendition: 'thumbnail' as const,
+              provider: replica.provider,
+              sourceKey: replica.provider === 'vercel' ? replica.key : null,
+              logicalKey: replica.key,
+              deliveryUrl: replica.url,
+              size: blob.metadata.size,
+              sha256: blob.metadata.sha256,
+              contentType: metadata.contentType,
+              generation: regenGeneration,
+              active: replica.provider === blob.provider,
+            })),
+          });
         });
       } catch (error) {
-        await storage.deleteReplicas?.(blob.replicas ?? [{ provider: blob.provider, key: blob.key, url: blob.url }]);
+        await storage.deleteReplicas?.(newReplicas);
         throw error;
       }
       try {

--- a/apps/web/lib/storage/object-store.ts
+++ b/apps/web/lib/storage/object-store.ts
@@ -3,6 +3,33 @@ import { createHmac } from 'node:crypto';
 import { del, list as listVercel, put } from '@vercel/blob';
 import { canonicalLogicalKey, createStorageConfig, stableDeliveryUrl, storageConfigFingerprint, storageConfigFromEnv, type StorageConfig, type StoragePhase } from './config';
 
+// Provider HTTP calls must never hang the request/cron indefinitely; both the
+// S3-compatible signer and the legacy Vercel Blob reader below bound every
+// outbound fetch with this timeout.
+const PROVIDER_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * A raw AbortSignal.timeout() rejection is an opaque DOMException ("The
+ * operation was aborted") with no context on which provider request timed
+ * out. Every outbound provider fetch in this module routes through here so
+ * an operator or caller sees a clear, actionable error naming the operation
+ * instead of that generic abort message.
+ */
+async function fetchWithTimeout(url: string | URL, init: RequestInit | undefined, operation: string): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(PROVIDER_REQUEST_TIMEOUT_MS) });
+  } catch (error) {
+    // DOMException (what AbortSignal.timeout() rejects with) does not
+    // reliably satisfy `instanceof Error` across runtimes, so check `name`
+    // directly on whatever was thrown rather than narrowing to Error first.
+    const name = (error as { name?: unknown } | null)?.name;
+    if (name === 'TimeoutError' || name === 'AbortError') {
+      throw new Error(`${operation} timed out after ${PROVIDER_REQUEST_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  }
+}
+
 export interface ObjectMetadata {
   size: number;
   sha256: string;
@@ -326,7 +353,7 @@ export class VercelObjectStore implements ObjectStore {
   }
 
   private async readUrl(url: string, logicalKey: string): Promise<StoredObject> {
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url, undefined, `Vercel Blob read of ${logicalKey}`);
     if (response.status === 404) throw new ObjectNotFoundError(logicalKey);
     if (!response.ok || !response.body) throw new Error(`Vercel Blob read failed: ${response.status}`);
     return { key: logicalKey, url: response.url, metadata: { size: Number(response.headers.get('content-length') ?? 0), sha256: response.headers.get('x-amz-meta-sha256') ?? '', contentType: response.headers.get('content-type') ?? undefined }, body: response.body };
@@ -410,7 +437,7 @@ export class S3CompatibleObjectStore implements ObjectStore {
     const bytes = await bodyToBuffer(body, Math.max(metadata.size, 1));
     const actual = actualMetadata(bytes, metadata.contentType);
     assertMetadata(actual, metadata);
-    const response = await this.request('PUT', logicalKey, bytes, metadata.contentType);
+    const response = await this.request('PUT', logicalKey, bytes, metadata.contentType, actual.sha256);
     if (!response.ok) throw new Error(`S3-compatible write failed: ${response.status}`);
     return { provider: this.provider, key: logicalKey, url: this.objectUrl(logicalKey), metadata: actual };
   }
@@ -463,7 +490,7 @@ export class S3CompatibleObjectStore implements ObjectStore {
     return stableDeliveryUrl(this.config, key);
   }
 
-  private async request(method: string, key: string, body?: Uint8Array, contentType?: string): Promise<Response> {
+  private async request(method: string, key: string, body?: Uint8Array, contentType?: string, sha256?: string): Promise<Response> {
     const encodedKey = key.split('/').map(encodeRfc3986).join('/');
     const endpointBase = this.endpoint.toString().replace(/\/$/, '');
     const requestPath = `${this.endpoint.pathname.replace(/\/$/, '')}/${encodeRfc3986(this.config.bucket)}/${encodedKey}`;
@@ -479,6 +506,10 @@ export class S3CompatibleObjectStore implements ObjectStore {
     };
     if (body) headers['content-length'] = String(body.byteLength);
     if (contentType) headers['content-type'] = contentType;
+    // Persisted as object metadata on write so a foreign reader/tool can see the
+    // canonical checksum; never trusted for integrity here, since every parity
+    // check in this codebase recomputes the hash from the actual response bytes.
+    if (sha256) headers['x-amz-meta-sha256'] = sha256;
     const signedHeaders = Object.keys(headers).sort().join(';');
     const canonicalHeaders = Object.keys(headers).sort().map(name => `${name}:${headers[name]!.trim()}\n`).join('');
     const canonicalRequest = [method, requestPath, '', canonicalHeaders, signedHeaders, payloadHash].join('\n');
@@ -486,7 +517,7 @@ export class S3CompatibleObjectStore implements ObjectStore {
     const stringToSign = ['AWS4-HMAC-SHA256', amzDate, scope, sha256Hex(Buffer.from(canonicalRequest))].join('\n');
     const signingKey = hmac(hmac(hmac(hmac(Buffer.from(`AWS4${this.config.secretAccessKey}`), date), this.config.region), 's3'), 'aws4_request');
     headers.authorization = `AWS4-HMAC-SHA256 Credential=${this.config.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${hmac(signingKey, stringToSign).toString('hex')}`;
-    return fetch(url, { method, headers, body: body as BodyInit | undefined });
+    return fetchWithTimeout(url, { method, headers, body: body as BodyInit | undefined }, `S3-compatible ${method} of ${key}`);
   }
 }
 

--- a/apps/web/lib/storage/permanent-delete.ts
+++ b/apps/web/lib/storage/permanent-delete.ts
@@ -42,6 +42,41 @@ export function replicasForPermanentDelete(rows: AssetReplicaRow[], fallback: As
  * used by explicit DELETE and the retention purge; outbox rows survive asset
  * deletion and are idempotent via their deterministic identity.
  */
+/**
+ * A physical object is fenced from deletion whenever any other still-live
+ * asset also references it (by exact provider+delivery-URL identity via its
+ * replica ledger, or via the raw legacy Asset columns before any replica row
+ * exists). Cutover explicitly models more than one live Asset row sharing a
+ * single legacy storage key/URL (see storage-portability.ts commitCutover's
+ * per-manifest-entry `assets` loop); deletion must honor the same invariant
+ * or it would physically destroy an object a sibling asset still serves.
+ */
+async function hasLiveSharedReference(
+  tx: CleanupTransaction,
+  assetId: string,
+  replica: StorageReplica,
+): Promise<boolean> {
+  const rows = await tx.$queryRawUnsafe<Array<{ shared: boolean }>>(
+    `SELECT (
+       EXISTS (
+         SELECT 1 FROM asset_storage_replicas r
+         JOIN assets a ON a.id = r.asset_id
+         WHERE r.asset_id <> $1 AND a.deleted_at IS NULL
+           AND r.provider = $2 AND r.delivery_url = $3
+       )
+       OR EXISTS (
+         SELECT 1 FROM assets a2
+         WHERE a2.id <> $1 AND a2.deleted_at IS NULL
+           AND (a2.blob_url = $3 OR a2.thumbnail_url = $3)
+       )
+     ) AS shared`,
+    assetId,
+    replica.provider,
+    replica.url,
+  );
+  return rows[0]?.shared === true;
+}
+
 export async function enqueueAssetReplicaCleanup(
   tx: CleanupTransaction,
   assetId: string,
@@ -51,8 +86,11 @@ export async function enqueueAssetReplicaCleanup(
     'SELECT provider, source_key, logical_key, delivery_url, active FROM asset_storage_replicas WHERE asset_id=$1',
     assetId,
   );
-  const replicas = replicasForPermanentDelete(rows, fallback);
-  for (const replica of replicas) {
+  const candidates = replicasForPermanentDelete(rows, fallback);
+  const replicas: StorageReplica[] = [];
+  for (const replica of candidates) {
+    if (await hasLiveSharedReference(tx, assetId, replica)) continue;
+    replicas.push(replica);
     await tx.$executeRawUnsafe(
       "INSERT INTO storage_cleanup_outbox (id, asset_id, provider, key, url, action, status, updated_at) VALUES (md5(concat_ws(chr(0), $1, $2, $3, $4, $5)), $1, $2, $3, $4, $5, 'pending', NOW()) ON CONFLICT (id) DO NOTHING",
       assetId,

--- a/apps/web/scripts/storage-portability.ts
+++ b/apps/web/scripts/storage-portability.ts
@@ -112,8 +112,44 @@ async function inventory(limit: number, cursor?: string) {
     if (assets.length < limit) break;
   }
   if (failures > 0) throw new Error('Inventory parity failed for ' + failures + ' asset(s); resume from the recorded cursor after repairing source objects');
+  // A full, uninterrupted pass above re-seeds every non-deleted asset's
+  // current original/thumbnail keys, so it is now safe to prune whatever no
+  // longer matches any live asset.
+  await pruneStaleMigrationEntries(prisma);
   const durableManifest = await prisma.storageMigrationEntry.findMany({ orderBy: { logicalKey: 'asc' }, select: { logicalKey: true, sourceKey: true, rendition: true, sourceProvider: true, size: true, sha256: true, contentType: true } });
   process.stdout.write(JSON.stringify(durableManifest) + '\n');
+}
+
+/**
+ * A never-claimed ('pending') migration-entry row that no longer matches any
+ * live asset's *current* original/thumbnail keys is orphaned — most commonly
+ * a thumbnail entry whose physical object was superseded by
+ * regenerate-thumbnails after it was inventoried (the crop-fix cron rewrites
+ * `thumbnail_storage_key`/`thumbnail_storage_source_key` and deletes the old
+ * object independently of this ledger). Left in place, a later commitCutover
+ * would fail closed for the whole batch on that single entry ("no matching
+ * live asset"), even though every other entry is fine.
+ *
+ * Only callable by inventory(), after a full, uninterrupted pass has re-seeded
+ * every live asset's current keys — otherwise an asset merely outside the
+ * current page's cursor range would look orphaned and get pruned by mistake.
+ * In-flight ('copying') and terminal ('verified'/'rolled_back') rows are
+ * never touched: pruning only ever discards work nothing has started yet.
+ */
+export async function pruneStaleMigrationEntries(db: PrismaClient): Promise<number> {
+  const result = await db.$executeRaw(Prisma.sql`
+    DELETE FROM storage_migration_entries e
+    WHERE e.status = 'pending'
+      AND NOT EXISTS (
+        SELECT 1 FROM assets a
+        WHERE a.deleted_at IS NULL
+          AND (
+            (e.rendition = 'original' AND (a.storage_source_key = e.source_key OR a.storage_key = e.logical_key))
+            OR (e.rendition = 'thumbnail' AND (a.thumbnail_storage_source_key = e.source_key OR a.thumbnail_storage_key = e.logical_key))
+          )
+      )
+  `);
+  return result;
 }
 async function ensureCutoverState(config: StorageConfig, digest: string, phase: 'dual-write' | 'target' | 'rollback'): Promise<void> {
   const fingerprint = storageConfigFingerprint(config);
@@ -177,17 +213,29 @@ export async function commitCutover(manifest: MigrationManifestEntry[], config: 
 }
 
 
-async function restoreCutoverMappings(config: StorageConfig, digest: string): Promise<void> {
+export async function restoreCutoverMappings(config: StorageConfig, digest: string, database: PrismaClient = prisma): Promise<void> {
   const fingerprint = storageConfigFingerprint(config);
-  await prisma.$transaction(async (tx) => {
+  await database.$transaction(async (tx) => {
     const state = await tx.storageCutoverState.findUnique({ where: { id: 'default' } });
     if (!state || state.phase !== 'target' || state.providerFingerprint !== fingerprint || state.manifestSha256 !== digest) throw new Error('Rollback fence mismatch; refusing mapping restoration');
-    const rows = await tx.$queryRawUnsafe<Array<{ asset_id: string; rendition: string; provider: string; source_key: string | null; delivery_url: string }>>('SELECT r.asset_id, r.rendition, old.provider, old.source_key, old.delivery_url FROM asset_storage_replicas r JOIN asset_storage_replicas old ON old.asset_id=r.asset_id AND old.rendition=r.rendition AND old.generation=r.generation AND old.active=false WHERE r.generation=$1 AND r.active=true', state.generation);
+    // `old.logical_key` is the canonical portable key the asset held pre-cutover
+    // (commitCutover's snapshot row uses the same logical_key as its target
+    // row); `old.source_key` is the raw legacy provider key. These are
+    // frequently different strings (inventory rewrites storageKey to a clean
+    // canonical key while storageSourceKey keeps the original, possibly
+    // percent-encoded, provider path) and must be restored into their own
+    // distinct asset columns, not collapsed into one.
+    const rows = await tx.$queryRawUnsafe<Array<{ asset_id: string; rendition: string; provider: string; source_key: string | null; logical_key: string; delivery_url: string }>>('SELECT r.asset_id, r.rendition, old.provider, old.source_key, old.logical_key, old.delivery_url FROM asset_storage_replicas r JOIN asset_storage_replicas old ON old.asset_id=r.asset_id AND old.rendition=r.rendition AND old.generation=r.generation AND old.active=false WHERE r.generation=$1 AND r.active=true', state.generation);
     for (const row of rows) {
-      if (row.rendition === 'thumbnail') await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, thumbnailStorageKey: row.source_key, thumbnailStorageSourceKey: row.source_key, thumbnailUrl: row.delivery_url } });
-      else await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, storageKey: row.source_key, storageSourceKey: row.source_key, blobUrl: row.delivery_url } });
+      if (row.rendition === 'thumbnail') await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, thumbnailStorageKey: row.logical_key, thumbnailStorageSourceKey: row.source_key, thumbnailUrl: row.delivery_url } });
+      else await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, storageKey: row.logical_key, storageSourceKey: row.source_key, blobUrl: row.delivery_url } });
     }
-    await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=false WHERE generation=$1', state.generation);
+    // The pre-cutover snapshot row (generation=N, active=false) is the one
+    // just restored onto the asset above; reactivate exactly that row so the
+    // ledger's `active` flag agrees with the asset's restored fields, instead
+    // of leaving zero active replicas for this asset+rendition.
+    await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=true WHERE generation=$1 AND active=false', state.generation);
+    await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=false WHERE generation=$1 AND provider=$2', state.generation, config.provider);
     await tx.storageCutoverState.updateMany({ where: { id: 'default', phase: 'target', generation: state.generation, providerFingerprint: fingerprint, manifestSha256: digest }, data: { phase: 'rollback', rollbackAt: new Date(), updatedAt: new Date() } });
   });
 }

--- a/apps/web/scripts/storage-portability.ts
+++ b/apps/web/scripts/storage-portability.ts
@@ -218,24 +218,43 @@ export async function restoreCutoverMappings(config: StorageConfig, digest: stri
   await database.$transaction(async (tx) => {
     const state = await tx.storageCutoverState.findUnique({ where: { id: 'default' } });
     if (!state || state.phase !== 'target' || state.providerFingerprint !== fingerprint || state.manifestSha256 !== digest) throw new Error('Rollback fence mismatch; refusing mapping restoration');
-    // `old.logical_key` is the canonical portable key the asset held pre-cutover
-    // (commitCutover's snapshot row uses the same logical_key as its target
-    // row); `old.source_key` is the raw legacy provider key. These are
-    // frequently different strings (inventory rewrites storageKey to a clean
-    // canonical key while storageSourceKey keeps the original, possibly
-    // percent-encoded, provider path) and must be restored into their own
-    // distinct asset columns, not collapsed into one.
-    const rows = await tx.$queryRawUnsafe<Array<{ asset_id: string; rendition: string; provider: string; source_key: string | null; logical_key: string; delivery_url: string }>>('SELECT r.asset_id, r.rendition, old.provider, old.source_key, old.logical_key, old.delivery_url FROM asset_storage_replicas r JOIN asset_storage_replicas old ON old.asset_id=r.asset_id AND old.rendition=r.rendition AND old.generation=r.generation AND old.active=false WHERE r.generation=$1 AND r.active=true', state.generation);
+    // A target-phase thumbnail regeneration (regenerate-thumbnails cron) writes a
+    // fresh replica pair at its own unix-seconds generation without deactivating
+    // the cutover-generation pair it supersedes — the app runtime role has no
+    // UPDATE grant on this table (insert-only; see the asset_storage_replicas
+    // grants in stripe-ledger-bootstrap-post.sql), so it cannot deactivate
+    // anything itself. Restoring blindly from `state.generation` would therefore
+    // resurrect the stale pre-regeneration Vercel identity and leave the
+    // regenerated S3 replica active. Instead, for every asset+rendition this
+    // cutover touched (any row recorded at the cutover's own generation, i.e.
+    // `scope` below), find the *freshest* still-active target-provider replica
+    // for that asset+rendition — the cutover's own row when nothing regenerated
+    // it since, or a later regen's row when one did, since a regen's
+    // unix-seconds generation always outranks the small sequential cutover
+    // generation — and require its paired source-provider peer at that exact
+    // same generation (commitCutover and the regen cron always insert their pair
+    // together at one shared generation, opposite providers). The LEFT JOINs
+    // below surface a scoped asset+rendition with no active target row, or a
+    // target row with no paired peer, as NULLs rather than silently dropping it;
+    // either case fails the whole transaction closed instead of restoring a
+    // stale or mixed-generation mapping.
+    const rows = await tx.$queryRawUnsafe<Array<{ asset_id: string; rendition: string; target_generation: number | null; provider: string | null; source_key: string | null; logical_key: string | null; delivery_url: string | null; old_generation: number | null }>>('WITH scope AS (SELECT DISTINCT asset_id, rendition FROM asset_storage_replicas WHERE generation=$1), target AS (SELECT DISTINCT ON (t.asset_id, t.rendition) t.asset_id, t.rendition, t.generation FROM asset_storage_replicas t JOIN scope s ON s.asset_id=t.asset_id AND s.rendition=t.rendition WHERE t.provider=$2 AND t.active=true ORDER BY t.asset_id, t.rendition, t.generation DESC) SELECT s.asset_id, s.rendition, target.generation AS target_generation, old.provider, old.source_key, old.logical_key, old.delivery_url, old.generation AS old_generation FROM scope s LEFT JOIN target ON target.asset_id=s.asset_id AND target.rendition=s.rendition LEFT JOIN asset_storage_replicas old ON old.asset_id=target.asset_id AND old.rendition=target.rendition AND old.generation=target.generation AND old.provider<>$2', state.generation, config.provider);
     for (const row of rows) {
-      if (row.rendition === 'thumbnail') await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, thumbnailStorageKey: row.logical_key, thumbnailStorageSourceKey: row.source_key, thumbnailUrl: row.delivery_url } });
-      else await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, storageKey: row.logical_key, storageSourceKey: row.source_key, blobUrl: row.delivery_url } });
+      if (row.target_generation === null || row.provider === null) {
+        throw new Error('Rollback cannot find a complete provider-paired replica generation for ' + row.asset_id + '/' + row.rendition + '; refusing to restore a stale or mixed-generation mapping');
+      }
+      if (row.rendition === 'thumbnail') await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, thumbnailStorageKey: row.logical_key!, thumbnailStorageSourceKey: row.source_key, thumbnailUrl: row.delivery_url! } });
+      else await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, storageKey: row.logical_key!, storageSourceKey: row.source_key, blobUrl: row.delivery_url! } });
+      // Deactivate every generation of this asset+rendition — mirrors
+      // commitCutover's own blanket deactivate — then reactivate exactly the row
+      // just restored onto the asset above. This keeps the ledger's `active`
+      // flag single-valued and in agreement with the asset's columns regardless
+      // of how many un-deactivatable regen rows piled up since the cutover, and
+      // commits atomically with the asset-column restore above and the phase
+      // transition below (all inside this one transaction).
+      await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=false, updated_at=NOW() WHERE asset_id=$1 AND rendition=$2', row.asset_id, row.rendition);
+      await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=true, updated_at=NOW() WHERE asset_id=$1 AND rendition=$2 AND generation=$3 AND provider=$4', row.asset_id, row.rendition, row.old_generation, row.provider);
     }
-    // The pre-cutover snapshot row (generation=N, active=false) is the one
-    // just restored onto the asset above; reactivate exactly that row so the
-    // ledger's `active` flag agrees with the asset's restored fields, instead
-    // of leaving zero active replicas for this asset+rendition.
-    await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=true WHERE generation=$1 AND active=false', state.generation);
-    await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=false WHERE generation=$1 AND provider=$2', state.generation, config.provider);
     await tx.storageCutoverState.updateMany({ where: { id: 'default', phase: 'target', generation: state.generation, providerFingerprint: fingerprint, manifestSha256: digest }, data: { phase: 'rollback', rollbackAt: new Date(), updatedAt: new Date() } });
   });
 }


### PR DESCRIPTION
## Summary

Reimplements a fully-worked-out and verified storage-portability repair patch that was lost when the prior session's worktree died mid-edit before ever pushing (no branch/PR was ever created for it). Reconstructed from that session's saved transcript, verified against current master, and re-validated with fresh live evidence.

Fixes the confirmed-live blockers from the InvestigateBlockers audit (`agent://RepairStoragePortability.InvestigateBlockers`); all stale/false findings from that audit are left untouched.

## Changes

- **`lib/storage/object-store.ts`** — S3 PUT now signs and persists `x-amz-meta-sha256` as part of the SigV4 signed-header set. S3 and legacy Vercel Blob provider requests are bounded by a 30s `AbortSignal.timeout`, surfaced as a structured `"<operation> timed out after 30000ms"` error instead of a raw `DOMException`.
- **`lib/storage/permanent-delete.ts`** — `enqueueAssetReplicaCleanup` now fences any replica still referenced by another live asset (checked transactionally, via the replica ledger + raw legacy `Asset` columns) before enqueuing/deleting it. Closes the cutover multi-asset shared-key gap `commitCutover` explicitly models but deletion never fenced against.
- **`app/api/cron/regenerate-thumbnails/route.ts`** — the asset update and replica-ledger insert now run in one `prisma.$transaction`. The replica write is insert-only (the app runtime role has no UPDATE grant on `asset_storage_replicas`), using a unix-seconds `generation` sentinel so a pre-cutover regen correctly outranks stale rows in cutover's `ORDER BY generation DESC` source lookup — proven live (see below). The unique constraint `(assetId, rendition, generation, provider)` is left to throw and roll back the whole transaction on a same-second collision rather than silently dropping the ledger row via `skipDuplicates` (which would leak the new object on permanent delete).
- **`scripts/storage-portability.ts`** — `inventory()` now prunes only never-claimed (`'pending'`) migration-entry rows that no longer match any live asset's current keys, after a full re-seeding pass; in-flight/terminal rows are never touched. `restoreCutoverMappings` (rollback) now restores the canonical logical key and the raw legacy source key into their own distinct asset columns (was collapsing both onto the source key), and reactivates exactly the pre-cutover replica row it just restored (was leaving zero active replicas after rollback).

## Design notes / residual risk

- **Generation sentinel safety**: `generation` is Prisma `Int` (Postgres `int4`); unix-seconds fits until 2038, well past any realistic replacement horizon for this one-time migration tool. Cutover's own generation counter (`state.generation + 1`) stays small (increments once per cutover/rollback cycle), so it can never collide with or exceed a unix-seconds sentinel in practice. The app runtime role's column-restricted SELECT grant on `asset_storage_replicas` excludes `generation`, so reading a true next value isn't available — the sentinel is the only viable option without a grant change.
- **Fence atomicity**: the shared-reference check and the outbox enqueue decision run inside the same DB transaction (atomic with each other). The physical provider delete happens after that transaction commits, same as every other consumer of this outbox pattern — an unavoidable consequence of a network call not being transactional. The residual TOCTOU window (a new asset created against a soon-to-be-deleted shared key between commit and physical delete) only exists for the already-rare, operator-only cutover multi-asset scenario; normal uploads structurally can't share a key. Not solved here as a new locking mechanism — flagged as a pre-existing, shared architectural property of the outbox pattern, out of scope for this patch.

## Testing

- 50/50 focused mocked tests green: `storage-contract`, `cleanup-outbox`, `assets-permanent-delete`, `regenerate-thumbnails`, `purge-deleted-assets`, `storage-portability` (script contracts).
- 3/3 live pgvector integration tests green (`storage-portability-postgres.test.ts`, fresh `pgvector/pgvector:pg15` container): the existing cutover test, a rollback test (distinct key-column restoration + correct replica reactivation), and a new test proving the regen→cutover generation-ordering mechanism end-to-end — a pre-cutover regenerated thumbnail replica (unix-seconds generation) is correctly snapshotted by cutover instead of the stale upload-time row (generation 0).
- `web` typecheck clean.
- Not run: full lint/build/project-wide test suite (per instruction — parent owns exact CI).

## Scope

sploot-blob-portability (Powder card, run-BjexNcZamBwT). Auto-merge is OFF; this PR is ready for review, not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented permanent deletion from removing storage still shared by another active asset.
  - Improved thumbnail regeneration reliability, including cleanup of newly uploaded files when updates fail.
  - Strengthened storage migration rollback to restore the correct replica generation and fail safely when mappings are incomplete.
  - Cleaned up stale pending migration records without affecting active or completed work.

- **Improvements**
  - Added 30-second timeouts and clearer error messages for storage operations.
  - Added checksum metadata to S3-compatible uploads for improved integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->