### PR TITLE
fix(db): detect owner-visibility migration failure through Postgres's cascade error

### DIFF
--- a/apps/web/__tests__/scripts/migrate-deploy.test.ts
+++ b/apps/web/__tests__/scripts/migrate-deploy.test.ts
@@ -417,6 +417,31 @@ describe('bootstrap failure handling with injected faults', () => {
     expect(isOwnerVisibilityEnforcementFailure(new Error('asset embedding visibility enforcement refused'))).toBe(false);
   });
 
+  it('regression 2026-07-23: recognizes the cascading transaction-aborted error Prisma actually surfaces when the RAISE fires mid-batch', () => {
+    // Production incident: schema-engine applies migration.sql as one
+    // multi-statement batch. The DO block's RAISE aborts the transaction,
+    // but the trailing ALTER TABLE statements in the same batch report
+    // Postgres's generic cascade error instead of the RAISE's own message,
+    // and only the last one reaches the thrown error.
+    const cascade = new Error('Command failed: prisma migrate deploy');
+    cascade.stderr = [
+      'Error: ERROR: current transaction is aborted, commands ignored until end of transaction block',
+      '   0: schema_commands::commands::apply_migrations::Applying migration',
+      '           with migration_name="20260717022000_enforce_asset_embedding_owner_visibility"',
+    ].join('\n');
+    expect(isOwnerVisibilityEnforcementFailure(cascade)).toBe(true);
+
+    // A different migration hitting the same generic cascade text must not
+    // be misclassified as the owner-visibility gate.
+    const unrelated = new Error('Command failed: prisma migrate deploy');
+    unrelated.stderr = [
+      'Error: ERROR: current transaction is aborted, commands ignored until end of transaction block',
+      '   0: schema_commands::commands::apply_migrations::Applying migration',
+      '           with migration_name="20260101000000_unrelated_migration"',
+    ].join('\n');
+    expect(isOwnerVisibilityEnforcementFailure(unrelated)).toBe(false);
+  });
+
   it('runs pre -> prisma migrate -> post with the declared version and writes no failure report', async () => {
     const harness = makeHarness();
     await runMigrateDeploy(harness.env, harness.runOptions);

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -122,8 +122,18 @@ export async function drainOwnerVisibilityBackfill(databaseUrl, options = {}) {
 
 export function isOwnerVisibilityEnforcementFailure(error) {
   const message = [error?.message, error?.stdout, error?.stderr].filter(Boolean).map(String).join('\n');
-  return message.includes(OWNER_VISIBILITY_MIGRATION)
-    && message.includes('asset embedding visibility enforcement refused');
+  if (!message.includes(OWNER_VISIBILITY_MIGRATION)) return false;
+  // Production incident 2026-07-23: the DO block's own RAISE EXCEPTION text
+  // ("asset embedding visibility enforcement refused: ...") is not always
+  // what Prisma surfaces. schema-engine applies a migration.sql file as one
+  // multi-statement batch; once the RAISE aborts the transaction, the two
+  // trailing ALTER TABLE statements each fail with Postgres's generic
+  // cascade error, and only the LAST one reaches this error's message. The
+  // migration-name anchor above already scopes this to the one file whose
+  // only failure mode is the backfill-remaining check, so treating the
+  // cascade as equivalent evidence is safe.
+  return message.includes('asset embedding visibility enforcement refused')
+    || message.includes('current transaction is aborted, commands ignored until end of transaction block');
 }
 
 // Spawns apply-online-embedding-index.mjs as its own process (not an


### PR DESCRIPTION
## Summary

Enabling `deploy_on_push` (#312) triggered production's first real deploy in weeks and immediately surfaced a latent bug in the two-phase owner-visibility migration's self-healing retry.

## Incident

Deployment `01b99daf-0212-452c-acda-947e3934e5ad` (triggered by the #312 merge) failed at PRE_DEPLOY:

```
Error: ERROR: current transaction is aborted, commands ignored until end of transaction block
   0: schema_commands::commands::apply_migrations::Applying migration
           with migration_name="20260717022000_enforce_asset_embedding_owner_visibility"
```

`migrate-deploy.mjs` already has a self-healing path for exactly this migration (`drainOwnerVisibilityBackfill` + `prisma migrate resolve --rolled-back` + retry), gated by `isOwnerVisibilityEnforcementFailure()`. It never engaged, because that function required the migration's own `RAISE EXCEPTION` text (`'asset embedding visibility enforcement refused'`) to appear in the error — but schema-engine applies `migration.sql` as one multi-statement batch, so once the `DO` block's `RAISE` aborts the transaction, the two trailing `ALTER TABLE` statements each fail with Postgres's generic cascade error instead, and only the last one reaches the thrown error. The RAISE's own message never surfaces.

## Fix

`isOwnerVisibilityEnforcementFailure()` now also accepts the generic cascade text (`'current transaction is aborted, commands ignored until end of transaction block'`), still anchored to the exact migration name so a genuinely different failure on a different migration can never be misclassified as recoverable.

## Production impact

None — the PRE_DEPLOY gate correctly refused both cutover attempts (the original push and DigitalOcean's automated rollback retry). Production is still serving the prior commit; verified `/api/health/live` returns `200 alive` throughout. This PR only fixes the retry path so the *next* deploy attempt (triggered automatically by this merge) can drain the backfill and complete.

## Verification

- New regression test reproduces the exact cascade text from the failed deployment's logs, plus a negative case proving an unrelated migration hitting the same generic text is not misclassified.
- `pnpm --filter web exec vitest run __tests__/scripts/migrate-deploy.test.ts __tests__/scripts/enrollment-lifecycle.test.ts` — 84/84 passed
- `pnpm type-check` — 4/4 packages passed

Once merged, `deploy_on_push` will trigger a new deployment; I'll watch it complete end-to-end (build → PRE_DEPLOY backfill-drain-and-retry → cutover) as final proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment migration handling for an alternate PostgreSQL transaction error associated with owner-visibility enforcement.
  * Deployments can now continue through the appropriate recovery and retry process when this error variant occurs.
  * Added regression coverage to ensure unrelated migration errors are not treated as recoverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->