### PR TITLE
add signed sploot release verification

### DIFF
--- a/apps/web/docs/DEPLOYMENT.md
+++ b/apps/web/docs/DEPLOYMENT.md
@@ -180,6 +180,63 @@ not a verified deployment. the deployed smoke also asserts `/api/health/live`
 answers `alive` — the platform routing probe is explicitly shallow, and the
 deep `/api/health` contract above remains the readiness authority.
 
+## sploot release verification
+
+`release:verify` is a read-only product-runtime proof for an Estate release transaction. it never invokes `doctl`, reads provider state, writes a database/storage surface, or performs compensation. Estate remains the authority for provider readback, rollback, and quarantine.
+
+forward mode probes the exact `/api/health/live`, `/api/health`, and `/api/health/enrollment` routes. `rollback_safety` repeats those probes, then reads the bearer only from `SPLOOT_RELEASE_VERIFIER_BEARER_TOKEN` and posts valid JSON to `/api/embeddings/text`; only the exact HTTP 503 typed `embeddings_disabled` response is accepted. redirects, non-HTTPS URLs (outside explicit local test mode), malformed/unknown/oversized/stale responses, and 401/403 responses fail closed.
+ordinary probe failures still emit a signed closed packet with `ok: false`, the affected check set to `false`, and generic redacted failure observations; the process exits nonzero so automation cannot mistake it for a green run. malformed authority/input, missing bearer, invalid signing key, and expired evidence windows produce no packet.
+
+```bash
+pnpm --filter web release:verify -- \
+  --transaction-id "$ESTATE_TRANSACTION_ID" \
+  --mode forward \
+  --target-commit "$TARGET_COMMIT" \
+  --target-deployment-id "$TARGET_DEPLOYMENT_ID" \
+  --target-change-id "$TARGET_CHANGE_ID" \
+  --target-marker "$TARGET_MARKER" \
+  --base-url "$EXACT_DEPLOYMENT_URL" \
+  --observed-at "$OBSERVED_AT" --expires-at "$EXPIRES_AT" \
+  --signing-key-file "$SIGNING_KEY_FILE" \
+  --checks liveness,health,enrollment
+```
+
+for a local HTTP fixture only, add `--test-mode`; never use that switch for a deployed URL. rollback safety uses the same command with `--mode rollback_safety` and the bearer environment reference. the token is never accepted as a flag and never appears in evidence, signatures, errors, or logs.
+
+evidence is closed JSON under `sploot.release-verification.v1`. observed/expiry timestamps must be current, ordered, and no more than five minutes apart. the optional `--checks` list must exactly match Estate's declared required checks (the default public set is `liveness,health,enrollment`; rollback mode also requires `rollback_safety`). the signature is detached Ed25519 over canonical UTF-8 JSON of the `evidence` object (recursively sorted object keys, array order preserved, no whitespace). the outer packet contains only `schema`, `evidence`, `signature` (base64url without padding), and `public_key` (raw 32-byte Ed25519 public key, base64url without padding). `evidence.verifier_identity` is `ed25519:<sha256(raw-public-key)>`; Estate uses that identity to select the trusted key. requested target metadata—including the base URL—is signed request binding, not an observed commit claim. `target_change_id` remains an independent caller-supplied binding; the verifier never derives it from health/version output.
+
+```json
+{
+  "schema": "sploot.release-verification.v1",
+  "evidence": {
+    "schema": "sploot.release-verification.v1",
+    "verifier_identity": "ed25519:<sha256-of-raw-public-key>",
+    "transaction_id": "estate-tx-123",
+    "mode": "forward",
+    "requested": {
+      "target_commit": "<requested-commit>",
+      "target_deployment_id": "<requested-deployment>",
+      "target_change_id": "<requested-change>",
+      "target_marker": "<requested-marker>",
+      "base_url": "https://example.invalid"
+    },
+    "ok": true,
+    "observed_at": "2026-07-18T12:00:00.000Z",
+    "expires_at": "2026-07-18T12:04:00.000Z",
+    "checks": { "liveness": true, "health": true, "enrollment": true },
+    "runtime": {
+      "liveness": { "http_status": 200, "status": "alive", "service": "sploot-web" },
+      "readiness": { "http_status": 200, "status": "ok", "timestamp": "2026-07-18T12:01:00.000Z", "version": "0.1.0", "dependencies": { "database": "up", "embedding_limiter": "up", "share_slug_cache": "local" } },
+      "enrollment": { "http_status": 200, "configuration": "valid", "mode": "closed", "status": "paused" }
+    },
+    "safety": null,
+    "redaction": "provider secrets, bearer credentials, and signing private bytes omitted"
+  },
+  "signature": "<base64url-ed25519-signature>",
+  "public_key": "<base64url-raw-ed25519-public-key>"
+}
+```
+
 ## rollback
 
 for a deliberate application rollback, first set

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,7 +53,9 @@
     "e2e:public-truth": "playwright test --config playwright.config.ts --project=public-truth --grep \"public truth\"",
     "e2e:public-truth:build": "node scripts/build-public-truth.mjs",
     "e2e:public-truth:production-guard": "node scripts/verify-production-public-truth-guard.mjs",
-    "e2e:public-truth:serve": "node scripts/serve-public-truth.mjs"
+    "e2e:public-truth:serve": "node scripts/serve-public-truth.mjs",
+    "release:verify": "node scripts/verify-release.mjs",
+    "release:verify:test": "node --test scripts/verify-release.test.mjs"
   },
   "dependencies": {
     "@clerk/backend": "^2.33.4",

--- a/apps/web/scripts/verify-release.mjs
+++ b/apps/web/scripts/verify-release.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+
+import { createHash, createPrivateKey, createPublicKey, sign } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+const SCHEMA = 'sploot.release-verification.v1';
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const MAX_KEY_BYTES = 1024 * 1024;
+const MAX_HTTP_TIMEOUT_MS = 30_000;
+const MAX_HEALTH_AGE_MS = 5 * 60 * 1000;
+const MAX_EVIDENCE_WINDOW_MS = 5 * 60 * 1000;
+const EMBEDDINGS_PATH = '/api/embeddings/text';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  const flags = new Set();
+  const aliases = new Map([
+    ['--transaction-id', 'transaction_id'],
+    ['--estate-transaction-id', 'transaction_id'],
+    ['--estate-transaction', 'transaction_id'],
+    ['--mode', 'mode'],
+    ['--target-commit', 'target_commit'],
+    ['--target-deployment', 'target_deployment_id'],
+    ['--target-deployment-id', 'target_deployment_id'],
+    ['--target-change', 'target_change_id'],
+    ['--target-change-id', 'target_change_id'],
+    ['--target-marker', 'target_marker'],
+    ['--base-url', 'base_url'],
+    ['--observed-at', 'observed_at'],
+    ['--expires-at', 'expires_at'],
+    ['--expiry', 'expires_at'],
+    ['--signing-key', 'signing_key_file'],
+    ['--signing-key-file', 'signing_key_file'],
+    ['--timeout-ms', 'timeout_ms'],
+    ['--checks', 'checks'],
+    ['--required-checks', 'checks'],
+  ]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+    if (raw === '--') {
+      continue;
+    }
+    if (raw === '--help' || raw === '-h') {
+      return { help: true };
+    }
+    if (raw === '--test-mode' || raw === '--allow-insecure-test-http') {
+      flags.add('test_mode');
+      continue;
+    }
+    if (raw === '--bearer-token' || raw === '--token') {
+      fail('bearer token must be provided only by SPLOOT_RELEASE_VERIFIER_BEARER_TOKEN');
+    }
+    const key = aliases.get(raw);
+    if (!key) fail('unknown argument');
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) fail('argument value is missing');
+    if (values.has(key)) fail('duplicate argument');
+    values.set(key, value);
+    index += 1;
+  }
+
+  return { values, flags };
+}
+
+function usage() {
+  return [
+    'usage: pnpm release:verify -- --transaction-id <id> --mode <forward|rollback_safety>',
+    '  --target-commit <sha> --target-deployment-id <id> --target-change-id <id>',
+    '  --target-marker <marker> --base-url <https://...> --observed-at <iso> --expires-at <iso>',
+    '  --signing-key-file <path> [--checks liveness,health,enrollment] [--test-mode] [--timeout-ms <1..30000>]',
+  ].join('\n');
+}
+
+function required(values, key) {
+  const value = values.get(key);
+  if (!value) fail('required argument missing');
+  if (value.length > 512) fail('argument is too long');
+  return value;
+}
+
+function optional(values, key) {
+  const value = values.get(key);
+  if (value !== undefined && value.length > 512) fail('argument is too long');
+  return value;
+}
+
+function iso(value, label) {
+  if (!value || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) fail(label + ' must be an ISO-8601 UTC timestamp');
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) fail(label + ' is invalid');
+  return { value, time };
+}
+
+function text(value, label) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 512) fail(label + ' is invalid');
+  return value;
+}
+
+function baseUrl(value, testMode) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail('base URL is invalid');
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash || parsed.pathname !== '/') fail('base URL must be an origin');
+  if (parsed.protocol !== 'https:' && !(testMode && parsed.protocol === 'http:')) fail('base URL must use HTTPS');
+  if (testMode && parsed.protocol === 'http:' && !['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname)) fail('test-mode HTTP must target loopback');
+  return parsed.origin;
+}
+
+function exactKeys(value, expected, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(label + ' is malformed');
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) fail(label + ' contains unknown fields');
+}
+
+function exactObject(value, expected, label) {
+  exactKeys(value, Object.keys(expected), label);
+  for (const [key, predicate] of Object.entries(expected)) {
+    if (!predicate(value[key])) fail(label + ' is malformed');
+  }
+}
+
+function isString(value) {
+  return typeof value === 'string';
+}
+function isBoolean(value) {
+  return typeof value === 'boolean';
+}
+function isNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function validateLiveness(body) {
+  exactObject(body, { service: isString, status: isString }, 'liveness response');
+  if (body.status !== 'alive' || body.service !== 'sploot-web') fail('liveness response is not healthy');
+  return { http_status: 200, status: body.status, service: body.service };
+}
+
+function validateReadiness(body, observedTime, expiresTime, now) {
+  exactKeys(body, ['status', 'timestamp', 'dependencies', 'diagnostics', 'version'], 'readiness response');
+  if (body.status !== 'ok' || !isString(body.timestamp) || !isString(body.version)) fail('readiness response is malformed');
+  const timestamp = iso(body.timestamp, 'readiness timestamp');
+  if (timestamp.time < now - MAX_HEALTH_AGE_MS || timestamp.time > now + 30_000 || timestamp.time > expiresTime || timestamp.time < observedTime - MAX_HEALTH_AGE_MS) fail('readiness response is stale');
+  exactObject(body.dependencies, { database: isString, embedding_limiter: isString, share_slug_cache: isString }, 'readiness dependencies');
+  if (body.dependencies.database !== 'up' || body.dependencies.embedding_limiter !== 'up' || body.dependencies.share_slug_cache !== 'local') fail('readiness dependencies are unhealthy');
+  exactKeys(body.diagnostics, ['canary_configured', 'database_url_configured', 'env_vars', 'prisma_connection_test', 'embedding_limiter_schema', 'connection_latency_ms'], 'readiness diagnostics');
+  if (!isBoolean(body.diagnostics.canary_configured) || body.diagnostics.database_url_configured !== true || body.diagnostics.prisma_connection_test !== true || body.diagnostics.embedding_limiter_schema !== true || !isNumber(body.diagnostics.connection_latency_ms)) fail('readiness diagnostics are malformed');
+  exactObject(body.diagnostics.env_vars, { DATABASE_URL: isString }, 'readiness environment diagnostics');
+  if (body.diagnostics.env_vars.DATABASE_URL !== 'configured') fail('readiness environment is not configured');
+  return { http_status: 200, status: body.status, timestamp: body.timestamp, version: body.version, dependencies: body.dependencies };
+}
+
+function validateEnrollment(body, expectedMode) {
+  exactObject(body, { configuration: isString, mode: isString, status: isString }, 'enrollment response');
+  if (body.configuration !== 'valid' || body.mode !== expectedMode || body.status !== (expectedMode === 'ga' ? 'open' : 'paused')) fail('enrollment response does not match requested mode');
+  return { http_status: 200, configuration: body.configuration, mode: body.mode, status: body.status };
+}
+
+function validateSafety(body) {
+  exactKeys(body, ['action', 'code', 'error', 'retryable'], 'embedding response');
+  if (body.code !== 'embeddings_disabled' || body.error !== 'Embedding generation is temporarily paused' || body.retryable !== true) fail('embedding response is not the typed disabled contract');
+  exactObject(body.action, { label: isString, type: isString }, 'embedding action');
+  if (body.action.type !== 'try_later' || body.action.label !== 'Try again later') fail('embedding response action is malformed');
+  return { route: EMBEDDINGS_PATH, http_status: 503, code: body.code, retryable: body.retryable };
+}
+
+async function fetchJson(base, endpoint, init, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(base + endpoint, { ...init, redirect: 'manual', signal: controller.signal });
+    if (response.status >= 300 && response.status < 400) fail('redirect refused');
+    const declaredLength = response.headers.get('content-length');
+    if (declaredLength && Number(declaredLength) > MAX_RESPONSE_BYTES) fail('response is oversized');
+    const reader = response.body?.getReader();
+    if (!reader) fail('response body is missing');
+    const chunks = [];
+    let totalBytes = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value.byteLength > MAX_RESPONSE_BYTES - totalBytes) {
+        await reader.cancel();
+        fail('response is oversized');
+      }
+      chunks.push(value);
+      totalBytes += value.byteLength;
+    }
+    const bodyText = Buffer.concat(chunks, totalBytes).toString('utf8');
+    let body;
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
+      fail('response is not valid JSON');
+    }
+    return { response, body };
+  } catch (error) {
+    if (error?.name === 'AbortError') fail('request timed out');
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+
+async function collectProbe(name, run, failures) {
+  try {
+    return { ok: true, value: await run() };
+  } catch {
+    failures.push(name);
+    return { ok: false, value: { ok: false, error: 'probe_failed' } };
+  }
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail('evidence contains a non-finite number');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+  if (typeof value === 'object') {
+    return '{' + Object.keys(value).sort().map((key) => JSON.stringify(key) + ':' + canonicalize(value[key])).join(',') + '}';
+  }
+  fail('evidence contains an unsupported value');
+}
+
+
+async function readSigningKey(file) {
+  let bytes;
+  try {
+    bytes = await readFile(file);
+  } catch {
+    fail('signing key file is unavailable');
+  }
+  if (bytes.length > MAX_KEY_BYTES) fail('signing key file is oversized');
+  let key;
+  try {
+    key = createPrivateKey(bytes);
+  } catch {
+    fail('signing key is invalid');
+  }
+  if (key.asymmetricKeyType !== 'ed25519') fail('signing key must be Ed25519');
+  return key;
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    console.log(usage());
+    return;
+  }
+  const { values, flags } = parsed;
+  const testMode = flags.has('test_mode') || process.env.SPLOOT_RELEASE_VERIFIER_TEST_MODE === '1';
+  const mode = required(values, 'mode');
+  if (mode !== 'forward' && mode !== 'rollback_safety') fail('mode is invalid');
+  const transactionId = text(required(values, 'transaction_id'), 'transaction id');
+  const targetCommit = text(required(values, 'target_commit'), 'target commit');
+  const targetDeploymentId = text(required(values, 'target_deployment_id'), 'target deployment id');
+  const targetChangeId = text(required(values, 'target_change_id'), 'target change id');
+  const targetMarker = text(required(values, 'target_marker'), 'target marker');
+  const origin = baseUrl(required(values, 'base_url'), testMode);
+  const observed = iso(required(values, 'observed_at'), 'observed_at');
+  const expires = iso(required(values, 'expires_at'), 'expires_at');
+  if (expires.time <= observed.time) fail('expires_at must be after observed_at');
+  if (expires.time - observed.time > MAX_EVIDENCE_WINDOW_MS) fail('evidence window is too long');
+  const now = Date.now();
+  if (expires.time <= now) fail('expires_at is stale');
+  if (observed.time > now + MAX_HEALTH_AGE_MS) fail('observed_at is in the future');
+  if (now - observed.time > MAX_HEALTH_AGE_MS) fail('observed_at is stale');
+  const keyFile = required(values, 'signing_key_file');
+  const checkValue = optional(values, 'checks');
+  const checkNames = checkValue === undefined ? ['liveness', 'health', 'enrollment', ...(mode === 'rollback_safety' ? ['rollback_safety'] : [])] : checkValue.split(',').map((name) => name.trim()).filter(Boolean);
+  if (checkNames.length === 0 || new Set(checkNames).size !== checkNames.length || checkNames.some((name) => !['liveness', 'health', 'enrollment', 'rollback_safety'].includes(name))) fail('checks are invalid');
+  if (!checkNames.includes('liveness') || !checkNames.includes('health') || !checkNames.includes('enrollment')) fail('checks omit a required public probe');
+  if (mode === 'rollback_safety' && !checkNames.includes('rollback_safety')) fail('checks omit rollback safety');
+  if (mode === 'forward' && checkNames.includes('rollback_safety')) fail('rollback safety check requires rollback_safety mode');
+  const timeoutValue = optional(values, 'timeout_ms');
+  const timeoutMs = timeoutValue === undefined ? 10_000 : Number(timeoutValue);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_HTTP_TIMEOUT_MS) fail('timeout is invalid');
+
+  let bearer;
+  if (mode === 'rollback_safety') {
+    bearer = process.env.SPLOOT_RELEASE_VERIFIER_BEARER_TOKEN;
+    if (!bearer) fail('rollback safety requires SPLOOT_RELEASE_VERIFIER_BEARER_TOKEN');
+    if (bearer.length > 8192) fail('rollback safety bearer token is invalid');
+  }
+
+  const privateKey = await readSigningKey(keyFile);
+  const publicKey = createPublicKey(privateKey);
+  const spki = publicKey.export({ type: 'spki', format: 'der' });
+  const rawPublicKey = spki.subarray(-32);
+  const verifierIdentity = 'ed25519:' + createHash('sha256').update(rawPublicKey).digest('hex');
+  const failures = [];
+
+  const livenessProbe = await collectProbe('liveness', async () => {
+    const result = await fetchJson(origin, '/api/health/live', { headers: { accept: 'application/json' } }, timeoutMs);
+    if (result.response.status !== 200) fail('liveness probe failed');
+    return validateLiveness(result.body);
+  }, failures);
+  const healthProbe = await collectProbe('health', async () => {
+    const result = await fetchJson(origin, '/api/health', { headers: { accept: 'application/json' } }, timeoutMs);
+    if (result.response.status !== 200) fail('readiness probe failed');
+    return validateReadiness(result.body, observed.time, expires.time, Date.now());
+  }, failures);
+  const enrollmentProbe = await collectProbe('enrollment', async () => {
+    const result = await fetchJson(origin, '/api/health/enrollment', { headers: { accept: 'application/json' } }, timeoutMs);
+    if (result.response.status !== 200) fail('enrollment probe failed');
+    return validateEnrollment(result.body, 'closed');
+  }, failures);
+
+  let safetyProbe = { ok: true, value: null };
+  if (mode === 'rollback_safety') {
+    safetyProbe = await collectProbe('rollback_safety', async () => {
+      const result = await fetchJson(origin, EMBEDDINGS_PATH, {
+        method: 'POST',
+        headers: { accept: 'application/json', 'content-type': 'application/json', authorization: 'Bearer ' + bearer },
+        body: JSON.stringify({ query: 'release-verification-rollback-safety' }),
+      }, timeoutMs);
+      if (result.response.status === 401 || result.response.status === 403) fail('rollback safety authentication failed');
+      if (result.response.status !== 503) fail('rollback safety returned an unexpected status');
+      return validateSafety(result.body);
+    }, failures);
+  }
+
+  const completedAt = Date.now();
+  if (expires.time <= completedAt || completedAt - observed.time > MAX_HEALTH_AGE_MS) fail('evidence window expired during probes');
+  const checks = Object.fromEntries(checkNames.map((name) => [name, !failures.includes(name)]));
+  const evidence = {
+    schema: SCHEMA,
+    verifier_identity: verifierIdentity,
+    ok: failures.length === 0,
+    transaction_id: transactionId,
+    mode,
+    requested: {
+      target_commit: targetCommit,
+      target_deployment_id: targetDeploymentId,
+      target_change_id: targetChangeId,
+      target_marker: targetMarker,
+      base_url: origin,
+    },
+    observed_at: observed.value,
+    expires_at: expires.value,
+    checks,
+    runtime: {
+      liveness: livenessProbe.value,
+      readiness: healthProbe.value,
+      enrollment: enrollmentProbe.value,
+    },
+    safety: mode === 'rollback_safety' ? (safetyProbe.ok ? safetyProbe.value : { route: EMBEDDINGS_PATH, ok: false, error: 'probe_failed' }) : null,
+    redaction: 'provider secrets, bearer credentials, and signing private bytes omitted',
+  };
+  exactKeys(evidence, ['checks', 'expires_at', 'mode', 'observed_at', 'ok', 'redaction', 'requested', 'runtime', 'safety', 'schema', 'transaction_id', 'verifier_identity'], 'evidence');
+  const canonicalBytes = Buffer.from(canonicalize(evidence), 'utf8');
+  const signature = sign(null, canonicalBytes, privateKey).toString('base64url');
+  const output = {
+    schema: SCHEMA,
+    evidence,
+    signature,
+    public_key: rawPublicKey.toString('base64url'),
+  };
+  exactKeys(output, ['evidence', 'public_key', 'schema', 'signature'], 'signed envelope');
+  process.stdout.write(JSON.stringify(output) + '\n');
+  if (failures.length > 0) {
+    console.error('release verifier failed: one or more probes failed');
+    process.exitCode = 1;
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('release verifier failed: ' + (error instanceof Error ? error.message : 'unexpected failure'));
+  process.exitCode = 1;
+}

--- a/apps/web/scripts/verify-release.test.mjs
+++ b/apps/web/scripts/verify-release.test.mjs
@@ -8,9 +8,10 @@ import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 const SCRIPT = join(process.cwd(), 'scripts/verify-release.mjs');
-const OBSERVED_AT = new Date(Date.now() - 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
-const EXPIRES_AT = new Date(Date.now() + 4 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
-const HEALTH_TIMESTAMP = new Date(Date.now() - 30_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+const TEST_NOW = Date.now();
+const OBSERVED_AT = new Date(TEST_NOW - 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+const EXPIRES_AT = new Date(TEST_NOW + 3 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+const HEALTH_TIMESTAMP = new Date(TEST_NOW - 30_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
 const TOKEN = 'bearer-test-value-that-must-not-leak';
 const targetArgs = [
   '--transaction-id', 'estate-tx-123',
@@ -221,6 +222,8 @@ describe('verify-release.mjs', () => {
     const futureArgs = await successfulArgs('forward', futureOrigin, file);
     const observedIndex = futureArgs.indexOf('--observed-at');
     futureArgs[observedIndex + 1] = new Date(Date.now() + 10 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+    const expiresIndex = futureArgs.indexOf('--expires-at');
+    futureArgs[expiresIndex + 1] = new Date(Date.now() + 11 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
     const future = await run(futureArgs);
     assert.notEqual(future.code, 0);
   });

--- a/apps/web/scripts/verify-release.test.mjs
+++ b/apps/web/scripts/verify-release.test.mjs
@@ -1,0 +1,268 @@
+import { generateKeyPairSync, verify } from 'node:crypto';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const SCRIPT = join(process.cwd(), 'scripts/verify-release.mjs');
+const OBSERVED_AT = new Date(Date.now() - 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+const EXPIRES_AT = new Date(Date.now() + 4 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+const HEALTH_TIMESTAMP = new Date(Date.now() - 30_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+const TOKEN = 'bearer-test-value-that-must-not-leak';
+const targetArgs = [
+  '--transaction-id', 'estate-tx-123',
+  '--target-commit', '9c2ff5c9',
+  '--target-deployment-id', 'deployment-123',
+  '--target-change-id', 'change-123',
+  '--target-marker', 'marker-123',
+  '--observed-at', OBSERVED_AT,
+  '--expires-at', EXPIRES_AT,
+];
+
+let tempRoot;
+let servers = [];
+
+afterEach(async () => {
+  await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+  servers = [];
+  if (tempRoot) await rm(tempRoot, { recursive: true, force: true });
+  tempRoot = undefined;
+});
+
+function fixture({ enrollmentMode = 'closed', enrollmentStatus = 'paused', readinessTimestamp = HEALTH_TIMESTAMP, redirect = false, safety = true } = {}) {
+  return (request, response) => {
+    if (redirect && request.url === '/api/health/live') {
+      response.writeHead(302, { location: '/api/health/live' });
+      response.end();
+      return;
+    }
+    if (request.url === '/api/health/live') {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({ status: 'alive', service: 'sploot-web' }));
+      return;
+    }
+    if (request.url === '/api/health') {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        status: 'ok',
+        timestamp: readinessTimestamp,
+        dependencies: { database: 'up', embedding_limiter: 'up', share_slug_cache: 'local' },
+        diagnostics: {
+          prisma_connection_test: true,
+          embedding_limiter_schema: true,
+          database_url_configured: true,
+          connection_latency_ms: 2,
+          env_vars: { DATABASE_URL: 'configured' },
+          canary_configured: false,
+        },
+        version: '0.1.0',
+      }));
+      return;
+    }
+    if (request.url === '/api/health/enrollment') {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({ configuration: 'valid', mode: enrollmentMode, status: enrollmentStatus }));
+      return;
+    }
+    if (request.url === '/api/embeddings/text' && request.method === 'POST') {
+      let body = '';
+      request.setEncoding('utf8');
+      request.on('data', (chunk) => { body += chunk; });
+      request.on('end', () => {
+        assert.equal(request.headers.authorization, 'Bearer ' + TOKEN);
+        assert.deepEqual(JSON.parse(body), { query: 'release-verification-rollback-safety' });
+        response.setHeader('content-type', 'application/json');
+        response.statusCode = safety ? 503 : 401;
+        response.end(JSON.stringify(safety ? {
+          error: 'Embedding generation is temporarily paused',
+          code: 'embeddings_disabled',
+          retryable: true,
+          action: { type: 'try_later', label: 'Try again later' },
+        } : { error: 'Unauthorized' }));
+      });
+      return;
+    }
+    response.statusCode = 404;
+    response.end('{}');
+  };
+}
+
+async function startServer(handler) {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return 'http://127.0.0.1:' + server.address().port;
+}
+
+async function keyFile() {
+  tempRoot = await mkdtemp(join(tmpdir(), 'sploot-release-verifier-'));
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const file = join(tempRoot, 'signing-key.pem');
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' });
+  await writeFile(file, privatePem);
+  return { file, publicKey, privatePem };
+}
+
+function run(args, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [SCRIPT, ...args], {
+      cwd: process.cwd(),
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'number') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+  return '{' + Object.keys(value).sort().map((key) => JSON.stringify(key) + ':' + canonicalize(value[key])).join(',') + '}';
+}
+
+
+function assertSignedFailure(result, publicKey) {
+  const packet = JSON.parse(result.stdout);
+  assert.equal(packet.evidence.ok, false);
+  assert.equal(verify(null, Buffer.from(canonicalize(packet.evidence)), publicKey, Buffer.from(packet.signature, 'base64url')), true);
+  return packet;
+}
+
+async function successfulArgs(mode, origin, file) {
+  return [...targetArgs, '--mode', mode, '--base-url', origin, '--signing-key-file', file, '--test-mode'];
+}
+
+describe('verify-release.mjs', () => {
+
+  it('accepts pnpm argument separator before CLI flags', async () => {
+    const result = await run(['--', '--help']);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /usage: pnpm release:verify/);
+  });
+
+  it('emits deterministic closed forward evidence and a verifiable detached Ed25519 signature', async () => {
+    const { file, publicKey, privatePem } = await keyFile();
+    const origin = await startServer(fixture());
+    const args = await successfulArgs('forward', origin, file);
+    const first = await run(args);
+    const second = await run(args);
+    assert.equal(first.code, 0, first.stderr);
+    assert.equal(second.code, 0, second.stderr);
+    assert.equal(first.stdout, second.stdout);
+    assert.equal(first.stdout.includes(privatePem), false);
+    assert.equal(first.stderr.includes('BEGIN PRIVATE KEY'), false);
+    const envelope = JSON.parse(first.stdout);
+    assert.equal(envelope.schema, 'sploot.release-verification.v1');
+    assert.deepEqual(envelope.evidence.requested, {
+      target_commit: '9c2ff5c9',
+      target_deployment_id: 'deployment-123',
+      target_change_id: 'change-123',
+      target_marker: 'marker-123',
+      base_url: origin,
+    });
+    assert.equal(envelope.evidence.runtime.liveness.http_status, 200);
+    assert.equal(envelope.evidence.safety, null);
+    const canonical = canonicalize(envelope.evidence);
+    assert.equal(verify(null, Buffer.from(canonical), publicKey, Buffer.from(envelope.signature, 'base64url')), true);
+    assert.match(envelope.public_key, /^[A-Za-z0-9_-]{43}$/);
+    assert.match(envelope.evidence.verifier_identity, /^ed25519:[a-f0-9]{64}$/);
+  });
+
+  it('proves rollback safety with the environment-only bearer and redacts it', async () => {
+    const { file } = await keyFile();
+    const origin = await startServer(fixture());
+    const result = await run(await successfulArgs('rollback_safety', origin, file), { SPLOOT_RELEASE_VERIFIER_BEARER_TOKEN: TOKEN });
+    assert.equal(result.code, 0, result.stderr);
+    const envelope = JSON.parse(result.stdout);
+    assert.deepEqual(envelope.evidence.safety, { route: '/api/embeddings/text', http_status: 503, code: 'embeddings_disabled', retryable: true });
+    assert.equal(result.stdout.includes(TOKEN), false);
+    assert.equal(result.stderr.includes(TOKEN), false);
+  });
+
+  it('fails closed for stale, wrong-target, redirects, and auth responses without leaking secrets', async () => {
+    const cases = [
+      { name: 'stale readiness', handler: fixture({ readinessTimestamp: new Date(Date.now() - 10 * 60_000).toISOString() }), mode: 'forward' },
+      { name: 'wrong enrollment target', handler: fixture({ enrollmentMode: 'capped', enrollmentStatus: 'paused' }), mode: 'forward' },
+      { name: 'redirect', handler: fixture({ redirect: true }), mode: 'forward' },
+      { name: 'auth failure', handler: fixture({ safety: false }), mode: 'rollback_safety' },
+    ];
+    for (const item of cases) {
+      const { file, publicKey } = await keyFile();
+      const origin = await startServer(item.handler);
+      const result = await run(await successfulArgs(item.mode, origin, file), { SPLOOT_RELEASE_VERIFIER_BEARER_TOKEN: TOKEN });
+      assert.notEqual(result.code, 0, item.name);
+      const packet = assertSignedFailure(result, publicKey);
+      assert.equal(packet.evidence.ok, false, item.name);
+      assert.equal(result.stderr.includes(TOKEN), false, item.name);
+      await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+      servers = [];
+    }
+  });
+
+
+  it('rejects expired and materially future evidence windows', async () => {
+    const { file } = await keyFile();
+    const origin = await startServer(fixture());
+    const expired = await run(await successfulArgs('forward', origin, file).then((args) => args.map((value, index) => index === args.indexOf('--expires-at') + 1 ? new Date(Date.now() - 1_000).toISOString().replace(/\.\d{3}Z$/, '.000Z') : value)));
+    assert.notEqual(expired.code, 0);
+    await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+    servers = [];
+    const futureOrigin = await startServer(fixture());
+    const futureArgs = await successfulArgs('forward', futureOrigin, file);
+    const observedIndex = futureArgs.indexOf('--observed-at');
+    futureArgs[observedIndex + 1] = new Date(Date.now() + 10 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z');
+    const future = await run(futureArgs);
+    assert.notEqual(future.code, 0);
+  });
+
+
+  it('fails closed for malformed and chunked oversized responses', async () => {
+    for (const body of ['{', JSON.stringify({ status: 'alive', service: 'sploot-web', padding: 'x'.repeat(70 * 1024) })]) {
+      const { file, publicKey } = await keyFile();
+      const origin = await startServer((request, response) => {
+        response.setHeader('content-type', 'application/json');
+        if (body.length > 1000) {
+          response.write(body.slice(0, 1024));
+          setTimeout(() => response.end(body.slice(1024)), 1);
+        } else {
+          response.end(body);
+        }
+      });
+      const result = await run(await successfulArgs('forward', origin, file));
+      assert.notEqual(result.code, 0);
+      const packet = assertSignedFailure(result, publicKey);
+      assert.equal(result.stderr.includes('BEGIN PRIVATE KEY'), false);
+      await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+      servers = [];
+    }
+  });
+
+  it('rejects malformed unknown payloads and has no provider mutation path', async () => {
+    const { file, publicKey } = await keyFile();
+    const origin = await startServer((request, response) => {
+      if (request.url === '/api/health/live') {
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify({ status: 'alive', service: 'sploot-web', unknown: true }));
+        return;
+      }
+      response.statusCode = 500;
+      response.end('not-json');
+    });
+    const result = await run(await successfulArgs('forward', origin, file));
+    assert.notEqual(result.code, 0);
+    const packet = assertSignedFailure(result, publicKey);
+    const source = await readFile(SCRIPT, 'utf8');
+    assert.equal(source.includes('doctl'), false);
+    assert.equal(source.includes('mutation'), false);
+  });
+});


### PR DESCRIPTION
## what changed

- add read-only `release:verify` for forward and rollback-safety runtime probes
- emit closed `sploot.release-verification.v1` evidence with canonical Ed25519 signature, raw public key, and signed verifier identity
- fail closed with signed `ok:false` probe packets while redacting bearer/private material
- add deterministic local HTTP child coverage and deployment runbook schema

## proof

- `pnpm --filter web release:verify:test`
- `node --check apps/web/scripts/verify-release.mjs`
- `node --check apps/web/scripts/verify-release.test.mjs`
- `pnpm --filter web release:verify -- --help`

## gate note

Pre-commit/pre-push gitleaks and secrets passed. Hook typecheck could not run because this worktree has no installed `turbo`/node_modules; standalone web typecheck is also blocked by pre-existing repository parse errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release verification tooling that checks service health, readiness, enrollment, and optional rollback safety.
  * Generates signed verification evidence with strict validity windows and secure secret redaction.
  * Added commands for running verification and its automated test suite.

* **Documentation**
  * Documented verification modes, expected results, failure handling, evidence format, and signing requirements.

* **Tests**
  * Added coverage for successful verification, rollback checks, malformed responses, stale evidence, redirects, authentication failures, and oversized payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->