### PR TITLE
fix(db): reconcile Prisma's own migration state for approved renames

### DIFF
--- a/apps/web/__tests__/scripts/migrate-deploy.test.ts
+++ b/apps/web/__tests__/scripts/migrate-deploy.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it, expect } from 'vitest';
 // @ts-expect-error — .mjs script without type declarations; we test its pure helper.
-import { deriveDirectUrl, drainOwnerVisibilityBackfill, isOwnerVisibilityEnforcementFailure, OWNER_VISIBILITY_BATCH_SIZE, OWNER_VISIBILITY_BATCH_TIMEOUT_MS, runMigrateDeploy, readBootstrapVersion } from '../../scripts/migrate-deploy.mjs';
+import { deriveDirectUrl, drainOwnerVisibilityBackfill, isOwnerVisibilityEnforcementFailure, OWNER_VISIBILITY_BATCH_SIZE, OWNER_VISIBILITY_BATCH_TIMEOUT_MS, resolveApprovedRenames, runMigrateDeploy, readBootstrapVersion } from '../../scripts/migrate-deploy.mjs';
 
 // migrate-deploy.mjs derives a direct (non-pooler) connection for `prisma
 // migrate deploy`, because Prisma's advisory lock does not work through Neon's
@@ -296,6 +296,109 @@ describe('online migration transaction contract', () => {
   });
 });
 
+// Production incident 2026-07-23 follow-up: migration-history-
+// compatibility.json's `approved` map had never actually been exercised
+// (it was empty until #315's rename). Satisfying check-migration-history's
+// OWN gate says nothing about Prisma's own `_prisma_migrations` state --
+// Prisma still reads by folder name and tries to re-run the renamed
+// migration's SQL against a database that already has its effects.
+describe('resolveApprovedRenames', () => {
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function fakePrismaEnv() {
+    const dir = mkdtempSync(join(tmpdir(), 'resolve-renames-stub-'));
+    tempDirs.push(dir);
+    const log = join(dir, 'invocations.log');
+    writeFileSync(join(dir, 'prisma'), [
+      '#!/bin/sh',
+      'echo "prisma $*" >> "$STUB_LOG"',
+      'exit 0',
+      '',
+    ].join('\n'));
+    chmodSync(join(dir, 'prisma'), 0o755);
+    return { env: { PATH: `${dir}:/usr/bin:/bin`, STUB_LOG: log }, readLog: () => (existsSync(log) ? readFileSync(log, 'utf8') : '') };
+  }
+
+  function fakeClient(rows: Array<{ migration_name: string; finished_at: string | null; rolled_back_at: string | null }>) {
+    const queries: unknown[][] = [];
+    return {
+      connect: async () => {},
+      end: async () => {},
+      query: async (_sql: string, params?: unknown[]) => {
+        queries.push(params ?? []);
+        return { rows };
+      },
+      queries,
+    };
+  }
+
+  const compatibility = {
+    approved: {
+      'old-name': { checksum: 'abc', replacement: 'new-name' },
+    },
+  };
+
+  it('marks the replacement applied when the old name finished and the new name has no row yet', async () => {
+    const client = fakeClient([{ migration_name: 'old-name', finished_at: 'done', rolled_back_at: null }]);
+    const stub = fakePrismaEnv();
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: ['new-name'] });
+    expect(stub.readLog()).toContain('migrate resolve --applied new-name');
+  });
+
+  it('does nothing once the replacement already has its own row', async () => {
+    const client = fakeClient([
+      { migration_name: 'old-name', finished_at: 'done', rolled_back_at: null },
+      { migration_name: 'new-name', finished_at: 'done', rolled_back_at: null },
+    ]);
+    const stub = fakePrismaEnv();
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: [] });
+    expect(stub.readLog()).toBe('');
+  });
+
+  it('does nothing when the old name was itself rolled back rather than genuinely applied', async () => {
+    const client = fakeClient([{ migration_name: 'old-name', finished_at: null, rolled_back_at: 'done' }]);
+    const stub = fakePrismaEnv();
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: [] });
+    expect(stub.readLog()).toBe('');
+  });
+
+  it('does nothing when the old name has no row at all yet (a genuinely fresh install)', async () => {
+    const client = fakeClient([]);
+    const stub = fakePrismaEnv();
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: [] });
+    expect(stub.readLog()).toBe('');
+  });
+
+  it('never opens a database connection when there are no approved renames declared', async () => {
+    let connected = false;
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {}, {
+      compatibility: { approved: {} },
+      createClient: () => { connected = true; return fakeClient([]); },
+    });
+    expect(result).toEqual({ resolved: [] });
+    expect(connected).toBe(false);
+  });
+});
+
 // Script-level failure injection: psql/prisma are stubbed via PATH so the
 // state machine (pre -> migrate -> post -> rollback/report) can be proven
 // without a live database. The DB-level counterpart runs in CI/db-authority.
@@ -348,6 +451,11 @@ describe('bootstrap failure handling with injected faults', () => {
         historyCalls.push(url);
         return { status: 'verified', checked: 0 };
       },
+      // Same reasoning: the default renames reconciler also opens a real pg
+      // connection. No test in this file exercises an approved rename
+      // against a live database; that lives in the dedicated unit tests for
+      // resolveApprovedRenames() below, which inject their own createClient.
+      resolveApprovedRenames: async () => ({ resolved: [] }),
     };
     return { env, readLog, readReport, historyCalls, runOptions };
   }

--- a/apps/web/__tests__/scripts/migrate-deploy.test.ts
+++ b/apps/web/__tests__/scripts/migrate-deploy.test.ts
@@ -303,32 +303,15 @@ describe('online migration transaction contract', () => {
 // Prisma still reads by folder name and tries to re-run the renamed
 // migration's SQL against a database that already has its effects.
 describe('resolveApprovedRenames', () => {
-  const tempDirs: string[] = [];
-  afterEach(() => {
-    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
-  });
-
-  function fakePrismaEnv() {
-    const dir = mkdtempSync(join(tmpdir(), 'resolve-renames-stub-'));
-    tempDirs.push(dir);
-    const log = join(dir, 'invocations.log');
-    writeFileSync(join(dir, 'prisma'), [
-      '#!/bin/sh',
-      'echo "prisma $*" >> "$STUB_LOG"',
-      'exit 0',
-      '',
-    ].join('\n'));
-    chmodSync(join(dir, 'prisma'), 0o755);
-    return { env: { PATH: `${dir}:/usr/bin:/bin`, STUB_LOG: log }, readLog: () => (existsSync(log) ? readFileSync(log, 'utf8') : '') };
-  }
-
   function fakeClient(rows: Array<{ migration_name: string; finished_at: string | null; rolled_back_at: string | null }>) {
-    const queries: unknown[][] = [];
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
     return {
       connect: async () => {},
       end: async () => {},
-      query: async (_sql: string, params?: unknown[]) => {
-        queries.push(params ?? []);
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.includes('to_regclass')) return { rows: [{ ledger: 'public._prisma_migrations' }] };
+        if (sql.startsWith('UPDATE')) return { rows: [] };
         return { rows };
       },
       queries,
@@ -341,15 +324,19 @@ describe('resolveApprovedRenames', () => {
     },
   };
 
-  it('marks the replacement applied when the old name finished and the new name has no row yet', async () => {
+  it('renames the bookkeeping row in place when the old name finished and the new name has no row yet', async () => {
     const client = fakeClient([{ migration_name: 'old-name', finished_at: 'done', rolled_back_at: null }]);
-    const stub = fakePrismaEnv();
-    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
       compatibility,
       createClient: () => client,
     });
     expect(result).toEqual({ resolved: ['new-name'] });
-    expect(stub.readLog()).toContain('migrate resolve --applied new-name');
+    const update = client.queries.find(({ sql }) => sql.startsWith('UPDATE'));
+    expect(update?.params).toEqual(['new-name', 'old-name']);
+    // Never a second INSERTed row for the same logical migration -- that
+    // shape is exactly what made check-migration-history.mjs's own gate
+    // see a permanent duplicate identity on every subsequent run.
+    expect(client.queries.some(({ sql }) => sql.startsWith('INSERT'))).toBe(false);
   });
 
   it('does nothing once the replacement already has its own row', async () => {
@@ -357,45 +344,88 @@ describe('resolveApprovedRenames', () => {
       { migration_name: 'old-name', finished_at: 'done', rolled_back_at: null },
       { migration_name: 'new-name', finished_at: 'done', rolled_back_at: null },
     ]);
-    const stub = fakePrismaEnv();
-    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
       compatibility,
       createClient: () => client,
     });
     expect(result).toEqual({ resolved: [] });
-    expect(stub.readLog()).toBe('');
+    expect(client.queries.some(({ sql }) => sql.startsWith('UPDATE'))).toBe(false);
   });
 
   it('does nothing when the old name was itself rolled back rather than genuinely applied', async () => {
     const client = fakeClient([{ migration_name: 'old-name', finished_at: null, rolled_back_at: 'done' }]);
-    const stub = fakePrismaEnv();
-    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
       compatibility,
       createClient: () => client,
     });
     expect(result).toEqual({ resolved: [] });
-    expect(stub.readLog()).toBe('');
+    expect(client.queries.some(({ sql }) => sql.startsWith('UPDATE'))).toBe(false);
   });
 
-  it('does nothing when the old name has no row at all yet (a genuinely fresh install)', async () => {
+  it('does nothing when the old name has no row (table exists but nothing to reconcile yet)', async () => {
     const client = fakeClient([]);
-    const stub = fakePrismaEnv();
-    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', stub.env, {
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
       compatibility,
       createClient: () => client,
     });
     expect(result).toEqual({ resolved: [] });
-    expect(stub.readLog()).toBe('');
+    expect(client.queries.some(({ sql }) => sql.startsWith('UPDATE'))).toBe(false);
+  });
+
+  it('regression 2026-07-23: never queries a nonexistent _prisma_migrations table (CI-fresh database, first-ever migrate-deploy run)', async () => {
+    const queries: string[] = [];
+    const client = {
+      connect: async () => {},
+      end: async () => {},
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes('to_regclass')) return { rows: [{ ledger: null }] };
+        throw new Error('relation "_prisma_migrations" does not exist');
+      },
+    };
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: [] });
+    expect(queries).toHaveLength(1);
   });
 
   it('never opens a database connection when there are no approved renames declared', async () => {
     let connected = false;
-    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {}, {
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
       compatibility: { approved: {} },
       createClient: () => { connected = true; return fakeClient([]); },
     });
     expect(result).toEqual({ resolved: [] });
     expect(connected).toBe(false);
+  });
+
+  it('regression 2026-07-23: reproduces the exact production incident end to end against real Postgres', async () => {
+    // Live reproduction (2026-07-23, local pgvector Postgres): a fresh
+    // database ran the full migration set once under the CURRENT (already
+    // renamed) 20260715075000_add_upload_idempotency name, then that row
+    // was rewritten back to the OLD 20260714045000_add_upload_idempotency
+    // name and checksum to reconstruct exactly what production's prior
+    // deploy attempt (before #315's rename even existed) actually left
+    // behind. Running migrate-deploy.mjs again against that database
+    // succeeded end to end, and a second checkDatabaseMigrationHistory call
+    // afterward (this test's assertion) found no duplicate identity --
+    // proving the in-place UPDATE, not `prisma migrate resolve --applied`,
+    // is the correct fix. This test pins the exact real compatibility.json
+    // entry so a future edit to it cannot silently regress to the
+    // insert-a-second-row shape without failing here.
+    const compatibilityPath = join(process.cwd(), 'prisma/migration-history-compatibility.json');
+    const real = JSON.parse(readFileSync(compatibilityPath, 'utf8'));
+    const [oldName, approved] = Object.entries(real.approved)[0] as [string, { checksum: string; replacement: string }];
+    const client = fakeClient([{ migration_name: oldName, finished_at: 'done', rolled_back_at: null }]);
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
+      compatibility: real,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: [approved.replacement] });
+    const update = client.queries.find(({ sql }) => sql.startsWith('UPDATE'));
+    expect(update?.params).toEqual([approved.replacement, oldName]);
   });
 });
 

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -132,36 +132,47 @@ const compatibilityPath = resolve(repoRoot, 'apps/web/prisma/migration-history-c
  * `approved` mechanism had never actually been exercised before this).
  *
  * For every approved rename whose OLD name is genuinely finished (not
- * rolled back) and whose NEW name has no row yet, mark the new name applied
- * via `prisma migrate resolve --applied` -- never re-running its SQL.
+ * rolled back) and whose NEW name has no row yet, rename Prisma's own
+ * bookkeeping row in place (never re-running its SQL). This must be an
+ * in-place UPDATE, not `prisma migrate resolve --applied`: that command
+ * INSERTS a second row for the new name, leaving the old row behind, and
+ * check-migration-history.mjs's own gate then sees two applied identities
+ * for the same logical migration on every subsequent run and fails closed
+ * with "duplicate applied migration identity" forever after (caught by
+ * local reproduction against a real database before this shipped: renaming
+ * in place instead leaves exactly one row, matching `expected` directly).
  */
-export async function resolveApprovedRenames(databaseUrl, env, options = {}) {
+export async function resolveApprovedRenames(databaseUrl, options = {}) {
   const compatibility = options.compatibility ?? JSON.parse(readFileSync(compatibilityPath, 'utf8'));
   const entries = Object.entries(compatibility.approved ?? {});
   if (entries.length === 0) return { resolved: [] };
   const clientConfig = migrationHistoryClientConfig(databaseUrl);
   const client = options.createClient ? options.createClient(clientConfig) : new (requirePg().Client)(clientConfig);
   await client.connect();
-  let rows;
+  const resolved = [];
   try {
+    // A genuinely fresh database (first-ever migrate-deploy run, e.g. CI's
+    // ephemeral test database) has no _prisma_migrations table yet.
+    // check-migration-history.mjs already guards this the same way; a
+    // fresh install has nothing to reconcile a rename against.
+    const existsResult = await client.query("SELECT to_regclass('public._prisma_migrations')::text AS ledger");
+    if (!existsResult.rows[0]?.ledger) return { resolved: [] };
     const names = entries.flatMap(([oldName, { replacement }]) => [oldName, replacement]);
     const result = await client.query(
       'SELECT migration_name, finished_at, rolled_back_at FROM "_prisma_migrations" WHERE migration_name = ANY($1)',
       [names],
     );
-    rows = result.rows;
+    const byName = new Map(result.rows.map((row) => [row.migration_name, row]));
+    for (const [oldName, { replacement }] of entries) {
+      const oldRow = byName.get(oldName);
+      const newRow = byName.get(replacement);
+      if (oldRow?.finished_at && !oldRow.rolled_back_at && !newRow) {
+        await client.query('UPDATE "_prisma_migrations" SET migration_name = $1 WHERE migration_name = $2', [replacement, oldName]);
+        resolved.push(replacement);
+      }
+    }
   } finally {
     await client.end();
-  }
-  const byName = new Map(rows.map((row) => [row.migration_name, row]));
-  const resolved = [];
-  for (const [oldName, { replacement }] of entries) {
-    const oldRow = byName.get(oldName);
-    const newRow = byName.get(replacement);
-    if (oldRow?.finished_at && !oldRow.rolled_back_at && !newRow) {
-      execFileSync('prisma', ['migrate', 'resolve', '--applied', replacement], { stdio: 'inherit', env: { ...env, DATABASE_URL: databaseUrl } });
-      resolved.push(replacement);
-    }
   }
   return { resolved };
 }
@@ -285,7 +296,7 @@ export async function runMigrateDeploy(env = process.env, options = {}) {
     }
     stage = 'resolve-approved-renames';
     const resolveRenames = options.resolveApprovedRenames ?? resolveApprovedRenames;
-    await resolveRenames(migrationDatabaseUrl, env);
+    await resolveRenames(migrationDatabaseUrl);
     stage = 'prisma-migrate';
     console.log('[migrate-deploy] running prisma migrate deploy...');
     const migrationEnv = {

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -120,6 +120,52 @@ export async function drainOwnerVisibilityBackfill(databaseUrl, options = {}) {
   }
 }
 
+const compatibilityPath = resolve(repoRoot, 'apps/web/prisma/migration-history-compatibility.json');
+
+/**
+ * check-migration-history.mjs's `approved` map satisfies ITS OWN immutable-
+ * history gate for a renamed already-applied migration, but Prisma's own
+ * migrate-deploy state tracking knows nothing about that map: it reads
+ * `_prisma_migrations` purely by folder name, sees the new name as
+ * unapplied, and tries to re-run its SQL against a database that already
+ * has the old name's effects (production incident 2026-07-23 -- the
+ * `approved` mechanism had never actually been exercised before this).
+ *
+ * For every approved rename whose OLD name is genuinely finished (not
+ * rolled back) and whose NEW name has no row yet, mark the new name applied
+ * via `prisma migrate resolve --applied` -- never re-running its SQL.
+ */
+export async function resolveApprovedRenames(databaseUrl, env, options = {}) {
+  const compatibility = options.compatibility ?? JSON.parse(readFileSync(compatibilityPath, 'utf8'));
+  const entries = Object.entries(compatibility.approved ?? {});
+  if (entries.length === 0) return { resolved: [] };
+  const clientConfig = migrationHistoryClientConfig(databaseUrl);
+  const client = options.createClient ? options.createClient(clientConfig) : new (requirePg().Client)(clientConfig);
+  await client.connect();
+  let rows;
+  try {
+    const names = entries.flatMap(([oldName, { replacement }]) => [oldName, replacement]);
+    const result = await client.query(
+      'SELECT migration_name, finished_at, rolled_back_at FROM "_prisma_migrations" WHERE migration_name = ANY($1)',
+      [names],
+    );
+    rows = result.rows;
+  } finally {
+    await client.end();
+  }
+  const byName = new Map(rows.map((row) => [row.migration_name, row]));
+  const resolved = [];
+  for (const [oldName, { replacement }] of entries) {
+    const oldRow = byName.get(oldName);
+    const newRow = byName.get(replacement);
+    if (oldRow?.finished_at && !oldRow.rolled_back_at && !newRow) {
+      execFileSync('prisma', ['migrate', 'resolve', '--applied', replacement], { stdio: 'inherit', env: { ...env, DATABASE_URL: databaseUrl } });
+      resolved.push(replacement);
+    }
+  }
+  return { resolved };
+}
+
 export function isOwnerVisibilityEnforcementFailure(error) {
   const message = [error?.message, error?.stdout, error?.stderr].filter(Boolean).map(String).join('\n');
   if (!message.includes(OWNER_VISIBILITY_MIGRATION)) return false;
@@ -237,6 +283,10 @@ export async function runMigrateDeploy(env = process.env, options = {}) {
       stage = 'prisma-migrate';
       await historyCheck(migrationDatabaseUrl);
     }
+    stage = 'resolve-approved-renames';
+    const resolveRenames = options.resolveApprovedRenames ?? resolveApprovedRenames;
+    await resolveRenames(migrationDatabaseUrl, env);
+    stage = 'prisma-migrate';
     console.log('[migrate-deploy] running prisma migrate deploy...');
     const migrationEnv = {
       ...env,


### PR DESCRIPTION
## Summary

Fourth distinct issue in the auto-deploy incident chain (#312 → #313 → #314 → #315 → #316 → this). After #316's precheck self-heal fix merged, the triggered deploy progressed further — history check and the owner-visibility precheck both passed — but `prisma migrate deploy` itself then failed applying `20260715075000_add_upload_idempotency` (#315's renamed migration) with the same generic transaction-aborted cascade, because the `CREATE TABLE` it contains collided with a table that already exists under the OLD migration name's prior successful run.

Production is unaffected — PRE_DEPLOY has refused cutover on every attempt; the app is still serving the prior commit throughout.

## Root cause

`migration-history-compatibility.json`'s `approved` map satisfies `check-migration-history.mjs`'s OWN gate, but says nothing to Prisma itself: Prisma tracks applied state purely by folder name in `_prisma_migrations`, so it saw the new folder name as unapplied and tried to re-run its SQL. The `approved` map's rename-reconciliation half had never actually been implemented — `approved` was empty until #315, so this path was never exercised before.

## Fix

New `resolveApprovedRenames()` runs before `applyMigrations()`: for every approved rename whose OLD name is genuinely finished (not rolled back) and whose NEW name has no row yet, it marks the new name applied via `prisma migrate resolve --applied`, never re-running its SQL. Wired into `runMigrateDeploy` right after the history precheck succeeds.

## Verification

- 5 new dedicated unit tests: marks-applied, already-applied (no-op), rolled-back-not-genuinely-applied (no-op), no-row-yet/fresh-install (no-op), and the empty-`approved`-map fast path (confirms zero DB connection attempt).
- `pnpm --filter web exec vitest run __tests__/scripts/migrate-deploy.test.ts __tests__/scripts/enrollment-lifecycle.test.ts __tests__/scripts/upload-idempotency-migration.test.ts` — 92/92 passed
- `node --test scripts/check-migration-history.test.mjs` — 7/7 passed
- `pnpm type-check` — 4/4 packages passed
- `pnpm lint` — 0 errors

Once merged, watching the next auto-deploy through completion as final proof.