### PR TITLE
fix(storage): repair post-merge CodeRabbit findings on PR #308 (sploot-blob-portability)

### DIFF
--- a/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
+++ b/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
@@ -9,10 +9,29 @@ vi.mock('next/headers', () => ({
   headers: () => mockHeaders(),
 }));
 
+// Spy on the observability logger's logError to observe structured error
+// signals, while keeping every other export (including withTraceId, used by
+// withObservability) real.
+const mockLogError = vi.fn();
+vi.mock('@/lib/observability-logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/observability-logger')>();
+  return {
+    ...actual,
+    logger: {
+      logInfo: actual.logger.logInfo.bind(actual.logger),
+      logError: (...args: unknown[]) => mockLogError(...args),
+      logTiming: actual.logger.logTiming.bind(actual.logger),
+      getTraceId: actual.logger.getTraceId.bind(actual.logger),
+    },
+  };
+});
+
 // Mock lib/db
 const mockTx = {
   asset: { update: vi.fn() },
   assetStorageReplica: { createMany: vi.fn() },
+  $queryRawUnsafe: vi.fn(),
+  $executeRawUnsafe: vi.fn(),
 };
 const mockPrisma = {
   asset: {
@@ -101,6 +120,11 @@ describe('/api/cron/regenerate-thumbnails', () => {
     mockTx.asset.update.mockResolvedValue({});
     mockTx.assetStorageReplica.createMany.mockResolvedValue({ count: 1 });
     mockPrisma.$executeRawUnsafe.mockResolvedValue(1);
+    // Not shared by default: the old-thumbnail/orphaned-replica
+    // shared-reference fence check (hasLiveSharedReference) resolves false
+    // unless a test explicitly overrides it.
+    mockTx.$queryRawUnsafe.mockResolvedValue([{ shared: false }]);
+    mockTx.$executeRawUnsafe.mockResolvedValue(1);
   });
 
   it('rejects requests without the cron secret', async () => {
@@ -210,7 +234,7 @@ describe('/api/cron/regenerate-thumbnails', () => {
     expect(body.nextCursor).toBe('asset-2'); // third candidate signals more work
   });
 
-  it('prefers the raw legacy source key over the inventoried logical key when recording an old-thumbnail cleanup failure', async () => {
+  it('prefers the raw legacy source key over the inventoried logical key when enqueuing an old-thumbnail cleanup', async () => {
     const inventoriedAsset = {
       ...baseAsset,
       storageProvider: 'vercel',
@@ -233,14 +257,48 @@ describe('/api/cron/regenerate-thumbnails', () => {
     // The replica ledger write and asset update still committed before the
     // best-effort old-object delete failed, so the new thumbnail is not lost.
     expect(mockTx.assetStorageReplica.createMany).toHaveBeenCalledTimes(1);
-    expect(mockPrisma.$executeRawUnsafe).toHaveBeenCalledWith(
+    // Durably enqueued (fenced, not shared) through the shared outbox seam
+    // BEFORE the best-effort delete was attempted — using the raw legacy
+    // source key, not the inventoried logical key.
+    expect(mockTx.$executeRawUnsafe).toHaveBeenCalledWith(
       expect.any(String),
       'asset-1',
       'vercel',
       'user/raw-legacy-thumb.png',
       'https://blob.example/original-thumb.png',
-      'provider outage',
+      'delete-thumbnail',
     );
+  });
+
+  it('does not physically delete an old thumbnail still shared by another live asset, and does not enqueue it either', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const legacySquareThumb = await png(256, 256);
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce(fetchResponse(legacySquareThumb))
+      .mockResolvedValueOnce(fetchResponse(original));
+    // A second live asset still references this exact legacy thumbnail
+    // URL/key (dedup/cutover multi-asset scenario) — the shared-reference
+    // fence must refuse both the enqueue and the physical delete.
+    mockTx.$queryRawUnsafe.mockResolvedValue([{ shared: true }]);
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.regenerated).toBe(1);
+    expect(body.failed).toBe(0);
+    // The new thumbnail still commits normally.
+    expect(mockTx.assetStorageReplica.createMany).toHaveBeenCalledTimes(1);
+    // Deterministic proof of the fence: the old shared thumbnail is never
+    // physically deleted...
+    expect(mockDel).not.toHaveBeenCalledWith('https://blob.example/original-thumb.png');
+    // ...and never durably enqueued for cleanup either, since it is still
+    // legitimately referenced by the sibling asset.
+    const oldThumbInserts = (mockTx.$executeRawUnsafe as ReturnType<typeof vi.fn>).mock.calls.filter((call) =>
+      String(call[0]).includes('INSERT INTO storage_cleanup_outbox') && call[4] === 'delete-thumbnail',
+    );
+    expect(oldThumbInserts).toHaveLength(0);
   });
 
   it('preserves the original transaction error and durably enqueues the orphaned replica when cleanup-after-failure also fails', async () => {
@@ -264,16 +322,58 @@ describe('/api/cron/regenerate-thumbnails', () => {
     expect(body.failures[0].reason).toBe('permission denied');
     expect(body.failures[0].reason).not.toContain('cleanup provider outage');
     // The orphaned new replica that could not be deleted must be durably
-    // enqueued through the existing storage_cleanup_outbox seam — never
-    // silently dropped as a best-effort-only leak.
-    expect(mockPrisma.$executeRawUnsafe).toHaveBeenCalledWith(
+    // enqueued through the same shared-reference-aware outbox seam
+    // old-thumbnail cleanup uses — never silently dropped as a
+    // best-effort-only leak.
+    expect(mockTx.$executeRawUnsafe).toHaveBeenCalledWith(
       expect.any(String),
       'asset-1',
       'vercel',
       'user/original-thumb-new.png',
       'https://blob.example/original-thumb-new.png',
-      'cleanup provider outage',
+      'delete-thumbnail',
     );
+    // Cleanup succeeded via the durable outbox insert, so no double-failure
+    // signal was needed.
+    expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it('emits an explicit structured signal (never masking the original error, never logging the delivery URL) when cleanup AND the durable outbox insert both fail', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const legacySquareThumb = await png(256, 256);
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce(fetchResponse(legacySquareThumb))
+      .mockResolvedValueOnce(fetchResponse(original));
+    mockTx.assetStorageReplica.createMany.mockRejectedValueOnce(new Error('permission denied'));
+    // Both the provider cleanup AND the durable outbox insert fail: the
+    // just-uploaded replica is now leaked with no retry path recorded
+    // anywhere unless an explicit signal is emitted.
+    mockDel.mockRejectedValueOnce(new Error('cleanup provider outage'));
+    mockTx.$executeRawUnsafe.mockRejectedValueOnce(new Error('outbox insert failed'));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(body.failed).toBe(1);
+    // The original transaction failure is still what surfaces to the caller.
+    expect(body.failures[0].reason).toBe('permission denied');
+    expect(body.failures[0].reason).not.toContain('outbox insert failed');
+    // An explicit structured signal was emitted through the shared
+    // logger/Canary convention for the now-unrecorded leak.
+    expect(mockLogError).toHaveBeenCalledTimes(1);
+    const [context, error, metadata] = mockLogError.mock.calls[0];
+    expect(context).toBe('storage.regenerate-thumbnails.orphaned-replica-leak');
+    expect((error as Error).message).toBe('outbox insert failed');
+    expect(metadata).toMatchObject({
+      assetId: 'asset-1',
+      provider: 'vercel',
+      key: 'user/original-thumb-new.png',
+      cleanupError: 'cleanup provider outage',
+      originalError: 'permission denied',
+    });
+    // Never log the delivery URL alongside the leak signal.
+    expect(JSON.stringify(metadata)).not.toContain('https://blob.example/original-thumb-new.png');
   });
 
   it('rolls back the asset update when the replica ledger write fails, and cleans up the newly uploaded object', async () => {

--- a/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
+++ b/apps/web/__tests__/api/cron/regenerate-thumbnails.test.ts
@@ -243,6 +243,39 @@ describe('/api/cron/regenerate-thumbnails', () => {
     );
   });
 
+  it('preserves the original transaction error and durably enqueues the orphaned replica when cleanup-after-failure also fails', async () => {
+    mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
+    const legacySquareThumb = await png(256, 256);
+    const original = await png(800, 1000);
+    fetchMock
+      .mockResolvedValueOnce(fetchResponse(legacySquareThumb))
+      .mockResolvedValueOnce(fetchResponse(original));
+    mockTx.assetStorageReplica.createMany.mockRejectedValueOnce(new Error('permission denied'));
+    // The cleanup attempt for the just-uploaded orphan ALSO fails (e.g. a
+    // provider outage right after the ledger write failed).
+    mockDel.mockRejectedValueOnce(new Error('cleanup provider outage'));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(body.failed).toBe(1);
+    // The ORIGINAL transaction error must survive — never replaced by the
+    // cleanup failure that happened while handling it.
+    expect(body.failures[0].reason).toBe('permission denied');
+    expect(body.failures[0].reason).not.toContain('cleanup provider outage');
+    // The orphaned new replica that could not be deleted must be durably
+    // enqueued through the existing storage_cleanup_outbox seam — never
+    // silently dropped as a best-effort-only leak.
+    expect(mockPrisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.any(String),
+      'asset-1',
+      'vercel',
+      'user/original-thumb-new.png',
+      'https://blob.example/original-thumb-new.png',
+      'cleanup provider outage',
+    );
+  });
+
   it('rolls back the asset update when the replica ledger write fails, and cleans up the newly uploaded object', async () => {
     mockPrisma.asset.findMany.mockResolvedValue([baseAsset]);
     const legacySquareThumb = await png(256, 256);

--- a/apps/web/__tests__/integration/storage-portability-postgres.test.ts
+++ b/apps/web/__tests__/integration/storage-portability-postgres.test.ts
@@ -402,4 +402,102 @@ describeWithDatabase('storage portability PostgreSQL authority', () => {
     expect(afterReplicas).toEqual(beforeReplicas);
     expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual(beforeState);
   });
+
+
+  it('fails closed and leaves the database unchanged when the state fence is lost immediately before the rollback phase-advance update lands', async () => {
+    previousState = await admin.storageCutoverState.findUnique({ where: { id: 'default' } });
+    const config = createStorageConfig({
+      provider: 's3',
+      phase: 'dual-write',
+      endpoint: 'https://objects.example.test',
+      publicUrlBase: 'https://objects.example.test',
+      bucket: 'sploot',
+      accessKeyId: 'integration-id',
+      secretAccessKey: 'integration-secret',
+    });
+    const manifest = [
+      { logicalKey: 'assets/storage-portability-lost-fence/original.png', sourceKey: 'uploads/original.png', rendition: 'original' as const, sourceProvider: 'vercel', size: 3, sha256: 'a'.repeat(64), contentType: 'image/png' },
+      { logicalKey: 'assets/storage-portability-lost-fence/thumb.png', sourceKey: 'uploads/thumb.png', rendition: 'thumbnail' as const, sourceProvider: 'vercel', size: 3, sha256: 'b'.repeat(64), contentType: 'image/png' },
+    ];
+    const digest = manifestSha256(manifest);
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/original.png',
+      thumbnailUrl: 'https://source.public.blob.vercel-storage.com/uploads/thumb.png',
+      pathname: 'uploads/original.png',
+      thumbnailPath: 'uploads/thumb.png',
+      storageProvider: 'vercel',
+      storageKey: manifest[0]!.logicalKey,
+      storageSourceKey: manifest[0]!.sourceKey,
+      thumbnailStorageKey: manifest[1]!.logicalKey,
+      thumbnailStorageSourceKey: manifest[1]!.sourceKey,
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-lost-fence-checksum',
+    } });
+    await admin.storageCutoverState.create({ data: { id: 'default', phase: 'dual-write', generation: 0, providerFingerprint: storageConfigFingerprint(config), manifestSha256: digest } });
+
+    await commitCutover(manifest, config, digest, admin);
+
+    const beforeAsset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: {
+      storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true,
+      thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailUrl: true,
+    } });
+    const beforeReplicas = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { generation: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, generation: true, active: true } });
+    const beforeState = await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } });
+
+    // Simulate a concurrent racer moving the fence between
+    // restoreCutoverMappings' own initial read and its terminal
+    // phase-advance update: wrap the real Postgres transaction client so
+    // every statement executes for real EXCEPT the final
+    // storageCutoverState.updateMany, whose result is forced to
+    // { count: 0 } as if a concurrent writer had already claimed the row.
+    // Every asset/replica mutation inside the same transaction still runs
+    // against real Postgres, so this proves the WHOLE transaction — not
+    // just the fence-check statement — rolls back when the count-guard
+    // fires, exactly as commitCutover's sibling guard already does.
+    const fencedAdmin = {
+      $transaction: (fn: (tx: unknown) => Promise<unknown>) => admin.$transaction((tx) => {
+        const realUpdateMany = tx.storageCutoverState.updateMany.bind(tx.storageCutoverState);
+        const wrappedCutoverState = new Proxy(tx.storageCutoverState, {
+          get(target, prop, receiver) {
+            if (prop === 'updateMany') {
+              return async (...args: Parameters<typeof realUpdateMany>) => {
+                // A real racer would have already updated the row (0 further
+                // matches); we simulate that outcome directly rather than
+                // actually running a second concurrent transaction.
+                void args;
+                return { count: 0 };
+              };
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        });
+        const wrappedTx = new Proxy(tx, {
+          get(target, prop, receiver) {
+            if (prop === 'storageCutoverState') return wrappedCutoverState;
+            return Reflect.get(target, prop, receiver);
+          },
+        });
+        return fn(wrappedTx);
+      }),
+    } as unknown as typeof admin;
+
+    await expect(restoreCutoverMappings(config, digest, fencedAdmin)).rejects.toThrow(/[Rr]ollback fence lost/);
+
+    // Fails closed: the asset columns, every replica row, and the cutover
+    // state itself must be byte-for-byte unchanged — the lost fence must
+    // roll back the mapping-restoration work done earlier in the SAME
+    // transaction, not just skip the terminal phase write.
+    const afterAsset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: {
+      storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true,
+      thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailUrl: true,
+    } });
+    expect(afterAsset).toEqual(beforeAsset);
+    const afterReplicas = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { generation: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, generation: true, active: true } });
+    expect(afterReplicas).toEqual(beforeReplicas);
+    expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual(beforeState);
+  });
 });

--- a/apps/web/__tests__/integration/storage-portability-postgres.test.ts
+++ b/apps/web/__tests__/integration/storage-portability-postgres.test.ts
@@ -1,7 +1,8 @@
+import { randomBytes } from 'node:crypto';
 import { PrismaClient } from '@prisma/client';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createStorageConfig, storageConfigFingerprint } from '@/lib/storage/config';
-import { commitCutover, manifestSha256, restoreCutoverMappings } from '@/scripts/storage-portability';
+import { commitCutover, inventory, manifestSha256, restoreCutoverMappings } from '@/scripts/storage-portability';
 
 const hasAuthorityDatabase = Boolean(process.env.DATABASE_URL && process.env.STRIPE_LEDGER_ADMIN_DATABASE_URL);
 const describeWithDatabase = hasAuthorityDatabase ? describe.sequential : describe.skip;
@@ -499,5 +500,167 @@ describeWithDatabase('storage portability PostgreSQL authority', () => {
     const afterReplicas = await admin.assetStorageReplica.findMany({ where: { assetId }, orderBy: [{ rendition: 'asc' }, { generation: 'asc' }, { provider: 'asc' }], select: { rendition: true, provider: true, generation: true, active: true } });
     expect(afterReplicas).toEqual(beforeReplicas);
     expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual(beforeState);
+  });
+});
+
+describeWithDatabase('storage portability restricted sploot_storage_operator authority', () => {
+  let admin: PrismaClient;
+  let operator: PrismaClient;
+  let operatorPassword: string;
+  const userId = 'storage-portability-operator-user';
+  const assetId = 'storage-portability-operator-asset';
+
+  beforeAll(async () => {
+    admin = new PrismaClient({ datasources: { db: { url: process.env.STRIPE_LEDGER_ADMIN_DATABASE_URL! } } });
+    // Grant LOGIN for this test run only, so the connection below
+    // authenticates AS sploot_storage_operator over the wire -- proving the
+    // grants under real Postgres privilege enforcement, never a SET
+    // ROLE-from-superuser shortcut (which would retain the superuser's
+    // bypass) and never the STRIPE_LEDGER_ADMIN_DATABASE_URL superuser
+    // connection every other test in this file uses (that bypasses ALL
+    // privilege checks regardless of grants, which is exactly how the
+    // missing grant on `assets` stayed invisible).
+    operatorPassword = randomBytes(32).toString('hex');
+    await admin.$executeRawUnsafe(`ALTER ROLE sploot_storage_operator LOGIN PASSWORD '${operatorPassword}'`);
+    const operatorUrl = new URL(process.env.STRIPE_LEDGER_ADMIN_DATABASE_URL!);
+    operatorUrl.username = 'sploot_storage_operator';
+    operatorUrl.password = operatorPassword;
+    operator = new PrismaClient({ datasources: { db: { url: operatorUrl.toString() } } });
+  });
+
+  afterAll(async () => {
+    await operator.$disconnect();
+    await admin.$executeRawUnsafe('ALTER ROLE sploot_storage_operator NOLOGIN').catch(() => undefined);
+    await admin.$disconnect();
+  });
+
+  afterEach(async () => {
+    await admin.asset.deleteMany({ where: { id: assetId } });
+    await admin.user.deleteMany({ where: { id: userId } });
+    await admin.storageMigrationEntry.deleteMany({ where: { logicalKey: { startsWith: 'assets/storage-portability-operator' } } });
+    await admin.storageInventoryState.deleteMany({ where: { id: 'legacy-assets' } });
+    await admin.storageCutoverState.deleteMany({ where: { id: 'default' } });
+  });
+
+  it('runs as the real non-superuser, non-inheriting sploot_storage_operator identity -- never a superuser bypass', async () => {
+    const identity = await operator.$queryRawUnsafe<Array<{ sessionUser: string; isSuperuser: boolean; inherits: boolean }>>(
+      'SELECT current_user AS "sessionUser", rolsuper AS "isSuperuser", rolinherit AS "inherits" FROM pg_roles WHERE rolname = current_user',
+    );
+    expect(identity[0]).toEqual({ sessionUser: 'sploot_storage_operator', isSuperuser: false, inherits: false });
+  });
+
+  it('denies every unrelated assets column and the table broadly, while the enumerated storage-identity columns remain granted', async () => {
+    const tableGrants = await admin.$queryRawUnsafe<Array<{ hasSelect: boolean; hasUpdate: boolean; hasInsert: boolean; hasDelete: boolean }>>(
+      `SELECT has_table_privilege('sploot_storage_operator','public.assets','SELECT') AS "hasSelect", has_table_privilege('sploot_storage_operator','public.assets','UPDATE') AS "hasUpdate", has_table_privilege('sploot_storage_operator','public.assets','INSERT') AS "hasInsert", has_table_privilege('sploot_storage_operator','public.assets','DELETE') AS "hasDelete"`,
+    );
+    // No broad table-level grant -- only the enumerated columns below.
+    expect(tableGrants[0]).toEqual({ hasSelect: false, hasUpdate: false, hasInsert: false, hasDelete: false });
+
+    const deniedColumns = await admin.$queryRawUnsafe<Array<{ allDenied: boolean }>>(
+      `SELECT bool_and(NOT has_column_privilege('sploot_storage_operator', 'public.assets', column_name, 'SELECT') AND NOT has_column_privilege('sploot_storage_operator', 'public.assets', column_name, 'UPDATE')) AS "allDenied"
+       FROM (VALUES ('favorite'), ('checksum_sha256'), ('phash'), ('share_slug'), ('owner_user_id'), ('size'), ('width'), ('height'), ('shuffle_key'), ('createdAt')) AS unrelated(column_name)`,
+    );
+    expect(deniedColumns[0]?.allDenied).toBe(true);
+
+    const grantedColumns = await admin.$queryRawUnsafe<Array<{ allGranted: boolean }>>(
+      `SELECT bool_and(has_column_privilege('sploot_storage_operator', 'public.assets', column_name, 'SELECT')) AS "allGranted"
+       FROM (VALUES ('id'), ('deleted_at'), ('pathname'), ('mime'), ('storage_provider'), ('storage_key'), ('storage_source_key'), ('blob_url'), ('thumbnail_storage_key'), ('thumbnail_storage_source_key'), ('thumbnail_path'), ('thumbnail_url')) AS granted(column_name)`,
+    );
+    expect(grantedColumns[0]?.allGranted).toBe(true);
+
+    // "updatedAt" is UPDATE-granted (Prisma's @updatedAt auto-timestamp
+    // appends it to every Asset.update() SET clause regardless of what the
+    // caller writes) but deliberately NOT SELECT-granted -- it is never
+    // read by inventory/commitCutover/restoreCutoverMappings.
+    const updatedAtGrants = await admin.$queryRawUnsafe<Array<{ hasUpdate: boolean; hasSelect: boolean }>>(
+      `SELECT has_column_privilege('sploot_storage_operator', 'public.assets', 'updatedAt', 'UPDATE') AS "hasUpdate", has_column_privilege('sploot_storage_operator', 'public.assets', 'updatedAt', 'SELECT') AS "hasSelect"`,
+    );
+    expect(updatedAtGrants[0]).toEqual({ hasUpdate: true, hasSelect: false });
+
+    // A denied column really fails over the literal restricted connection,
+    // not just in the catalog: no has_column_privilege false negative.
+    await expect(operator.$queryRawUnsafe('SELECT favorite FROM assets LIMIT 1')).rejects.toThrow(/permission denied/i);
+    await expect(operator.$queryRawUnsafe("UPDATE assets SET favorite = true WHERE id = 'nonexistent'")).rejects.toThrow(/permission denied/i);
+  });
+
+  it('inventory reaches and commits under the real restricted operator role', async () => {
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/operator-original.png',
+      pathname: 'uploads/operator-original.png',
+      storageProvider: 'vercel',
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-operator-checksum',
+    } });
+    const originalBytes = Buffer.from('png-bytes-for-operator-grant-proof');
+    const fetchMock = vi.fn(async () => new Response(originalBytes, { status: 200, headers: { 'content-length': String(originalBytes.byteLength) } }));
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      // The real requireOperatorAuthority() gate, the assets SELECT/UPDATE
+      // grants, and the storage_migration_entries/storage_inventory_state
+      // CRUD grants ALL run for real against Postgres as literal
+      // sploot_storage_operator -- the exact combination that was
+      // previously proven only under the STRIPE_LEDGER_ADMIN_DATABASE_URL
+      // superuser connection everywhere else in this file.
+      await inventory(10, undefined, operator);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const updated = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: { storageKey: true, storageSourceKey: true, storageSize: true, storageSha256: true } });
+    expect(updated.storageSourceKey).toBe('uploads/operator-original.png');
+    expect(updated.storageSize).toBe(originalBytes.byteLength);
+    expect(updated.storageSha256).toMatch(/^[a-f0-9]{64}$/);
+    const migrationEntry = await admin.storageMigrationEntry.findFirst({ where: { sourceKey: 'uploads/operator-original.png' } });
+    expect(migrationEntry).not.toBeNull();
+    const inventoryState = await admin.storageInventoryState.findUnique({ where: { id: 'legacy-assets' } });
+    expect(inventoryState?.cursor).toBe(assetId);
+  });
+
+  it('commitCutover and restoreCutoverMappings commit under the real restricted operator role, not superuser', async () => {
+    const config = createStorageConfig({
+      provider: 's3',
+      phase: 'dual-write',
+      endpoint: 'https://objects.example.test',
+      publicUrlBase: 'https://objects.example.test',
+      bucket: 'sploot',
+      accessKeyId: 'integration-id',
+      secretAccessKey: 'integration-secret',
+    });
+    const manifest = [
+      { logicalKey: 'assets/storage-portability-operator/original.png', sourceKey: 'uploads/operator-original.png', rendition: 'original' as const, sourceProvider: 'vercel', size: 3, sha256: 'a'.repeat(64), contentType: 'image/png' },
+    ];
+    const digest = manifestSha256(manifest);
+    await admin.user.create({ data: { id: userId, email: userId + '@example.test' } });
+    await admin.asset.create({ data: {
+      id: assetId,
+      ownerUserId: userId,
+      blobUrl: 'https://source.public.blob.vercel-storage.com/uploads/operator-original.png',
+      pathname: 'uploads/operator-original.png',
+      storageProvider: 'vercel',
+      storageKey: manifest[0]!.logicalKey,
+      storageSourceKey: manifest[0]!.sourceKey,
+      mime: 'image/png',
+      size: 3,
+      checksumSha256: 'storage-portability-operator-cutover-checksum',
+    } });
+    await admin.storageCutoverState.create({ data: { id: 'default', phase: 'dual-write', generation: 0, providerFingerprint: storageConfigFingerprint(config), manifestSha256: digest } });
+
+    // Both calls take `operator` (the literal restricted connection) as
+    // their `database` param instead of every other test's `admin`
+    // (superuser) -- this is the one substitution that turns "passes under
+    // a mocked sessionUser / superuser fallback" into a real proof.
+    await commitCutover(manifest, config, digest, operator);
+    expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual({ phase: 'target', generation: 1 });
+
+    await restoreCutoverMappings(config, digest, operator);
+    const asset = await admin.asset.findUniqueOrThrow({ where: { id: assetId }, select: { storageProvider: true, storageKey: true, storageSourceKey: true, blobUrl: true } });
+    expect(asset.storageProvider).toBe('vercel');
+    expect(asset.storageKey).toBe(manifest[0]!.logicalKey);
+    expect(asset.blobUrl).toBe('https://source.public.blob.vercel-storage.com/uploads/operator-original.png');
+    expect(await admin.storageCutoverState.findUnique({ where: { id: 'default' }, select: { phase: true, generation: true } })).toEqual({ phase: 'rollback', generation: 1 });
   });
 });

--- a/apps/web/__tests__/scripts/storage-portability.test.ts
+++ b/apps/web/__tests__/scripts/storage-portability.test.ts
@@ -1,5 +1,48 @@
-import { describe, expect, it, vi } from 'vitest';
-import { inventoryLogicalKey, manifestSha256, pruneStaleMigrationEntries, renditionMime } from '../../scripts/storage-portability';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockQueryRaw = vi.fn();
+const mockExecuteRaw = vi.fn();
+const mockAssetFindMany = vi.fn();
+const mockAssetUpdate = vi.fn();
+const mockInventoryStateUpsert = vi.fn();
+const mockMigrationEntryFindMany = vi.fn();
+
+vi.mock('../../lib/db', () => ({
+  prisma: {
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
+    asset: {
+      findMany: (...args: unknown[]) => mockAssetFindMany(...args),
+      update: (...args: unknown[]) => mockAssetUpdate(...args),
+    },
+    storageInventoryState: { upsert: (...args: unknown[]) => mockInventoryStateUpsert(...args) },
+    storageMigrationEntry: { findMany: (...args: unknown[]) => mockMigrationEntryFindMany(...args) },
+  },
+}));
+
+const mockGetSourceKey = vi.fn();
+vi.mock('../../lib/storage/object-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/storage/object-store')>();
+  class MockVercelObjectStore {
+    getSourceKey(...args: unknown[]) {
+      return mockGetSourceKey(...args);
+    }
+  }
+  return {
+    ...actual,
+    VercelObjectStore: MockVercelObjectStore,
+  };
+});
+
+const mockSeedMigrationManifest = vi.fn();
+vi.mock('../../lib/storage/prisma-journal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/storage/prisma-journal')>();
+  return { ...actual, seedMigrationManifest: (...args: unknown[]) => mockSeedMigrationManifest(...args) };
+});
+
+vi.mock('../../lib/storage/cleanup-outbox', () => ({ processStorageCleanup: vi.fn() }));
+
+import { inventory, inventoryLogicalKey, manifestSha256, pruneStaleMigrationEntries, renditionMime } from '../../scripts/storage-portability';
 
 describe('storage portability CLI contracts', () => {
   it('maps legacy keys deterministically without mutating source identity', () => {
@@ -47,5 +90,63 @@ describe('storage portability CLI contracts', () => {
     expect(sql).toContain("e.rendition = 'thumbnail'");
     expect(sql).toContain('a.thumbnail_storage_source_key = e.source_key');
     expect(sql).toContain('a.thumbnail_storage_key = e.logical_key');
+  });
+});
+
+describe('storage portability inventory cursor-resume safety', () => {
+  const authorizedRole = [{ sessionUser: 'sploot_storage_operator', isSuperuser: false }];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockQueryRaw.mockResolvedValue(authorizedRole);
+    mockAssetUpdate.mockResolvedValue({});
+    mockInventoryStateUpsert.mockResolvedValue({});
+    mockSeedMigrationManifest.mockResolvedValue(undefined);
+    mockExecuteRaw.mockResolvedValue(0);
+    mockMigrationEntryFindMany.mockResolvedValue([]);
+    mockGetSourceKey.mockResolvedValue({ body: Buffer.from('legacy-bytes'), metadata: { contentType: 'image/png' } });
+  });
+
+  function asset(id: string, sourceKey: string) {
+    return {
+      id,
+      storageKey: null,
+      storageSourceKey: sourceKey,
+      pathname: sourceKey,
+      thumbnailStorageKey: null,
+      thumbnailStorageSourceKey: null,
+      thumbnailPath: null,
+      thumbnailUrl: null,
+      mime: 'image/png',
+    };
+  }
+
+  it('prunes stale entries and emits the full durable manifest only after a fresh, cursor-less pass', async () => {
+    mockAssetFindMany
+      .mockResolvedValueOnce([asset('asset-1', 'uploads/a.png')])
+      .mockResolvedValueOnce([]);
+
+    await inventory(10);
+
+    // A fresh (cursor-less) pass re-seeds every live asset from the start,
+    // so it — and only it — is safe to prune from and treat as the
+    // authoritative full manifest.
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(mockMigrationEntryFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('never prunes and never emits the full durable manifest when resuming from a cursor', async () => {
+    mockAssetFindMany
+      .mockResolvedValueOnce([asset('asset-2', 'uploads/b.png')])
+      .mockResolvedValueOnce([]);
+
+    await inventory(10, 'asset-1');
+
+    // A cursor-resumed pass only re-seeds a SUFFIX of the live asset set —
+    // it must never be trusted as complete. Pruning and the durable
+    // full-manifest emission are gated on a subsequent fresh, cursor-less
+    // pass; a resumed run just seeds and stops.
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+    expect(mockMigrationEntryFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/cron/regenerate-thumbnails/route.ts
+++ b/apps/web/app/api/cron/regenerate-thumbnails/route.ts
@@ -8,6 +8,7 @@ import { withObservability } from '@/lib/with-observability';
 import { logger } from '@/lib/observability-logger';
 import { ConfiguredStorageWriter, bodyToBuffer, ObjectNotFoundError } from '@/lib/storage/object-store';
 import { storageConfigFromEnv, storageConfigFingerprint } from '@/lib/storage/config';
+import { enqueueReplicaCleanup, markReplicaCleanupDone } from '@/lib/storage/permanent-delete';
 
 /**
  * GET /api/cron/regenerate-thumbnails?limit=25&cursor=<assetId>
@@ -32,10 +33,6 @@ import { storageConfigFromEnv, storageConfigFingerprint } from '@/lib/storage/co
 const ASPECT_TOLERANCE = 0.02;
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
-
-async function recordThumbnailCleanupFailure(assetId: string, provider: string, key: string, url: string, error: string): Promise<void> {
-  await prisma.$executeRawUnsafe(`INSERT INTO "storage_cleanup_outbox" ("id", "asset_id", "provider", "key", "url", "action", "status", "last_error", "updated_at") VALUES (gen_random_uuid()::text, $1, $2, $3, $4, 'delete-thumbnail', 'pending', $5, NOW())`, assetId, provider, key, url, error);
-}
 
 const SUPPORTED_THUMBNAIL_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
 
@@ -227,21 +224,56 @@ async function getHandler(request: NextRequest) {
           const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
           for (const replica of newReplicas) {
             try {
-              await recordThumbnailCleanupFailure(asset.id, replica.provider, replica.key, replica.url, cleanupMessage);
-            } catch {
-              // Best-effort enqueue; the original transaction error below is
-              // always what surfaces to the caller regardless.
+              // Reuse the same shared-reference-aware outbox seam
+              // old-thumbnail cleanup uses below, rather than a bespoke
+              // insert, so this orphan is retried by the same worker.
+              await prisma.$transaction((tx) => enqueueReplicaCleanup(tx, asset.id, replica, 'delete-thumbnail'));
+            } catch (enqueueError) {
+              // Both the provider cleanup AND the durable outbox insert
+              // failed: the just-uploaded object is now leaked with no
+              // retry path recorded anywhere. This must never mask
+              // `error` (thrown below, unchanged below) but it must also
+              // never be silent — emit one explicit structured signal
+              // through the shared logger/Canary convention. Never log the
+              // delivery URL (provider URLs may carry signed query
+              // parameters); key/provider/assetId are enough to locate it.
+              logger.logError('storage.regenerate-thumbnails.orphaned-replica-leak', enqueueError instanceof Error ? enqueueError : new Error(String(enqueueError)), {
+                assetId: asset.id,
+                provider: replica.provider,
+                key: replica.key,
+                cleanupError: cleanupMessage,
+                originalError: error instanceof Error ? error.message : String(error),
+              });
             }
           }
         }
         throw error;
       }
-      try {
-        await storage.deleteUrl(oldThumbUrl);
-      } catch (error) {
-        await recordThumbnailCleanupFailure(asset.id, oldThumb.provider, oldThumb.key, oldThumb.url, error instanceof Error ? error.message : String(error));
-        throw error;
+      // Route the old thumbnail through the same shared-reference-aware
+      // outbox seam permanent-delete uses: a legacy dedup/cutover asset can
+      // still share this exact URL/key with another live asset, and
+      // deleting it out from under that sibling would break it
+      // deterministically. enqueueReplicaCleanup durably enqueues (fenced,
+      // inside its own transaction) BEFORE the best-effort physical
+      // attempt, so even an unshared old thumbnail whose immediate delete
+      // fails still reaches durable cleanup/retry via process-storage-cleanup.
+      const oldThumbCleanupEnqueued = await prisma.$transaction((tx) => enqueueReplicaCleanup(tx, asset.id, oldThumb, 'delete-thumbnail'));
+      if (oldThumbCleanupEnqueued) {
+        try {
+          await storage.deleteUrl(oldThumbUrl);
+          await markReplicaCleanupDone(prisma, asset.id, [oldThumb], 'delete-thumbnail');
+        } catch (error) {
+          // Already durably enqueued above, so process-storage-cleanup will
+          // retry this with backoff regardless of the throw below (which
+          // still counts this asset as a batch failure, matching the prior
+          // best-effort-delete contract).
+          throw error;
+        }
       }
+      // else: hasLiveSharedReference fenced this object — another live
+      // asset still references the same legacy thumbnail URL/key, so
+      // physical deletion is correctly skipped rather than breaking that
+      // sibling asset. It will be cleaned up once nothing live shares it.
       regenerated++;
     } catch (error) {
       failed++;

--- a/apps/web/app/api/cron/regenerate-thumbnails/route.ts
+++ b/apps/web/app/api/cron/regenerate-thumbnails/route.ts
@@ -214,7 +214,26 @@ async function getHandler(request: NextRequest) {
           });
         });
       } catch (error) {
-        await storage.deleteReplicas?.(newReplicas);
+        // The just-uploaded replica(s) must be cleaned up, but a failure
+        // here must never replace or mask the ORIGINAL transaction error —
+        // that's the actionable failure reason (e.g. a permission/DB error),
+        // not an artifact of best-effort cleanup. If cleanup itself fails,
+        // durably enqueue every new replica through the same
+        // storage_cleanup_outbox seam the old-thumbnail-delete path below
+        // already uses, so it is retried rather than silently leaked.
+        try {
+          await storage.deleteReplicas?.(newReplicas);
+        } catch (cleanupError) {
+          const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+          for (const replica of newReplicas) {
+            try {
+              await recordThumbnailCleanupFailure(asset.id, replica.provider, replica.key, replica.url, cleanupMessage);
+            } catch {
+              // Best-effort enqueue; the original transaction error below is
+              // always what surfaces to the caller regardless.
+            }
+          }
+        }
         throw error;
       }
       try {

--- a/apps/web/docs/STORAGE_PORTABILITY.md
+++ b/apps/web/docs/STORAGE_PORTABILITY.md
@@ -71,6 +71,6 @@ Run inventory with the schema-migrator/operator `DATABASE_URL` only:
 STORAGE_PROVIDER=vercel pnpm --filter web storage:portability inventory --limit 100 --cursor <last-id>
 ```
 
-Inventory reads each legacy original and thumbnail, computes bounded size/SHA-256, persists metadata, advances a durable cursor, and records failures. It exits non-zero on any parity failure; repair the source and resume from the recorded cursor.
+Inventory reads each legacy original and thumbnail, computes bounded size/SHA-256, persists metadata, advances a durable cursor, and records failures. It exits non-zero on any parity failure; repair the source and resume from the recorded cursor. A cursor-resumed run only re-seeds the remaining suffix of assets and never prunes or emits the durable full manifest — those are gated on a subsequent fresh, cursor-less pass that re-visits every live asset from the start in one unbroken run. Treat a resumed run's own stdout as a non-authoritative progress marker, not a `manifest.json` input; always finish with one plain `inventory` call (no `--cursor`) before `verify`.
 
 Before verify, set `STORAGE_CUTOVER_MANIFEST_SHA256` to the exact manifest digest. The CLI records provider fingerprint/manifest/phase in `storage_cutover_state`, refuses drift, and exits non-zero unless every journal row is verified (or rolled back). The restricted application role has SELECT access only to `storage_cutover_state` for runtime fail-closed checks; it intentionally has no access to journal, migration-entry, or inventory tables.

--- a/apps/web/lib/storage/permanent-delete.ts
+++ b/apps/web/lib/storage/permanent-delete.ts
@@ -77,6 +77,34 @@ async function hasLiveSharedReference(
   return rows[0]?.shared === true;
 }
 
+/**
+ * Fence-check one replica and, if no other live asset still references it,
+ * durably enqueue its provider cleanup under `action`. This is the single
+ * shared-reference-aware outbox seam every deletion path (permanent-delete's
+ * multi-replica sweep below, and the old-thumbnail/orphaned-replica cleanup
+ * in the thumbnail regen cron) goes through — never a bespoke point-in-time
+ * check duplicated per caller. Returns whether the row was enqueued (false
+ * means fenced: another live asset still owns this physical object, so
+ * deletion is correctly skipped rather than breaking that sibling asset).
+ */
+export async function enqueueReplicaCleanup(
+  tx: CleanupTransaction,
+  assetId: string,
+  replica: StorageReplica,
+  action: string,
+): Promise<boolean> {
+  if (await hasLiveSharedReference(tx, assetId, replica)) return false;
+  await tx.$executeRawUnsafe(
+    "INSERT INTO storage_cleanup_outbox (id, asset_id, provider, key, url, action, status, updated_at) VALUES (md5(concat_ws(chr(0), $1, $2, $3, $4, $5)), $1, $2, $3, $4, $5, 'pending', NOW()) ON CONFLICT (id) DO NOTHING",
+    assetId,
+    replica.provider,
+    replica.key,
+    replica.url,
+    action,
+  );
+  return true;
+}
+
 export async function enqueueAssetReplicaCleanup(
   tx: CleanupTransaction,
   assetId: string,
@@ -89,16 +117,7 @@ export async function enqueueAssetReplicaCleanup(
   const candidates = replicasForPermanentDelete(rows, fallback);
   const replicas: StorageReplica[] = [];
   for (const replica of candidates) {
-    if (await hasLiveSharedReference(tx, assetId, replica)) continue;
-    replicas.push(replica);
-    await tx.$executeRawUnsafe(
-      "INSERT INTO storage_cleanup_outbox (id, asset_id, provider, key, url, action, status, updated_at) VALUES (md5(concat_ws(chr(0), $1, $2, $3, $4, $5)), $1, $2, $3, $4, $5, 'pending', NOW()) ON CONFLICT (id) DO NOTHING",
-      assetId,
-      replica.provider,
-      replica.key,
-      replica.url,
-      'permanent-delete',
-    );
+    if (await enqueueReplicaCleanup(tx, assetId, replica, 'permanent-delete')) replicas.push(replica);
   }
   return replicas;
 }
@@ -107,6 +126,7 @@ export async function markReplicaCleanupDone(
   db: Pick<Prisma.TransactionClient, '$executeRawUnsafe'>,
   assetId: string,
   replicas: StorageReplica[],
+  action: string = 'permanent-delete',
 ): Promise<void> {
   for (const replica of replicas) {
     await db.$executeRawUnsafe(
@@ -115,7 +135,7 @@ export async function markReplicaCleanupDone(
       replica.provider,
       replica.key,
       replica.url,
-      'permanent-delete',
+      action,
     );
   }
 }

--- a/apps/web/prisma/stripe-ledger-bootstrap-post.sql
+++ b/apps/web/prisma/stripe-ledger-bootstrap-post.sql
@@ -463,6 +463,24 @@ DO $$ BEGIN
     GRANT SELECT (asset_id, provider, source_key, logical_key, delivery_url, active)
       ON TABLE public.asset_storage_replicas TO sploot_stripe_app;
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.storage_cutover_state, public.storage_migration_entries, public.storage_inventory_state, public.storage_inventory_failures, public.asset_storage_replicas, public.storage_cleanup_outbox TO sploot_storage_operator;
+    -- storage-portability.ts (inventory/commitCutover/restoreCutoverMappings)
+    -- reads and rewrites only the storage-identity columns on assets while
+    -- running as this role; every other column (favorite, checksum, phash,
+    -- share slug, owner, size, dimensions, timestamps, ...) stays denied.
+    -- Column set is the exact union of every WHERE/select/data clause those
+    -- three functions touch; their .update() calls are select-scoped to
+    -- `id` so no broader SELECT grant is required for the write-back
+    -- readback (Prisma's update() otherwise selects every scalar column).
+    GRANT SELECT (id, deleted_at, pathname, mime, storage_provider, storage_key, storage_source_key, blob_url, thumbnail_storage_key, thumbnail_storage_source_key, thumbnail_path, thumbnail_url)
+      ON TABLE public.assets TO sploot_storage_operator;
+    -- Prisma's `@updatedAt` auto-timestamp appends "updatedAt" to every
+    -- Asset.update() SET clause regardless of what the caller's `data`
+    -- contains, so it needs the same UPDATE grant as the columns actually
+    -- written (proven live: raw SQL against only the enumerated business
+    -- columns succeeds, but the Prisma-generated statement fails closed
+    -- with "permission denied for table assets" without this column).
+    GRANT UPDATE (storage_provider, storage_key, storage_source_key, storage_config_fingerprint, storage_size, storage_sha256, blob_url, thumbnail_storage_key, thumbnail_storage_source_key, thumbnail_storage_size, thumbnail_storage_sha256, thumbnail_url, "updatedAt")
+      ON TABLE public.assets TO sploot_storage_operator;
     GRANT SELECT, INSERT, UPDATE ON TABLE public.storage_cleanup_outbox TO sploot_stripe_app;
     GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO sploot_storage_operator;
   END IF;

--- a/apps/web/scripts/storage-portability.ts
+++ b/apps/web/scripts/storage-portability.ts
@@ -64,9 +64,14 @@ export function renditionMime(key: string, bytes: Buffer, reported?: string, fal
   return byExtension[extension ?? ''] ?? (fallback && isValidMimeType(fallback) ? normalizeMimeType(fallback) : undefined);
 }
 
-async function inventory(limit: number, cursor?: string) {
+export async function inventory(limit: number, cursor?: string): Promise<void> {
   await requireOperatorAuthority();
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_BATCH) throw new Error('Inventory batch size must be 1-' + MAX_BATCH);
+  // Captured before `cursor`/`nextCursor` are consulted below: only a call
+  // that started with no cursor at all re-seeds every live asset from the
+  // absolute beginning in one unbroken pass, which is the only case safe to
+  // treat as complete/authoritative for pruning and full-manifest emission.
+  const isFreshPass = cursor === undefined;
   const config = storageConfigFromEnv();
   const fingerprint = storageConfigFingerprint(config);
   const source = new VercelObjectStore(config.legacyBaseUrl);
@@ -112,12 +117,22 @@ async function inventory(limit: number, cursor?: string) {
     if (assets.length < limit) break;
   }
   if (failures > 0) throw new Error('Inventory parity failed for ' + failures + ' asset(s); resume from the recorded cursor after repairing source objects');
-  // A full, uninterrupted pass above re-seeds every non-deleted asset's
-  // current original/thumbnail keys, so it is now safe to prune whatever no
-  // longer matches any live asset.
-  await pruneStaleMigrationEntries(prisma);
-  const durableManifest = await prisma.storageMigrationEntry.findMany({ orderBy: { logicalKey: 'asc' }, select: { logicalKey: true, sourceKey: true, rendition: true, sourceProvider: true, size: true, sha256: true, contentType: true } });
-  process.stdout.write(JSON.stringify(durableManifest) + '\n');
+  if (isFreshPass) {
+    // A full, uninterrupted pass above re-seeds every non-deleted asset's
+    // current original/thumbnail keys, so it is now safe to prune whatever
+    // no longer matches any live asset.
+    await pruneStaleMigrationEntries(prisma);
+    const durableManifest = await prisma.storageMigrationEntry.findMany({ orderBy: { logicalKey: 'asc' }, select: { logicalKey: true, sourceKey: true, rendition: true, sourceProvider: true, size: true, sha256: true, contentType: true } });
+    process.stdout.write(JSON.stringify(durableManifest) + '\n');
+    return;
+  }
+  // A cursor-resumed pass only re-seeds a SUFFIX of the live asset set — it
+  // must never be trusted as a complete inventory. Pruning and the durable
+  // full-manifest emission stay gated on a fresh, cursor-less pass that
+  // re-visits every live asset from the very beginning in one unbroken run;
+  // this run's output is explicitly non-authoritative.
+  process.stderr.write('Inventory resumed from cursor ' + cursor + '; seeded ' + manifest.length + ' entr' + (manifest.length === 1 ? 'y' : 'ies') + ' through ' + (nextCursor ?? cursor) + '. Re-run inventory WITHOUT --cursor for a complete, prunable, authoritative manifest before verify.\n');
+  process.stdout.write(JSON.stringify({ resumed: true, cursor: nextCursor ?? null, seeded: manifest.length }) + '\n');
 }
 
 /**
@@ -255,7 +270,8 @@ export async function restoreCutoverMappings(config: StorageConfig, digest: stri
       await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=false, updated_at=NOW() WHERE asset_id=$1 AND rendition=$2', row.asset_id, row.rendition);
       await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=true, updated_at=NOW() WHERE asset_id=$1 AND rendition=$2 AND generation=$3 AND provider=$4', row.asset_id, row.rendition, row.old_generation, row.provider);
     }
-    await tx.storageCutoverState.updateMany({ where: { id: 'default', phase: 'target', generation: state.generation, providerFingerprint: fingerprint, manifestSha256: digest }, data: { phase: 'rollback', rollbackAt: new Date(), updatedAt: new Date() } });
+    const updated = await tx.storageCutoverState.updateMany({ where: { id: 'default', phase: 'target', generation: state.generation, providerFingerprint: fingerprint, manifestSha256: digest }, data: { phase: 'rollback', rollbackAt: new Date(), updatedAt: new Date() } });
+    if (updated.count !== 1) throw new Error('Rollback fence lost while restoring asset mappings');
   });
 }
 

--- a/apps/web/scripts/storage-portability.ts
+++ b/apps/web/scripts/storage-portability.ts
@@ -13,8 +13,8 @@ const MAX_BATCH = 100;
 const INVENTORY_ID = 'legacy-assets';
 const OPERATOR_ROLES = new Set(['sploot_stripe_schema_migrator', 'sploot_storage_operator']);
 
-async function requireOperatorAuthority(): Promise<void> {
-  const rows = await prisma.$queryRaw<Array<{ sessionUser: string; isSuperuser: boolean }>>(Prisma.sql`SELECT current_user AS "sessionUser", rolsuper AS "isSuperuser" FROM pg_roles WHERE rolname = current_user`);
+async function requireOperatorAuthority(database: PrismaClient = prisma): Promise<void> {
+  const rows = await database.$queryRaw<Array<{ sessionUser: string; isSuperuser: boolean }>>(Prisma.sql`SELECT current_user AS "sessionUser", rolsuper AS "isSuperuser" FROM pg_roles WHERE rolname = current_user`);
   const authority = rows[0];
   if (!authority || (!OPERATOR_ROLES.has(authority.sessionUser) && !authority.isSuperuser)) throw new Error('Storage portability requires DATABASE_URL owned by the schema-migrator/operator authority');
 }
@@ -23,8 +23,8 @@ export function manifestSha256(manifest: MigrationManifestEntry[]): string {
   return createHash('sha256').update(JSON.stringify(manifest)).digest('hex');
 }
 
-async function recordInventoryFailure(assetId: string, error: string): Promise<void> {
-  await prisma.$executeRaw(Prisma.sql`INSERT INTO "storage_inventory_failures" ("asset_id", "kind", "error", "attempts", "updated_at") VALUES (${assetId}, 'asset', ${error}, 1, NOW()) ON CONFLICT ("asset_id", "kind") DO UPDATE SET "error" = EXCLUDED."error", "attempts" = "storage_inventory_failures"."attempts" + 1, "updated_at" = NOW()`);
+async function recordInventoryFailure(database: PrismaClient, assetId: string, error: string): Promise<void> {
+  await database.$executeRaw(Prisma.sql`INSERT INTO "storage_inventory_failures" ("asset_id", "kind", "error", "attempts", "updated_at") VALUES (${assetId}, 'asset', ${error}, 1, NOW()) ON CONFLICT ("asset_id", "kind") DO UPDATE SET "error" = EXCLUDED."error", "attempts" = "storage_inventory_failures"."attempts" + 1, "updated_at" = NOW()`);
 }
 
 
@@ -64,8 +64,8 @@ export function renditionMime(key: string, bytes: Buffer, reported?: string, fal
   return byExtension[extension ?? ''] ?? (fallback && isValidMimeType(fallback) ? normalizeMimeType(fallback) : undefined);
 }
 
-export async function inventory(limit: number, cursor?: string): Promise<void> {
-  await requireOperatorAuthority();
+export async function inventory(limit: number, cursor?: string, database: PrismaClient = prisma): Promise<void> {
+  await requireOperatorAuthority(database);
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_BATCH) throw new Error('Inventory batch size must be 1-' + MAX_BATCH);
   // Captured before `cursor`/`nextCursor` are consulted below: only a call
   // that started with no cursor at all re-seeds every live asset from the
@@ -79,7 +79,7 @@ export async function inventory(limit: number, cursor?: string): Promise<void> {
   let failures = 0;
   let nextCursor = cursor;
   while (true) {
-    const assets = await prisma.asset.findMany({ where: { deletedAt: null, ...(nextCursor ? { id: { gt: nextCursor } } : {}) }, orderBy: { id: 'asc' }, take: limit, select: { id: true, storageKey: true, storageSourceKey: true, pathname: true, thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailPath: true, thumbnailUrl: true, mime: true } });
+    const assets = await database.asset.findMany({ where: { deletedAt: null, ...(nextCursor ? { id: { gt: nextCursor } } : {}) }, orderBy: { id: 'asc' }, take: limit, select: { id: true, storageKey: true, storageSourceKey: true, pathname: true, thumbnailStorageKey: true, thumbnailStorageSourceKey: true, thumbnailPath: true, thumbnailUrl: true, mime: true } });
     if (assets.length === 0) break;
     for (const asset of assets) {
       try {
@@ -88,28 +88,28 @@ export async function inventory(limit: number, cursor?: string): Promise<void> {
         const bytes = await bodyToBuffer(original.body, 512 * 1024 * 1024);
         const sha256 = createHash('sha256').update(bytes).digest('hex');
         const logicalKey = inventoryLogicalKey(asset.id, sourceKey, 'original');
-        await prisma.asset.update({ where: { id: asset.id }, data: { storageKey: logicalKey, storageSourceKey: sourceKey, storageConfigFingerprint: fingerprint, storageSize: bytes.byteLength, storageSha256: sha256 } });
+        await database.asset.update({ where: { id: asset.id }, data: { storageKey: logicalKey, storageSourceKey: sourceKey, storageConfigFingerprint: fingerprint, storageSize: bytes.byteLength, storageSha256: sha256 }, select: { id: true } });
         const originalEntry = { logicalKey, sourceKey, rendition: 'original' as const, sourceProvider: 'vercel', size: bytes.byteLength, sha256, contentType: renditionMime(sourceKey, bytes, original.metadata.contentType, asset.mime) };
         manifest.push(originalEntry);
-        await seedMigrationManifest(prisma, [originalEntry], { source: 'vercel', target: 's3' });
+        await seedMigrationManifest(database, [originalEntry], { source: 'vercel', target: 's3' });
         const thumbnailKey = asset.thumbnailStorageSourceKey ?? asset.thumbnailStorageKey ?? asset.thumbnailPath;
         if (thumbnailKey && (asset.thumbnailUrl || asset.thumbnailStorageKey)) {
           const thumbnail = await source.getSourceKey(thumbnailKey);
           const thumbBytes = await bodyToBuffer(thumbnail.body, 512 * 1024 * 1024);
           const thumbSha = createHash('sha256').update(thumbBytes).digest('hex');
           const thumbLogicalKey = inventoryLogicalKey(asset.id, thumbnailKey, 'thumbnail');
-          await prisma.asset.update({ where: { id: asset.id }, data: { thumbnailStorageKey: thumbLogicalKey, thumbnailStorageSourceKey: thumbnailKey, thumbnailStorageSize: thumbBytes.byteLength, thumbnailStorageSha256: thumbSha } });
+          await database.asset.update({ where: { id: asset.id }, data: { thumbnailStorageKey: thumbLogicalKey, thumbnailStorageSourceKey: thumbnailKey, thumbnailStorageSize: thumbBytes.byteLength, thumbnailStorageSha256: thumbSha }, select: { id: true } });
           const thumbnailEntry = { logicalKey: thumbLogicalKey, sourceKey: thumbnailKey, rendition: 'thumbnail' as const, sourceProvider: 'vercel', size: thumbBytes.byteLength, sha256: thumbSha, contentType: renditionMime(thumbnailKey, thumbBytes, thumbnail.metadata.contentType) };
           manifest.push(thumbnailEntry);
-          await seedMigrationManifest(prisma, [thumbnailEntry], { source: 'vercel', target: 's3' });
+          await seedMigrationManifest(database, [thumbnailEntry], { source: 'vercel', target: 's3' });
         }
         nextCursor = asset.id;
-        await prisma.storageInventoryState.upsert({ where: { id: INVENTORY_ID }, update: { cursor: asset.id, providerFingerprint: fingerprint, lastError: null }, create: { id: INVENTORY_ID, cursor: asset.id, providerFingerprint: fingerprint, updatedAt: new Date() } });
+        await database.storageInventoryState.upsert({ where: { id: INVENTORY_ID }, update: { cursor: asset.id, providerFingerprint: fingerprint, lastError: null }, create: { id: INVENTORY_ID, cursor: asset.id, providerFingerprint: fingerprint, updatedAt: new Date() } });
       } catch (error) {
         failures++;
         const message = error instanceof Error ? error.message : String(error);
-        await recordInventoryFailure(asset.id, message);
-        await prisma.storageInventoryState.upsert({ where: { id: INVENTORY_ID }, update: { providerFingerprint: fingerprint, lastError: message }, create: { id: INVENTORY_ID, cursor: nextCursor, providerFingerprint: fingerprint, lastError: message, updatedAt: new Date() } });
+        await recordInventoryFailure(database, asset.id, message);
+        await database.storageInventoryState.upsert({ where: { id: INVENTORY_ID }, update: { providerFingerprint: fingerprint, lastError: message }, create: { id: INVENTORY_ID, cursor: nextCursor, providerFingerprint: fingerprint, lastError: message, updatedAt: new Date() } });
         break;
       }
     }
@@ -121,8 +121,8 @@ export async function inventory(limit: number, cursor?: string): Promise<void> {
     // A full, uninterrupted pass above re-seeds every non-deleted asset's
     // current original/thumbnail keys, so it is now safe to prune whatever
     // no longer matches any live asset.
-    await pruneStaleMigrationEntries(prisma);
-    const durableManifest = await prisma.storageMigrationEntry.findMany({ orderBy: { logicalKey: 'asc' }, select: { logicalKey: true, sourceKey: true, rendition: true, sourceProvider: true, size: true, sha256: true, contentType: true } });
+    await pruneStaleMigrationEntries(database);
+    const durableManifest = await database.storageMigrationEntry.findMany({ orderBy: { logicalKey: 'asc' }, select: { logicalKey: true, sourceKey: true, rendition: true, sourceProvider: true, size: true, sha256: true, contentType: true } });
     process.stdout.write(JSON.stringify(durableManifest) + '\n');
     return;
   }
@@ -219,7 +219,7 @@ export async function commitCutover(manifest: MigrationManifestEntry[], config: 
         await tx.$executeRawUnsafe('UPDATE asset_storage_replicas SET active=false, updated_at=NOW() WHERE asset_id=$1 AND rendition=$2', asset.id, rendition);
         await tx.$executeRawUnsafe('INSERT INTO asset_storage_replicas (id, asset_id, rendition, provider, source_key, logical_key, delivery_url, size, sha256, content_type, generation, active) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,false) ON CONFLICT (asset_id, rendition, generation, provider) DO UPDATE SET source_key=EXCLUDED.source_key, logical_key=EXCLUDED.logical_key, delivery_url=EXCLUDED.delivery_url, size=EXCLUDED.size, sha256=EXCLUDED.sha256, content_type=EXCLUDED.content_type, active=false, updated_at=NOW()', randomUUID(), asset.id, rendition, sourceProvider, oldKey, entry.logicalKey, oldUrl, entry.size, entry.sha256, entry.contentType ?? asset.mime, generation);
         await tx.$executeRawUnsafe('INSERT INTO asset_storage_replicas (id, asset_id, rendition, provider, source_key, logical_key, delivery_url, size, sha256, content_type, generation, active) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,true) ON CONFLICT (asset_id, rendition, generation, provider) DO UPDATE SET source_key=EXCLUDED.source_key, logical_key=EXCLUDED.logical_key, delivery_url=EXCLUDED.delivery_url, size=EXCLUDED.size, sha256=EXCLUDED.sha256, content_type=EXCLUDED.content_type, active=true, updated_at=NOW()', randomUUID(), asset.id, rendition, config.provider, entry.sourceKey, entry.logicalKey, targetUrl, entry.size, entry.sha256, entry.contentType ?? asset.mime, generation);
-        await tx.asset.update({ where: { id: asset.id }, data: rendition === 'thumbnail' ? { storageProvider: config.provider, thumbnailStorageKey: entry.logicalKey, thumbnailStorageSourceKey: entry.sourceKey, thumbnailUrl: targetUrl, thumbnailStorageSize: entry.size, thumbnailStorageSha256: entry.sha256, storageConfigFingerprint: fingerprint } : { storageProvider: config.provider, storageKey: entry.logicalKey, storageSourceKey: entry.sourceKey, blobUrl: targetUrl, storageSize: entry.size, storageSha256: entry.sha256, storageConfigFingerprint: fingerprint } });
+        await tx.asset.update({ where: { id: asset.id }, data: rendition === 'thumbnail' ? { storageProvider: config.provider, thumbnailStorageKey: entry.logicalKey, thumbnailStorageSourceKey: entry.sourceKey, thumbnailUrl: targetUrl, thumbnailStorageSize: entry.size, thumbnailStorageSha256: entry.sha256, storageConfigFingerprint: fingerprint } : { storageProvider: config.provider, storageKey: entry.logicalKey, storageSourceKey: entry.sourceKey, blobUrl: targetUrl, storageSize: entry.size, storageSha256: entry.sha256, storageConfigFingerprint: fingerprint }, select: { id: true } });
       }
     }
     const updated = await tx.storageCutoverState.updateMany({ where: { id: 'default', phase: 'dual-write', generation: state.generation, providerFingerprint: fingerprint, manifestSha256: digest }, data: { phase: 'target', generation, verifiedAt: new Date(), updatedAt: new Date() } });
@@ -258,8 +258,8 @@ export async function restoreCutoverMappings(config: StorageConfig, digest: stri
       if (row.target_generation === null || row.provider === null) {
         throw new Error('Rollback cannot find a complete provider-paired replica generation for ' + row.asset_id + '/' + row.rendition + '; refusing to restore a stale or mixed-generation mapping');
       }
-      if (row.rendition === 'thumbnail') await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, thumbnailStorageKey: row.logical_key!, thumbnailStorageSourceKey: row.source_key, thumbnailUrl: row.delivery_url! } });
-      else await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, storageKey: row.logical_key!, storageSourceKey: row.source_key, blobUrl: row.delivery_url! } });
+      if (row.rendition === 'thumbnail') await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, thumbnailStorageKey: row.logical_key!, thumbnailStorageSourceKey: row.source_key, thumbnailUrl: row.delivery_url! }, select: { id: true } });
+      else await tx.asset.update({ where: { id: row.asset_id }, data: { storageProvider: row.provider, storageKey: row.logical_key!, storageSourceKey: row.source_key, blobUrl: row.delivery_url! }, select: { id: true } });
       // Deactivate every generation of this asset+rendition — mirrors
       // commitCutover's own blanket deactivate — then reactivate exactly the row
       // just restored onto the asset above. This keeps the ledger's `active`


### PR DESCRIPTION
## Summary

Final storage-portability repair for Powder card `sploot-blob-portability`, following merged PR #308. Closes every confirmed post-merge review gap while leaving the production cutover/soak criterion open.

## Fixed

- Thumbnail-regeneration transaction failures preserve the original error. Failed replica cleanup is durably queued; cleanup+outbox double failure emits an explicit redacted error signal.
- Old regenerated thumbnails use the same shared-reference-aware durable cleanup seam as permanent deletion, so a second live asset sharing a legacy URL is never broken.
- Cursor-resumed inventory runs are non-authoritative: they neither prune migration entries nor emit a full durable manifest. A fresh cursor-less pass is required.
- Rollback requires the final cutover-state fence update to affect exactly one row; a lost fence rolls back asset and replica mutations.
- `sploot_storage_operator` now receives exact column-level Asset authority only: 12 SELECT columns and 13 UPDATE columns (including Prisma's implicit `updatedAt`), with no table-level grant. Unrelated columns remain denied. All Asset.update calls select only `id`.

## Verification

Exact head `be1edfabe7f2fe67ab9ed3b73d9ab2c5181e749c`:

- CI run 29622175812: all jobs green, including pg15/pg16 restricted DB authority, full tests, browser seams, lint/type-check/build, and merge-gate.
- Red-before-green tests cover cleanup masking/leak signaling, shared legacy thumbnail fencing, cursor inventory authority, and rollback fence loss.
- A literal TCP login as non-superuser, non-inheriting `sploot_storage_operator` executes inventory/cutover/rollback under the real grant set; unrelated Asset columns are denied.
- Fresh exact-object adversarial review: PASS, no P1/P2 blockers.

Merged. No provider objects or production cutover were mutated. The Powder card remains open because byte/SHA migration, authenticated live cutover/rollback, soak, and deletion readback are still external acceptance work.