### PR TITLE
fix(db): self-heal a stale unfinished owner-visibility row before the history pre-check

### DIFF
--- a/apps/web/__tests__/scripts/migrate-deploy.test.ts
+++ b/apps/web/__tests__/scripts/migrate-deploy.test.ts
@@ -420,10 +420,61 @@ describe('bootstrap failure handling with injected faults', () => {
     expect(harness.readReport()).toBeNull();
   });
 
+  it('regression 2026-07-23: self-heals a stale unfinished owner-visibility row before applyMigrations ever runs', async () => {
+    // Production incident: a PRIOR failed deploy attempt left the
+    // owner-visibility migration unfinished-but-not-rolled-back. Every
+    // subsequent attempt's own history pre-check (which runs BEFORE
+    // applyMigrations()) then fails closed with "unfinished migration",
+    // so the existing applyMigrations()-side retry above never gets a
+    // chance to run. The pre-check itself must now drain+resolve too.
+    const harness = makeHarness();
+    const backfillUrls: string[] = [];
+    let historyCallCount = 0;
+    const resolveCalls: string[] = [];
+    await runMigrateDeploy(harness.env, {
+      ...harness.runOptions,
+      checkMigrationHistory: async (url: string) => {
+        historyCallCount += 1;
+        if (historyCallCount === 1) {
+          throw new Error('[migration-history] unfinished migration 20260717022000_enforce_asset_embedding_owner_visibility; deployment is paused');
+        }
+        return { status: 'verified', checked: 44 };
+      },
+      runOwnerVisibilityBackfill: async (url: string) => { backfillUrls.push(url); },
+    });
+    const log = harness.readLog();
+    resolveCalls.push(...log.split('\n').filter((line) => line.includes('migrate resolve --rolled-back')));
+    expect(historyCallCount).toBe(2);
+    expect(backfillUrls).toEqual(['postgresql://migrator:secret@db.example.test/app']);
+    expect(resolveCalls).toHaveLength(1);
+    expect(log).toContain('prisma migrate deploy');
+    // The pre-check's own resolve must run before the first real
+    // "prisma migrate deploy" attempt, not after it.
+    expect(log.indexOf('migrate resolve --rolled-back')).toBeLessThan(log.indexOf('prisma migrate deploy'));
+    expect(harness.readReport()).toBeNull();
+  });
+
   it('recognizes only the owner enforcement gate as recoverable', () => {
     expect(isOwnerVisibilityEnforcementFailure(new Error('P3018 20260717022000_enforce_asset_embedding_owner_visibility: asset embedding visibility enforcement refused: 1 rows remain'))).toBe(true);
     expect(isOwnerVisibilityEnforcementFailure(new Error('P3018 20260717022000_enforce_asset_embedding_owner_visibility: lock timeout'))).toBe(false);
     expect(isOwnerVisibilityEnforcementFailure(new Error('asset embedding visibility enforcement refused'))).toBe(false);
+  });
+
+  it('regression 2026-07-23: recognizes the pre-check "unfinished migration" text a stale unresolved row leaves behind', () => {
+    expect(isOwnerVisibilityEnforcementFailure(new Error(
+      '[migration-history] unfinished migration 20260717022000_enforce_asset_embedding_owner_visibility; deployment is paused',
+    ))).toBe(true);
+    // A different unfinished migration must never be misclassified.
+    expect(isOwnerVisibilityEnforcementFailure(new Error(
+      '[migration-history] unfinished migration 20260101000000_unrelated_migration; deployment is paused',
+    ))).toBe(false);
+    // The compatibility-branch variant names a distinct condition
+    // ("unfinished compatibility migration") that does not contain the
+    // plain phrase as a contiguous substring, so it is not (yet) treated
+    // as this specific recoverable gate.
+    expect(isOwnerVisibilityEnforcementFailure(new Error(
+      '[migration-history] unfinished compatibility migration 20260717022000_enforce_asset_embedding_owner_visibility; deployment is paused',
+    ))).toBe(false);
   });
 
   it('regression 2026-07-23: recognizes the cascading transaction-aborted error Prisma actually surfaces when the RAISE fires mid-batch', () => {

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -133,7 +133,8 @@ export function isOwnerVisibilityEnforcementFailure(error) {
   // only failure mode is the backfill-remaining check, so treating the
   // cascade as equivalent evidence is safe.
   return message.includes('asset embedding visibility enforcement refused')
-    || message.includes('current transaction is aborted, commands ignored until end of transaction block');
+    || message.includes('current transaction is aborted, commands ignored until end of transaction block')
+    || message.includes('unfinished migration');
 }
 
 // Spawns apply-online-embedding-index.mjs as its own process (not an
@@ -218,11 +219,28 @@ export async function runMigrateDeploy(env = process.env, options = {}) {
     // default is the workspace pg-client readback (no psql binary needed in
     // the PRE_DEPLOY image). Any history failure pauses the deployment.
     const historyCheck = options.checkMigrationHistory ?? checkDatabaseMigrationHistory;
-    await historyCheck(migrationAuthorityUrl ? deriveDirectUrl(migrationAuthorityUrl) : directUrl);
+    const migrationDatabaseUrl = migrationAuthorityUrl ? deriveDirectUrl(migrationAuthorityUrl) : directUrl;
+    try {
+      await historyCheck(migrationDatabaseUrl);
+    } catch (error) {
+      // A prior deploy attempt can leave the owner-visibility migration
+      // unfinished-but-not-rolled-back (production incident 2026-07-23): the
+      // history gate then fails closed on EVERY subsequent attempt, before
+      // applyMigrations() below ever runs, so its own retry path never gets
+      // a chance to self-heal. Resolve the same known-recoverable gate here
+      // too, then re-verify history before proceeding.
+      if (!isOwnerVisibilityEnforcementFailure(error)) throw error;
+      stage = 'owner-visibility-backfill-precheck';
+      const backfill = options.runOwnerVisibilityBackfill ?? drainOwnerVisibilityBackfill;
+      await backfill(migrationDatabaseUrl);
+      execFileSync('prisma', ['migrate', 'resolve', '--rolled-back', OWNER_VISIBILITY_MIGRATION], { stdio: 'inherit', env: { ...env, DATABASE_URL: migrationDatabaseUrl } });
+      stage = 'prisma-migrate';
+      await historyCheck(migrationDatabaseUrl);
+    }
     console.log('[migrate-deploy] running prisma migrate deploy...');
     const migrationEnv = {
       ...env,
-      DATABASE_URL: migrationAuthorityUrl ? deriveDirectUrl(migrationAuthorityUrl) : directUrl,
+      DATABASE_URL: migrationDatabaseUrl,
       PGOPTIONS: [env.PGOPTIONS, '-c lock_timeout=5s', '-c statement_timeout=30s'].filter(Boolean).join(' '),
     };
     const applyMigrations = () => {
@@ -247,7 +265,7 @@ export async function runMigrateDeploy(env = process.env, options = {}) {
     }
     if (options.applyOnlineIndex ?? (env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'test')) {
       stage = 'online-indexes';
-      applyOnlineIndexes(migrationAuthorityUrl ? deriveDirectUrl(migrationAuthorityUrl) : directUrl, env);
+      applyOnlineIndexes(migrationDatabaseUrl, env);
     }
     stage = 'post-bootstrap';
     if (bootstrapUrl) privileged(post);


### PR DESCRIPTION
## Summary

Third distinct issue in the auto-deploy incident chain (#312 → #313 → #314 → #315 → this). After #315's reordering fix merged, the triggered deploy failed on a *different* error: `checkDatabaseMigrationHistory`'s pre-check (which runs before `applyMigrations()`) fails closed with `unfinished migration 20260717022000_enforce_asset_embedding_owner_visibility`, because a prior failed run left that row unfinished-but-not-rolled-back. #313's `applyMigrations()`-side retry never gets a chance to run — the pre-check throws first, on every subsequent attempt, forever.

Production is unaffected — PRE_DEPLOY has refused cutover on every attempt; the app is still serving the prior commit throughout.

## Fix

`runMigrateDeploy` now wraps the `historyCheck` call in the same drain+resolve retry as `applyMigrations()`: on an owner-visibility-recoverable failure, it drains the backfill, resolves the migration as rolled-back, and re-verifies history before proceeding. `isOwnerVisibilityEnforcementFailure` now also recognizes the pre-check's `unfinished migration` text, still anchored to the exact migration name so an unrelated migration's genuine stuck state is never misclassified.

## Verification

- New regression test drives `runMigrateDeploy` with a stateful `checkMigrationHistory` stub that fails once then succeeds, confirming the backfill/resolve/re-check sequence runs *before* the first real `prisma migrate deploy` attempt.
- New detector unit test covers the exact pre-check error text, a negative case for an unrelated migration name, and the distinct `unfinished compatibility migration` branch text (verified empirically not to collide).
- `pnpm --filter web exec vitest run __tests__/scripts/migrate-deploy.test.ts __tests__/scripts/enrollment-lifecycle.test.ts __tests__/scripts/upload-idempotency-migration.test.ts` — 87/87 passed
- `node --test scripts/check-migration-history.test.mjs` — 7/7 passed
- `pnpm type-check` — 4/4 packages passed
- `pnpm lint` — 0 errors

Once merged, watching the next auto-deploy through to completion as final proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment recovery when owner-visibility migrations are interrupted or partially completed.
  - Deployments now automatically repair eligible migration states and retry before reporting a failure.
  - Improved detection of recoverable migration errors while avoiding recovery for unrelated migration issues.
  - Standardized migration connection handling to improve reliability across deployment steps.
- **Tests**
  - Added regression coverage for automatic recovery and migration error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->