### PR TITLE
fix(db): run resolveApprovedRenames before the history gate, not after

### DIFF
--- a/apps/web/__tests__/scripts/migrate-deploy.test.ts
+++ b/apps/web/__tests__/scripts/migrate-deploy.test.ts
@@ -352,6 +352,45 @@ describe('resolveApprovedRenames', () => {
     expect(client.queries.some(({ sql }) => sql.startsWith('UPDATE'))).toBe(false);
   });
 
+  it('regression 2026-07-23: rolls back a stray unfinished new-name row left by a prior failed re-application, then renames the old row into place', async () => {
+    // Production incident follow-up: a deploy attempt before this
+    // reconciliation step existed let Prisma re-run the replacement's SQL
+    // for real (not via `resolve --applied`), inserting a started-but-
+    // never-finished row. Every regular migration in this repo is
+    // transaction-wrapped, so that row has no persisted schema effect --
+    // it must be marked rolled back, not left to collide with the rename.
+    const client = fakeClient([
+      { migration_name: 'old-name', finished_at: 'done', rolled_back_at: null },
+      { migration_name: 'new-name', finished_at: null, rolled_back_at: null },
+    ]);
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: ['new-name'] });
+    const rollback = client.queries.find(({ sql }) => sql.startsWith('UPDATE') && sql.includes('rolled_back_at'));
+    expect(rollback?.params).toEqual(['new-name']);
+    const rename = client.queries.find(({ sql }) => sql.startsWith('UPDATE') && sql.includes('SET migration_name'));
+    expect(rename?.params).toEqual(['new-name', 'old-name']);
+    // The rollback must be issued before the rename, so a database read
+    // between the two statements never observes two live (non-rolled-back)
+    // rows sharing the replacement name.
+    expect(client.queries.indexOf(rollback!)).toBeLessThan(client.queries.indexOf(rename!));
+  });
+
+  it('leaves an already rolled-back new-name row alone rather than guessing at a second reconciliation', async () => {
+    const client = fakeClient([
+      { migration_name: 'old-name', finished_at: 'done', rolled_back_at: null },
+      { migration_name: 'new-name', finished_at: null, rolled_back_at: 'done' },
+    ]);
+    const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
+      compatibility,
+      createClient: () => client,
+    });
+    expect(result).toEqual({ resolved: [] });
+    expect(client.queries.some(({ sql }) => sql.startsWith('UPDATE'))).toBe(false);
+  });
+
   it('does nothing when the old name was itself rolled back rather than genuinely applied', async () => {
     const client = fakeClient([{ migration_name: 'old-name', finished_at: null, rolled_back_at: 'done' }]);
     const result = await resolveApprovedRenames('postgresql://u:p@db.example.test/app', {
@@ -592,6 +631,36 @@ describe('bootstrap failure handling with injected faults', () => {
     expect(harness.readReport()).toBeNull();
   });
 
+  it('regression 2026-07-23: runs resolveApprovedRenames before checkMigrationHistory, not after', async () => {
+    // Production incident follow-up: resolveApprovedRenames ran AFTER
+    // checkMigrationHistory, so a database left with both a compat-approved
+    // old row and the replacement's own row (from the prior INSERT-based
+    // bug, or any other stuck partial re-application) made the history
+    // gate throw "duplicate applied migration identity" before the renames
+    // reconciler -- whose entire purpose is to prevent exactly that -- ever
+    // got a chance to run. This harness's own checkMigrationHistory stub
+    // simulates that failure mode unless the rename call already landed.
+    const harness = makeHarness();
+    const calls: string[] = [];
+    let renamed = false;
+    await runMigrateDeploy(harness.env, {
+      ...harness.runOptions,
+      resolveApprovedRenames: async () => {
+        calls.push('resolveApprovedRenames');
+        renamed = true;
+        return { resolved: ['new-name'] };
+      },
+      checkMigrationHistory: async (url: string) => {
+        calls.push('checkMigrationHistory');
+        if (!renamed) {
+          throw new Error('[migration-history] duplicate applied migration identity new-name; deployment is paused');
+        }
+        return { status: 'verified', checked: 44 };
+      },
+    });
+    expect(calls).toEqual(['resolveApprovedRenames', 'checkMigrationHistory']);
+  });
+
   it('recognizes only the owner enforcement gate as recoverable', () => {
     expect(isOwnerVisibilityEnforcementFailure(new Error('P3018 20260717022000_enforce_asset_embedding_owner_visibility: asset embedding visibility enforcement refused: 1 rows remain'))).toBe(true);
     expect(isOwnerVisibilityEnforcementFailure(new Error('P3018 20260717022000_enforce_asset_embedding_owner_visibility: lock timeout'))).toBe(false);
@@ -663,6 +732,7 @@ describe('bootstrap failure handling with injected faults', () => {
   it('pauses the deployment and rolls back when the immutable-history gate rejects', async () => {
     const harness = makeHarness();
     await expect(runMigrateDeploy(harness.env, {
+      ...harness.runOptions,
       checkMigrationHistory: async () => {
         throw new Error('[migration-history] checksum mismatch for applied migration x; immutable history is paused');
       },

--- a/apps/web/scripts/migrate-deploy.mjs
+++ b/apps/web/scripts/migrate-deploy.mjs
@@ -141,6 +141,20 @@ const compatibilityPath = resolve(repoRoot, 'apps/web/prisma/migration-history-c
  * with "duplicate applied migration identity" forever after (caught by
  * local reproduction against a real database before this shipped: renaming
  * in place instead leaves exactly one row, matching `expected` directly).
+ *
+ * A prior deploy attempt can also have re-run the NEW name's SQL for real
+ * (not via `resolve --applied`) before this reconciliation step existed,
+ * inserting its own started-but-never-finished, never-rolled-back row
+ * (production incident 2026-07-23 follow-up: this is exactly what a
+ * database left mid-incident looks like). Every regular migration in this
+ * repo is wrapped in an explicit BEGIN/COMMIT transaction (enforced by the
+ * "online migration transaction contract" test in migrate-deploy.test.ts),
+ * so an unfinished, non-rolled-back row has no persisted schema effect --
+ * mark it rolled back first, then rename the old row into its name slot.
+ * Prisma's own retry workflow already relies on multiple rows sharing one
+ * migration_name (rolled-back ones are skipped by assertMigrationHistory's
+ * own leading `continue`), so this matches Prisma's supported pattern, not
+ * a new one.
  */
 export async function resolveApprovedRenames(databaseUrl, options = {}) {
   const compatibility = options.compatibility ?? JSON.parse(readFileSync(compatibilityPath, 'utf8'));
@@ -166,10 +180,19 @@ export async function resolveApprovedRenames(databaseUrl, options = {}) {
     for (const [oldName, { replacement }] of entries) {
       const oldRow = byName.get(oldName);
       const newRow = byName.get(replacement);
-      if (oldRow?.finished_at && !oldRow.rolled_back_at && !newRow) {
-        await client.query('UPDATE "_prisma_migrations" SET migration_name = $1 WHERE migration_name = $2', [replacement, oldName]);
-        resolved.push(replacement);
+      if (!oldRow?.finished_at || oldRow.rolled_back_at) continue;
+      // The new name is already a genuinely finished or rolled-back
+      // identity of its own; that is either already resolved or a real
+      // conflict deserving human review, not something to guess at here.
+      if (newRow?.finished_at || newRow?.rolled_back_at) continue;
+      if (newRow) {
+        await client.query(
+          'UPDATE "_prisma_migrations" SET rolled_back_at = NOW() WHERE migration_name = $1 AND finished_at IS NULL AND rolled_back_at IS NULL',
+          [replacement],
+        );
       }
+      await client.query('UPDATE "_prisma_migrations" SET migration_name = $1 WHERE migration_name = $2', [replacement, oldName]);
+      resolved.push(replacement);
     }
   } finally {
     await client.end();
@@ -277,6 +300,14 @@ export async function runMigrateDeploy(env = process.env, options = {}) {
     // the PRE_DEPLOY image). Any history failure pauses the deployment.
     const historyCheck = options.checkMigrationHistory ?? checkDatabaseMigrationHistory;
     const migrationDatabaseUrl = migrationAuthorityUrl ? deriveDirectUrl(migrationAuthorityUrl) : directUrl;
+    // Must run before historyCheck: a compat-approved rename the history
+    // gate has never seen resolved fails historyCheck closed (production
+    // incident 2026-07-23 follow-up) before this reconciliation step would
+    // otherwise get a chance to run.
+    stage = 'resolve-approved-renames';
+    const resolveRenames = options.resolveApprovedRenames ?? resolveApprovedRenames;
+    await resolveRenames(migrationDatabaseUrl);
+    stage = 'prisma-migrate';
     try {
       await historyCheck(migrationDatabaseUrl);
     } catch (error) {
@@ -294,10 +325,6 @@ export async function runMigrateDeploy(env = process.env, options = {}) {
       stage = 'prisma-migrate';
       await historyCheck(migrationDatabaseUrl);
     }
-    stage = 'resolve-approved-renames';
-    const resolveRenames = options.resolveApprovedRenames ?? resolveApprovedRenames;
-    await resolveRenames(migrationDatabaseUrl);
-    stage = 'prisma-migrate';
     console.log('[migrate-deploy] running prisma migrate deploy...');
     const migrationEnv = {
       ...env,


### PR DESCRIPTION
## Summary

Production is currently down for new deploys. Commit 89759b2c's own first production PRE_DEPLOY run (deployment `2c16f07b`) failed with "duplicate applied migration identity" -- the exact failure `resolveApprovedRenames` exists to prevent.

## Root cause (two parts)

1. **Ordering bug**: `runMigrateDeploy` called `checkMigrationHistory` BEFORE `resolveApprovedRenames`. A database state the reconciler could fix made the history gate throw first, so the reconciler never got a chance to run.
2. **Missing case**: production's `_prisma_migrations` table independently had a stray, unfinished, non-rolled-back row for the replacement name -- left behind by an earlier deploy attempt (before either the rename fix or this ordering fix existed) that let Prisma re-run the replacement's SQL for real. `resolveApprovedRenames` only handled "new name has no row yet", not "new name has an incomplete row".

## Fix

1. `resolveApprovedRenames` now runs before `checkMigrationHistory` (and before its owner-visibility retry path).
2. `resolveApprovedRenames` now also marks a stray unfinished/non-rolled-back replacement row as rolled back before renaming the old row into place. Every regular migration in this repo is transaction-wrapped (enforced by the existing "online migration transaction contract" test), so an unfinished row has no persisted schema effect. Matches Prisma's own supported pattern of multiple rows sharing one `migration_name`.

## Verification

- Reproduced production's exact stuck state against real local pgvector Postgres (old row finished, new row started but never finished/rolled back): `migrate-deploy.mjs` now succeeds, and `check-migration-history.mjs` reports `verified; checked=45` with no duplicate-identity error.
- 97/97 vitest (migrate-deploy + enrollment-lifecycle + upload-idempotency-migration), 7/7 node check-migration-history tests, lint clean, type-check clean.

Follow-up to #317. Once merged and CI is green, I will watch the auto-deploy through to ACTIVE as final proof -- production has been down for new deploys since 2c16f07b failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment recovery for approved migration renames interrupted mid-deployment.
  * Prevented duplicate migration identity errors by reconciling renamed migrations before history validation.
  * Avoided unnecessary reconciliation when a replacement migration has already been rolled back.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->